### PR TITLE
Add a custom 'debug' component to the trace system

### DIFF
--- a/bpf/tap/trace.bpf.h
+++ b/bpf/tap/trace.bpf.h
@@ -30,6 +30,7 @@
 // enum to represent the different components that can be traced
 enum QTAP_COMPONENT {
 	QTAP_CA,
+	QTAP_DEBUG,
 	QTAP_GOTLS,
 	QTAP_JAVASSL,
 	QTAP_NODETLS,
@@ -344,6 +345,7 @@ static __always_inline void trace_port(uint64_t tsid, const char *title, uint16_
 // Empty definitions when tracing is not enabled
 #define TRACE_IF_ENABLED(component, pid, ...)
 #define TRACE_CA(pid, ...)
+#define TRACE_DEBUG(pid, ...)
 #define TRACE_GOTLS(pid, ...)
 #define TRACE_JAVASSL(pid, ...)
 #define TRACE_NODETLS(pid, ...)
@@ -360,6 +362,7 @@ static __always_inline void trace_port(uint64_t tsid, const char *title, uint16_
 	}
 
 #define TRACE_CA(pid, ...)         TRACE_IF_ENABLED(QTAP_CA, pid, __VA_ARGS__)
+#define TRACE_DEBUG(pid, ...)      TRACE_IF_ENABLED(QTAP_DEBUG, pid, __VA_ARGS__)
 #define TRACE_GOTLS(pid, ...)      TRACE_IF_ENABLED(QTAP_GOTLS, pid, __VA_ARGS__)
 #define TRACE_JAVASSL(pid, ...)    TRACE_IF_ENABLED(QTAP_JAVASSL, pid, __VA_ARGS__)
 #define TRACE_NODETLS(pid, ...)    TRACE_IF_ENABLED(QTAP_NODETLS, pid, __VA_ARGS__)

--- a/pkg/ebpf/trace/trace.go
+++ b/pkg/ebpf/trace/trace.go
@@ -5,6 +5,7 @@ type QtapComponent uint32
 
 const (
 	QtapCa QtapComponent = iota
+	QtapDebug
 	QtapGotls
 	QtapJavassl
 	QtapNodetls
@@ -17,6 +18,10 @@ const (
 
 func QtapComponentFromString(s string) (QtapComponent, bool) {
 	switch s {
+	case "ca":
+		return QtapCa, true
+	case "debug":
+		return QtapDebug, true
 	case "gotls":
 		return QtapGotls, true
 	case "javassl":
@@ -33,8 +38,7 @@ func QtapComponentFromString(s string) (QtapComponent, bool) {
 		return QtapRedirector, true
 	case "socket":
 		return QtapSocket, true
-	case "ca":
-		return QtapCa, true
+
 	default:
 		return 0, false
 	}

--- a/pkg/ebpf/trace/trace.go
+++ b/pkg/ebpf/trace/trace.go
@@ -38,7 +38,6 @@ func QtapComponentFromString(s string) (QtapComponent, bool) {
 		return QtapRedirector, true
 	case "socket":
 		return QtapSocket, true
-
 	default:
 		return 0, false
 	}


### PR DESCRIPTION
This adds a custom 'debug' component to the eBPF trace system. 

This is helpful for scenarios where you need to leverage the `bpf_printk` helper within libbpf, but don't want a firehose of data that comes from an active system. For instance, let's say you want to add a bpf_printk on a very active syscall, but only want to use it for a specific executable, like curl. In your bpf code:

```
...

uint32_t pid = bpf_get_current_pid_tgid() >> 32;

if (trace_enabled_for_pid(QTAP_DEBUG, pid)) {
  bpf_printk("...");
}

...
```

Which can be enabled by starting qtap as follows: `qtap --bpf-trace=mod:debug,exe.endsWith:curl`