### PR TITLE
feat(services): add NextFactory interface for graceful replacements

### DIFF
--- a/pkg/services/manager.go
+++ b/pkg/services/manager.go
@@ -54,6 +54,14 @@ func (sm *ServiceManager) SetConfig(config *config.Config) {
 
 		// Close old service if it exists and implements Closer
 		if old := sm.registry.Get(factory.ServiceType()); old != nil {
+			// sends replacement factory to services that support it
+			if next, ok := old.(NextFactory); ok {
+				defer func() {
+					next.Next(factory)
+				}()
+			}
+
+			// closes factories that are closeable
 			if closer, ok := old.(io.Closer); ok {
 				defer func() {
 					closer.Close()

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -42,3 +42,9 @@ type RegistryAccessor interface {
 	// Get retrieves a service factory by type
 	Get(serviceType ServiceType) ServiceFactory
 }
+
+// NextFactory indicates that a factory will handle graceful replacements
+// of itself to the replacement factory
+type NextFactory interface {
+	Next(ServiceFactory)
+}


### PR DESCRIPTION
Introduced the NextFactory interface to handle graceful replacements of service factories. Updated the SetConfig method in ServiceManager to utilize this interface, allowing services to manage their replacements effectively.

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Contributing Guide: https://github.com/qpoint-io/qtap/docs/CONTRIBUTING.md
     - 📖 Read the Contributor License Agreement (CLA): https://github.com/qpoint-io/qtap/docs/CLA.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Qpoint Team member.
-->
