### PR TITLE
refactor: remove context parameter from Put method in ObjectStore

### DIFF
--- a/pkg/services/objectstore/console/console.go
+++ b/pkg/services/objectstore/console/console.go
@@ -35,7 +35,7 @@ type ObjectStore struct {
 	objectstore.BaseObjectStore
 }
 
-func (s *ObjectStore) Put(ctx context.Context, artifact eventstore.Artifact) (*eventstore.ArtifactRecord, error) {
+func (s *ObjectStore) Put(artifact eventstore.Artifact) (*eventstore.ArtifactRecord, error) {
 	s.Log().Info("object store submission",
 		zap.String("digest", artifact.Digest()),
 		zap.Any("artifact", artifact),

--- a/pkg/services/objectstore/noop/noop.go
+++ b/pkg/services/objectstore/noop/noop.go
@@ -33,6 +33,6 @@ type ObjectStore struct {
 	objectstore.BaseObjectStore
 }
 
-func (s *ObjectStore) Put(ctx context.Context, artifact eventstore.Artifact) (*eventstore.ArtifactRecord, error) {
+func (s *ObjectStore) Put(artifact eventstore.Artifact) (*eventstore.ArtifactRecord, error) {
 	return nil, nil
 }

--- a/pkg/services/objectstore/objectstore.go
+++ b/pkg/services/objectstore/objectstore.go
@@ -1,8 +1,6 @@
 package objectstore
 
 import (
-	"context"
-
 	"github.com/qpoint-io/qtap/pkg/services"
 	"github.com/qpoint-io/qtap/pkg/services/eventstore"
 )
@@ -14,7 +12,7 @@ const (
 // ObjectStore defines the interface for object storage services
 type ObjectStore interface {
 	services.Service
-	Put(ctx context.Context, artifact eventstore.Artifact) (*eventstore.ArtifactRecord, error)
+	Put(artifact eventstore.Artifact) (*eventstore.ArtifactRecord, error)
 }
 
 // BaseObjectStore provides common functionality for ObjectStore implementations


### PR DESCRIPTION
Updated the Put method signature in the ObjectStore interface and its implementations to remove the context.Context parameter, simplifying the method call across the object store services.

The service context and loops should be independent of the callers.

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Contributing Guide: https://github.com/qpoint-io/qtap/docs/CONTRIBUTING.md
     - 📖 Read the Contributor License Agreement (CLA): https://github.com/qpoint-io/qtap/docs/CLA.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Qpoint Team member.
-->
