### PR TITLE
refactor(services): Change ServiceFactory to FactoryFactory

### DIFF
--- a/pkg/cmd/tap_linux.go
+++ b/pkg/cmd/tap_linux.go
@@ -57,14 +57,14 @@ var (
 )
 
 var (
-	serviceFactories = []services.ServiceFactory{
+	serviceFactories = []services.FactoryFactory{
 		// Eventstore services
-		&eventstoreconsole.Factory{},
-		&eventstorenoop.Factory{},
+		func() services.ServiceFactory { return &eventstoreconsole.Factory{} },
+		func() services.ServiceFactory { return &eventstorenoop.Factory{} },
 
 		// Objectstore services
-		&objectstoreconsole.Factory{},
-		&objectstorenoop.Factory{},
+		func() services.ServiceFactory { return &objectstoreconsole.Factory{} },
+		func() services.ServiceFactory { return &objectstorenoop.Factory{} },
 
 		// Add more services here...
 	}

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -17,6 +17,9 @@ type Service interface {
 	ServiceType() ServiceType
 }
 
+// FactoryFactory creates a service factory 🎶
+type FactoryFactory func() ServiceFactory
+
 // ServiceFactory creates service instances
 type ServiceFactory interface {
 	// Init initializes the service factory


### PR DESCRIPTION
Updated service factory definitions to use FactoryFactory functions instead of direct instances. This change enhances flexibility in service creation and registration within the ServiceManager.

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Contributing Guide: https://github.com/qpoint-io/qtap/docs/CONTRIBUTING.md
     - 📖 Read the Contributor License Agreement (CLA): https://github.com/qpoint-io/qtap/docs/CLA.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Qpoint Team member.
-->
