### PR TITLE
chore: add type cap check errors

### DIFF
--- a/pkg/cap/cap.go
+++ b/pkg/cap/cap.go
@@ -1,11 +1,24 @@
 package cap
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
 	"strings"
 	"syscall"
+)
+
+// readFile and statfs are exported for testing
+var (
+	readFile = os.ReadFile
+	statfs   = syscall.Statfs
+)
+
+var (
+	ErrCgroupsV2NotEnabled = errors.New("cgroups v2 is not enabled")
+	ErrModernKernel        = errors.New("kernel is not modern (5.10 or later required)")
+	ErrBpfProbeWriteUser   = errors.New("kernel is in lockdown mode, blocking bpf_probe_write_user functionality")
 )
 
 // the magic number for cgroup v2 defined as 0x63677270 in the Linux kernel
@@ -33,24 +46,11 @@ func (c Capability) String() string {
 	}
 }
 
-func HasCapability(cap Capability) (bool, error) {
-	switch cap {
-	case CAP_BPF_PROBE_WRITE_USER:
-		return CanBpfProbeWriteUser()
-	case CAP_IS_MODERN_KERNEL:
-		return IsModernKernel()
-	case CAP_CGROUPS_V2:
-		return HasCgroupsV2()
-	default:
-		return false, fmt.Errorf("unknown capability: %s", cap)
-	}
-}
-
-func CanBpfProbeWriteUser() (bool, error) {
+func CanBpfProbeWriteUser() error {
 	// read the contents of the lockdown file
-	content, err := os.ReadFile("/sys/kernel/security/lockdown")
+	content, err := readFile("/sys/kernel/security/lockdown")
 	if err != nil {
-		return false, fmt.Errorf("failed to read lockdown file: %w", err)
+		return fmt.Errorf("failed to read lockdown file: %w", err)
 	}
 
 	// convert content to string and trim whitespace
@@ -58,51 +58,59 @@ func CanBpfProbeWriteUser() (bool, error) {
 
 	// check if the lockdown status contains [none]
 	if strings.Contains(lockdownStatus, "[none]") {
-		return true, nil
+		return nil
 	}
 
 	// if [none] is not present, bpf_probe_write_user is likely not allowed
-	return false, nil
+	return ErrBpfProbeWriteUser
 }
 
-func IsModernKernel() (bool, error) {
+func IsModernKernel() error {
 	// Read the kernel version from /proc/sys/kernel/osrelease
-	kernelVersion, err := os.ReadFile("/proc/sys/kernel/osrelease")
+	kernelVersion, err := readFile("/proc/sys/kernel/osrelease")
 	if err != nil {
-		return false, fmt.Errorf("failed to read kernel version: %w", err)
+		return fmt.Errorf("failed to read kernel version: %w", err)
+	}
+
+	verParseFn := func(err error) error {
+		return fmt.Errorf("failed to parse kernel version: %w", err)
 	}
 
 	// Parse the kernel version string
 	version := strings.TrimSpace(string(kernelVersion))
 	parts := strings.SplitN(version, ".", 3)
 	if len(parts) < 2 {
-		return false, fmt.Errorf("invalid kernel version format: %s", version)
+		return verParseFn(fmt.Errorf("version (%s) incorrect semantic versioning", version))
 	}
 
 	// Convert major and minor version to integers
 	major, err := strconv.Atoi(parts[0])
 	if err != nil {
-		return false, fmt.Errorf("failed to parse major version: %w", err)
+		return verParseFn(fmt.Errorf("major version (%s) not an integer", parts[0]))
 	}
 
 	minor, err := strconv.Atoi(parts[1])
 	if err != nil {
-		return false, fmt.Errorf("failed to parse minor version: %w", err)
+		return verParseFn(fmt.Errorf("minor version (%s) not an integer", parts[1]))
 	}
 
 	// Check if the kernel version is 5.10 or later
 	if major > 5 || (major == 5 && minor >= 10) {
-		return true, nil
+		return nil
 	}
 
-	return false, nil
+	return ErrModernKernel
 }
 
-func HasCgroupsV2() (bool, error) {
-	var statfs syscall.Statfs_t
-	if err := syscall.Statfs("/sys/fs/cgroup", &statfs); err != nil {
-		return false, fmt.Errorf("failed to statfs /sys/fs/cgroup: %w", err)
+func HasCgroupsV2() error {
+	var s syscall.Statfs_t
+	if err := statfs("/sys/fs/cgroup", &s); err != nil {
+		return fmt.Errorf("failed to statfs /sys/fs/cgroup: %w", err)
 	}
 
-	return statfs.Type == CGROUP2_SUPER_MAGIC, nil
+	if s.Type == CGROUP2_SUPER_MAGIC {
+		return nil
+	}
+
+	return ErrCgroupsV2NotEnabled
 }

--- a/pkg/cap/cap_test.go
+++ b/pkg/cap/cap_test.go
@@ -1,0 +1,154 @@
+//go:build linux
+
+package cap
+
+import (
+	"errors"
+	"runtime"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCanBpfProbeWriteUser(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("skipping: only runs on Linux")
+	}
+
+	// Backup and restore original function
+	origReadFile := readFile
+	defer func() { readFile = origReadFile }()
+
+	tests := []struct {
+		name    string
+		content string
+		err     error
+		expect  error
+	}{
+		{
+			name:    "lockdown none",
+			content: "[none]",
+			expect:  nil,
+		},
+		{
+			name:    "lockdown enabled",
+			content: "[integrity]",
+			expect:  ErrBpfProbeWriteUser,
+		},
+		{
+			name:   "read error",
+			err:    errors.New("fail"),
+			expect: errors.New("failed to read lockdown file: fail"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			readFile = func(path string) ([]byte, error) {
+				if tt.err != nil {
+					return nil, tt.err
+				}
+				return []byte(tt.content), nil
+			}
+			err := CanBpfProbeWriteUser()
+			if tt.expect == nil {
+				require.NoError(t, err)
+			} else {
+				if errors.Is(tt.expect, ErrBpfProbeWriteUser) {
+					require.ErrorIs(t, err, ErrBpfProbeWriteUser)
+				} else {
+					require.Error(t, err)
+					require.Contains(t, err.Error(), "failed to read lockdown file")
+				}
+			}
+		})
+	}
+}
+
+func TestIsModernKernel(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("skipping: only runs on Linux")
+	}
+
+	origReadFile := readFile
+	defer func() { readFile = origReadFile }()
+
+	tests := []struct {
+		name   string
+		ver    string
+		err    error
+		expect error
+	}{
+		{"modern kernel 5.10.0", "5.10.0", nil, nil},
+		{"modern kernel 5.10", "5.10", nil, nil},
+		{"old kernel", "5.4.0", nil, ErrModernKernel},
+		{"very old kernel", "4.19.0", nil, ErrModernKernel},
+		{"future kernel", "6.0.0", nil, nil},
+		{"invalid format", "foo.bar", nil, errors.New("failed to parse kernel version: major version (foo) not an integer")},
+		{"read error", "", errors.New("fail"), errors.New("failed to read kernel version")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			readFile = func(path string) ([]byte, error) {
+				if tt.err != nil {
+					return nil, tt.err
+				}
+				return []byte(tt.ver), nil
+			}
+			err := IsModernKernel()
+			switch {
+			case tt.expect == nil:
+				require.NoError(t, err)
+			case errors.Is(tt.expect, ErrModernKernel):
+				require.ErrorIs(t, err, ErrModernKernel)
+			default:
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.expect.Error())
+			}
+		})
+	}
+}
+
+func TestHasCgroupsV2(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("skipping: only runs on Linux")
+	}
+
+	origStatfs := statfs
+	defer func() { statfs = origStatfs }()
+
+	tests := []struct {
+		name   string
+		fsType int64
+		err    error
+		expect error
+	}{
+		{"cgroups v2", CGROUP2_SUPER_MAGIC, nil, nil},
+		{"cgroups v1", 0x12345678, nil, ErrCgroupsV2NotEnabled},
+		{"statfs error", 0, errors.New("fail"), errors.New("failed to statfs /sys/fs/cgroup")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			statfs = func(path string, buf *syscall.Statfs_t) error {
+				if tt.err != nil {
+					return tt.err
+				}
+				buf.Type = tt.fsType
+				return nil
+			}
+			err := HasCgroupsV2()
+			switch {
+			case tt.expect == nil:
+				require.NoError(t, err)
+			case errors.Is(tt.expect, ErrCgroupsV2NotEnabled):
+				require.ErrorIs(t, err, ErrCgroupsV2NotEnabled)
+			default:
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "failed to statfs /sys/fs/cgroup")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds cap check error types that can be compared against using errors.is.

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Contributing Guide: https://github.com/qpoint-io/qtap/docs/CONTRIBUTING.md
     - 📖 Read the Contributor License Agreement (CLA): https://github.com/qpoint-io/qtap/docs/CLA.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Qpoint Team member.
-->
