### PR TITLE
fix(services): change log level from debug to info

### DIFF
--- a/pkg/services/eventstore/console/console.go
+++ b/pkg/services/eventstore/console/console.go
@@ -38,7 +38,7 @@ type EventStore struct {
 
 // Save stores an event
 func (s *EventStore) Save(ctx context.Context, item any) {
-	s.Log().Debug("logging event store submission",
+	s.Log().Info("event store submission",
 		zap.String("type", fmt.Sprintf("%T", item)),
 		zap.Any("item", item),
 	)

--- a/pkg/services/objectstore/console/console.go
+++ b/pkg/services/objectstore/console/console.go
@@ -36,7 +36,7 @@ type ObjectStore struct {
 }
 
 func (s *ObjectStore) Put(ctx context.Context, artifact eventstore.Artifact) (*eventstore.ArtifactRecord, error) {
-	s.Log().Debug("object store submission",
+	s.Log().Info("object store submission",
 		zap.String("digest", artifact.Digest()),
 		zap.Any("artifact", artifact),
 	)


### PR DESCRIPTION
Changes the console implementations for event and object stores to info level.

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Contributing Guide: https://github.com/qpoint-io/qtap/docs/CONTRIBUTING.md
     - 📖 Read the Contributor License Agreement (CLA): https://github.com/qpoint-io/qtap/docs/CLA.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Qpoint Team member.
-->
