### PR TITLE
fix filters on preloaded processes

### DIFF
--- a/pkg/ebpf/process/manager.go
+++ b/pkg/ebpf/process/manager.go
@@ -146,7 +146,7 @@ func (m *Manager) readProcEvent(record *ringbuf.Record) error {
 	return nil
 }
 
-func (m *Manager) setMeta(p *process.Process) error {
+func (m *Manager) SetMeta(p *process.Process) error {
 	if p == nil {
 		return nil
 	}

--- a/pkg/ebpf/process/reader.go
+++ b/pkg/ebpf/process/reader.go
@@ -59,7 +59,7 @@ func (m *Manager) handleExecStartEvent(r *bytes.Reader) error {
 		// set the notifier so the process can indicate when it's changed
 		// and when we should collect data for the ebpf meta map
 		p.SetNotifier(func() error {
-			return m.setMeta(p)
+			return m.SetMeta(p)
 		})
 
 		m.cache.Add(int32(e.Pid), p)

--- a/pkg/process/manager.go
+++ b/pkg/process/manager.go
@@ -27,6 +27,7 @@ type Eventer interface {
 	Start() error
 	Stop() error
 	Register(Receiver)
+	SetMeta(p *Process) error
 }
 
 type Manager struct {
@@ -175,6 +176,9 @@ func (m *Manager) preloadProcs() error {
 
 			if err := m.addProc(proc); err != nil {
 				return fmt.Errorf("adding process: %w", err)
+			}
+			if err := m.procEventer.SetMeta(proc); err != nil {
+				return fmt.Errorf("setting meta: %w", err)
 			}
 		}
 	}


### PR DESCRIPTION
this fixes filters not being correctly applied to processes that predated qtap.