### PR TITLE
fix(services) set next before close event

### DIFF
--- a/pkg/process/mocks/eventer.go
+++ b/pkg/process/mocks/eventer.go
@@ -52,6 +52,20 @@ func (mr *MockEventerMockRecorder) Register(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Register", reflect.TypeOf((*MockEventer)(nil).Register), arg0)
 }
 
+// SetMeta mocks base method.
+func (m *MockEventer) SetMeta(p *process.Process) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetMeta", p)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetMeta indicates an expected call of SetMeta.
+func (mr *MockEventerMockRecorder) SetMeta(p any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMeta", reflect.TypeOf((*MockEventer)(nil).SetMeta), p)
+}
+
 // Start mocks base method.
 func (m *MockEventer) Start() error {
 	m.ctrl.T.Helper()

--- a/pkg/services/manager.go
+++ b/pkg/services/manager.go
@@ -54,17 +54,17 @@ func (sm *ServiceManager) SetConfig(config *config.Config) {
 
 		// Close old service if it exists and implements Closer
 		if old := sm.registry.Get(factory.ServiceType()); old != nil {
-			// sends replacement factory to services that support it
-			if next, ok := old.(NextFactory); ok {
-				defer func() {
-					next.Next(factory)
-				}()
-			}
-
 			// closes factories that are closeable
 			if closer, ok := old.(io.Closer); ok {
 				defer func() {
 					closer.Close()
+				}()
+			}
+
+			// sends replacement factory to services that support it
+			if next, ok := old.(NextFactory); ok {
+				defer func() {
+					next.Next(factory)
 				}()
 			}
 		}


### PR DESCRIPTION
This ensures that the order of operations are:

1. init new factory
2. if supports next, set that
3. if closeable, close

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Contributing Guide: https://github.com/qpoint-io/qtap/docs/CONTRIBUTING.md
     - 📖 Read the Contributor License Agreement (CLA): https://github.com/qpoint-io/qtap/docs/CLA.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Qpoint Team member.
-->
