### PR TITLE
Refactor Kprobe and Kretprobe to accept multiple functions

### DIFF
--- a/pkg/cmd/tap_linux.go
+++ b/pkg/cmd/tap_linux.go
@@ -522,11 +522,11 @@ func NewEbpfSockManager(logger *zap.Logger, connMan *connection.Manager, objs *t
 		common.NewTracepoint("syscalls", "sys_exit_socket", objs.TapPrograms.SyscallProbeRetSocket),
 
 		// pid/fd mapping kprobes
-		common.NewKprobe("sock_alloc_file", objs.TapPrograms.TrackSockAllocFileEntry),
-		common.NewKretprobe("sock_alloc_file", objs.TapPrograms.TrackSockAllocFileRet),
-		common.NewKprobe("fd_install", objs.TapPrograms.TrackFdInstallEntry),
-		common.NewKprobe("__fput", objs.TapPrograms.CleanupPidFdFileEntries),
-		common.NewKprobe("tcp_close", objs.TapPrograms.TraceTcpClose),
+		common.NewKprobe(objs.TapPrograms.TrackSockAllocFileEntry, "sock_alloc_file"),
+		common.NewKretprobe(objs.TapPrograms.TrackSockAllocFileRet, "sock_alloc_file"),
+		common.NewKprobe(objs.TapPrograms.TrackFdInstallEntry, "fd_install"),
+		common.NewKprobe(objs.TapPrograms.CleanupPidFdFileEntries, "__fput", "fput", "__pfx_fput", "__pfx___fput"),
+		common.NewKprobe(objs.TapPrograms.TraceTcpClose, "tcp_close"),
 
 		// ftraces
 		common.NewFexit("tcp_v4_connect", objs.TapPrograms.TraceTcpV4ConnectFexit),

--- a/pkg/ebpf/common/kprobe.go
+++ b/pkg/ebpf/common/kprobe.go
@@ -1,32 +1,35 @@
 package common
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
 )
 
 type Kprobe struct {
 	// meta
-	Function string
-	Prog     *ebpf.Program
-	IsRet    bool
+	Functions []string
+	Prog      *ebpf.Program
+	IsRet     bool
 
 	// state
 	conn link.Link
 }
 
-func NewKprobe(function string, prog *ebpf.Program) *Kprobe {
+func NewKprobe(prog *ebpf.Program, functions ...string) *Kprobe {
 	return &Kprobe{
-		Function: function,
-		Prog:     prog,
+		Functions: functions,
+		Prog:      prog,
 	}
 }
 
-func NewKretprobe(function string, prog *ebpf.Program) *Kprobe {
+func NewKretprobe(prog *ebpf.Program, functions ...string) *Kprobe {
 	return &Kprobe{
-		Function: function,
-		Prog:     prog,
-		IsRet:    true,
+		Functions: functions,
+		Prog:      prog,
+		IsRet:     true,
 	}
 }
 
@@ -36,9 +39,9 @@ func (k *Kprobe) Attach() error {
 
 	// establish the link
 	if k.IsRet {
-		conn, err = link.Kretprobe(k.Function, k.Prog, nil)
+		conn, err = tryAttach(link.Kretprobe, k.Prog, k.Functions)
 	} else {
-		conn, err = link.Kprobe(k.Function, k.Prog, nil)
+		conn, err = tryAttach(link.Kprobe, k.Prog, k.Functions)
 	}
 
 	// set the state
@@ -57,5 +60,22 @@ func (k *Kprobe) Detach() error {
 }
 
 func (k *Kprobe) ID() string {
-	return "kprobe/" + k.Function
+	return "kprobe/" + strings.Join(k.Functions, ", ")
+}
+
+type kprobeLinkerFn func(symbol string, prog *ebpf.Program, opts *link.KprobeOptions) (link.Link, error)
+
+func tryAttach(fn kprobeLinkerFn, prog *ebpf.Program, functions []string) (link.Link, error) {
+	var conn link.Link
+	var err error
+
+	for _, function := range functions {
+		conn, err = fn(function, prog, nil)
+
+		if err == nil {
+			return conn, nil
+		}
+	}
+
+	return nil, fmt.Errorf("failed to attach to any of the functions: %s, error: %w", strings.Join(functions, ", "), err)
 }


### PR DESCRIPTION
Updated the Kprobe and Kretprobe constructors to take a variadic list of function names instead of a single function string. This change allows for more flexible attachment to multiple functions. Adjusted the Attach method to utilize a helper function for attaching to the first successful function in the list. Updated the ID method to return a comma-separated string of function names.

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Contributing Guide: https://github.com/qpoint-io/qtap/docs/CONTRIBUTING.md
     - 📖 Read the Contributor License Agreement (CLA): https://github.com/qpoint-io/qtap/docs/CLA.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Qpoint Team member.
-->
