### PR TITLE
Print empty bodies uniformly

### DIFF
--- a/pkg/plugins/accesslogs/console.go
+++ b/pkg/plugins/accesslogs/console.go
@@ -112,7 +112,7 @@ func (c *ConsolePrinter) printConsoleDetails(includeBody bool) error {
 			if c.ctx.GetRequestBodyBuffer().Length() > 0 {
 				sb.Write(c.ctx.GetRequestBodyBuffer().Copy())
 			} else {
-				sb.WriteString("\t(empty)\n")
+				sb.WriteString("(empty)\n")
 			}
 		}
 	}
@@ -129,7 +129,7 @@ func (c *ConsolePrinter) printConsoleDetails(includeBody bool) error {
 			if c.ctx.GetResponseBodyBuffer().Length() > 0 {
 				sb.Write(c.ctx.GetResponseBodyBuffer().Copy())
 			} else {
-				sb.WriteString("\t(empty)\n")
+				sb.WriteString("(empty)\n")
 			}
 		}
 	}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I agree to the [CLA](./CLA.md)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Description

When printing http access logs, an empty body is prefixed with a `\t` tab character. This breaks the left alignment and looks like a mistake. This PR contains a very tiny adjustment to remove the unnecessary indentation.