### PR TITLE
access logs: lowercase header keys in rule values

### DIFF
--- a/pkg/plugins/tools/txs.go
+++ b/pkg/plugins/tools/txs.go
@@ -132,10 +132,11 @@ func (h HeaderMap) RulePairs(prefix string) map[string]any {
 	}
 
 	for k, v := range h.headers.All() {
-		if strings.HasPrefix(k, ":") {
-			rulePairs[prefix+"."+strings.TrimPrefix(k, ":")] = v
+		key := strings.ToLower(k)
+		if strings.HasPrefix(key, ":") {
+			rulePairs[prefix+"."+strings.TrimPrefix(key, ":")] = v
 		} else {
-			rulePairs[prefix+".header."+k] = v
+			rulePairs[prefix+".header."+key] = v
 		}
 	}
 

--- a/pkg/plugins/tools/txs_test.go
+++ b/pkg/plugins/tools/txs_test.go
@@ -90,7 +90,7 @@ func TestHeaderMap_RulePairs(t *testing.T) {
 			name: "regular headers",
 			headers: map[string]string{
 				"content-type": "application/json",
-				"user-agent":   "test-client",
+				"User-Agent":   "test-client",
 				"x-request-id": "123456",
 			},
 			prefix: "response",


### PR DESCRIPTION
lowercase all header keys for more predictable behavior in rules.