### PR TITLE
e2e: event store: support full set of artifact types

### DIFF
--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -41,6 +41,7 @@ var (
 func mainSetup() error {
 	start = time.Now()
 	logger = e2e.NewLogger(start)
+	zap.ReplaceGlobals(logger)
 
 	e2ectx = e2e.NewContext(context.Background())
 	e2ectx.Start = start

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -225,6 +225,9 @@ func NewConnection(ctx context.Context, logger *zap.Logger, openEvent *OpenEvent
 			if l, ok := instance.(servicespkg.LoggerAdapter); ok {
 				l.SetLogger(c.logger)
 			}
+			if ca, ok := instance.(ConnectionAdapter); ok {
+				ca.SetConnection(c)
+			}
 			if es, ok := instance.(eventstore.EventStore); ok {
 				c.eventStore = es
 			} else {
@@ -656,4 +659,8 @@ func isValidDomainChar(ch rune) bool {
 // isAlphanumeric checks if a character is a letter or digit
 func isAlphanumeric(ch rune) bool {
 	return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9')
+}
+
+type ConnectionAdapter interface {
+	SetConnection(*Connection)
 }

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 	"testing"
@@ -22,7 +23,7 @@ type Context struct {
 	ctx          context.Context
 	closers      []func() error
 	Start        time.Time
-	EventStore   *EventStore
+	EventStore   *EventStoreFactory
 	ConfProvider *ConfigProvider
 	L            *zap.Logger
 	TestConfig   func(mut func(*config.Config)) *config.Config
@@ -128,12 +129,14 @@ func DefaultTestConfig(mut func(*config.Config)) *config.Config {
 
 func (c *Context) TestCtx(t *testing.T) *TestContext {
 	id := NewID()
-	return &TestContext{
+	ctx := &TestContext{
 		ID:     id,
 		e2ectx: c,
 		T:      t,
 		L:      c.L.With(zap.String("ctxid", id)),
 	}
+	ctx.L.Info("🔧 test context created")
+	return ctx
 }
 
 func (c *Context) SetConfig(conf *config.Config) {
@@ -209,7 +212,11 @@ func (c *TestContext) WithConfig(t *testing.T, mut func(*config.Config), fn func
 
 func NewLogger(start time.Time) *zap.Logger {
 	zapconf := zap.NewDevelopmentConfig()
-	zapconf.Level = zap.NewAtomicLevelAt(zap.InfoLevel)
+	level := zap.InfoLevel
+	if l, err := zap.ParseAtomicLevel(os.Getenv("LOG_LEVEL")); err == nil {
+		level = l.Level()
+	}
+	zapconf.Level = zap.NewAtomicLevelAt(level)
 	zapconf.DisableStacktrace = true
 	zapconf.DisableCaller = true
 	zapconf.EncoderConfig.EncodeTime = TimeElapsedEncoder(start)

--- a/pkg/e2e/eventstore.go
+++ b/pkg/e2e/eventstore.go
@@ -145,7 +145,6 @@ type EventStore struct {
 	eventstore.BaseEventStore
 	conn *connection.Connection
 	save func(conn *connection.Connection, item any)
-	ok   bool
 }
 
 func (s *EventStore) SetConnection(conn *connection.Connection) {

--- a/pkg/e2e/eventstore.go
+++ b/pkg/e2e/eventstore.go
@@ -6,14 +6,156 @@ import (
 	"sync"
 	"time"
 
+	"github.com/qpoint-io/qtap/pkg/connection"
 	"github.com/qpoint-io/qtap/pkg/services"
 	"github.com/qpoint-io/qtap/pkg/services/eventstore"
+	"github.com/qpoint-io/rulekit/set"
 	"go.uber.org/zap"
 )
 
 const (
 	TypeEventStore services.ServiceType = "e2e"
 )
+
+type EventStoreFactory struct {
+	eventstore.BaseEventStore
+
+	mu              sync.Mutex
+	logger          *zap.Logger
+	events          *Events
+	eventsByConn    map[string]*Events
+	connIDsByCtxIDs map[string]set.Set[string]
+	errors          []error
+}
+
+func NewEventStore(logger *zap.Logger) *EventStoreFactory {
+	return &EventStoreFactory{
+		logger:          logger,
+		eventsByConn:    make(map[string]*Events),
+		connIDsByCtxIDs: make(map[string]set.Set[string]),
+		events:          &Events{},
+	}
+}
+
+func (f *EventStoreFactory) Init(ctx context.Context, cfg any) error {
+	return nil
+}
+
+func (f *EventStoreFactory) Create(ctx context.Context) (services.Service, error) {
+	return &EventStore{
+		save: f.save,
+	}, nil
+}
+
+func (f *EventStoreFactory) save(conn *connection.Connection, item any) {
+	f.logger.Debug("saving event",
+		zap.String("type", fmt.Sprintf("%T", item)),
+		zap.Any("item", item))
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if conn != nil {
+		if c, ok := item.(connidable); ok {
+			c.SetConnectionID(conn.ID())
+		}
+
+		if t, ok := item.(taggable); ok {
+			t.AddTags(conn.Tags().List()...)
+		}
+
+		if f.eventsByConn[conn.ID()] == nil {
+			f.eventsByConn[conn.ID()] = &Events{}
+		}
+		_ = f.eventsByConn[conn.ID()].Add(item)
+
+		if conn.Tags() != nil {
+			tags := conn.Tags().Map()
+			for _, id := range tags["ctxid"] {
+				if f.connIDsByCtxIDs[id] == nil {
+					f.connIDsByCtxIDs[id] = make(set.Set[string])
+				}
+				f.connIDsByCtxIDs[id].Add(conn.ID())
+			}
+		}
+	} else {
+		f.logger.Warn("got event to a store instance without a connection")
+	}
+
+	err := f.events.Add(item)
+	if err != nil {
+		f.errors = append(f.errors, err)
+	}
+}
+
+// ServiceType returns the service type
+func (f *EventStoreFactory) FactoryType() services.ServiceType {
+	return services.ServiceType(fmt.Sprintf("%s.%s", eventstore.TypeEventStore, TypeEventStore))
+}
+
+func (f *EventStoreFactory) Errors() ([]error, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return f.errors, len(f.errors) == 0
+}
+
+func (f *EventStoreFactory) GetByCtxID(id string) *Events {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	var events Events
+	for _, connid := range f.connIDsByCtxIDs[id].Items() {
+		if f.eventsByConn[connid] != nil {
+			events.Merge(f.eventsByConn[connid])
+		}
+	}
+	return &events
+}
+
+// AwaitByCtxID waits for at least numConnections to be saved for a given ctxid
+func (f *EventStoreFactory) AwaitByCtxID(id string, numConnections int, timeout time.Duration) (*Events, error) {
+	if numConnections == 0 {
+		return f.GetByCtxID(id), nil
+	}
+
+	deadline := time.Now().Add(timeout)
+	for {
+		if timeout > 0 && time.Now().After(deadline) {
+			return nil, fmt.Errorf("exceeded %s timeout while waiting for %d connections for ctxid %s", timeout, numConnections, id)
+		}
+
+		f.logger.Info(fmt.Sprintf("waiting for %d connections", numConnections), zap.String("ctxid", id))
+		events := f.GetByCtxID(id)
+		if len(events.Connections) >= numConnections {
+			return events, nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+type connidable interface {
+	SetConnectionID(id string)
+}
+
+type taggable interface {
+	AddTags(tag ...string)
+}
+
+type EventStore struct {
+	eventstore.BaseEventStore
+	conn *connection.Connection
+	save func(conn *connection.Connection, item any)
+	ok   bool
+}
+
+func (s *EventStore) SetConnection(conn *connection.Connection) {
+	s.conn = conn
+}
+
+// Save stores an event
+func (s *EventStore) Save(ctx context.Context, item any) {
+	s.save(s.conn, item)
+}
 
 type Events struct {
 	Requests    []*eventstore.Request
@@ -23,59 +165,22 @@ type Events struct {
 	Connections []*eventstore.Connection
 }
 
-type EventStore struct {
-	eventstore.BaseEventStore
-
-	mu           sync.Mutex
-	logger       *zap.Logger
-	events       *Events
-	byConnection map[string]*Events
-	byCtxID      map[string][]string
-	errors       []error
-}
-
-func NewEventStore(logger *zap.Logger) *EventStore {
-	return &EventStore{
-		logger:       logger,
-		byConnection: make(map[string]*Events),
-		byCtxID:      make(map[string][]string),
-		events:       &Events{},
-	}
-}
-
-func (f *EventStore) Init(ctx context.Context, cfg any) error {
-	return nil
-}
-
-func (f *EventStore) Create(ctx context.Context) (services.Service, error) {
-	return f, nil
-}
-
-// ServiceType returns the service type
-func (f *EventStore) FactoryType() services.ServiceType {
-	return services.ServiceType(fmt.Sprintf("%s.%s", eventstore.TypeEventStore, TypeEventStore))
-}
-
-func (e *Events) Add(item any) (string, bool) {
+func (e *Events) Add(item any) error {
 	switch i := item.(type) {
 	case *eventstore.Request:
 		e.Requests = append(e.Requests, i)
-		return i.ConnectionID, true
 	case *eventstore.Issue:
 		e.Issues = append(e.Issues, i)
-		return i.ConnectionID, true
 	case *eventstore.Artifact:
 		e.Artifacts = append(e.Artifacts, i)
-		return i.ConnectionID, true
 	case *eventstore.PIIEntity:
 		e.PIIEntities = append(e.PIIEntities, i)
-		return i.ConnectionID, true
 	case *eventstore.Connection:
 		e.Connections = append(e.Connections, i)
-		return i.ConnectionID, true
 	default:
-		return "", false
+		return fmt.Errorf("unknown event type: %T", item)
 	}
+	return nil
 }
 
 func (e *Events) Merge(other *Events) {
@@ -84,75 +189,4 @@ func (e *Events) Merge(other *Events) {
 	e.Artifacts = append(e.Artifacts, other.Artifacts...)
 	e.PIIEntities = append(e.PIIEntities, other.PIIEntities...)
 	e.Connections = append(e.Connections, other.Connections...)
-}
-
-// Save stores an event
-func (f *EventStore) Save(ctx context.Context, item any) {
-	f.logger.Debug("saving event", zap.Any("item", item), zap.String("type", fmt.Sprintf("%T", item)))
-	f.mu.Lock()
-	defer f.mu.Unlock()
-
-	connid, ok := f.events.Add(item)
-	if !ok {
-		f.errors = append(f.errors, fmt.Errorf("unknown event type: %T", item))
-		return
-	}
-
-	if f.byConnection[connid] == nil {
-		f.byConnection[connid] = &Events{}
-	}
-	f.byConnection[connid].Add(item)
-
-	if conn, ok := item.(*eventstore.Connection); ok {
-		if conn.Tags != nil {
-			for _, id := range conn.Tags["ctxid"] {
-				f.byCtxID[id] = append(f.byCtxID[id], connid)
-			}
-		}
-	}
-}
-
-func (f *EventStore) Close() error {
-	return nil
-}
-
-func (f *EventStore) Errors() ([]error, bool) {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-
-	return f.errors, len(f.errors) == 0
-}
-
-func (f *EventStore) GetByCtxID(id string) *Events {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-
-	var events Events
-	for _, connid := range f.byCtxID[id] {
-		if f.byConnection[connid] != nil {
-			events.Merge(f.byConnection[connid])
-		}
-	}
-	return &events
-}
-
-// AwaitByCtxID waits for at least numConnections to be saved for a given ctxid
-func (e *EventStore) AwaitByCtxID(id string, numConnections int, timeout time.Duration) (*Events, error) {
-	if numConnections == 0 {
-		return e.GetByCtxID(id), nil
-	}
-
-	deadline := time.Now().Add(timeout)
-	for {
-		if timeout > 0 && time.Now().After(deadline) {
-			return nil, fmt.Errorf("exceeded %s timeout while waiting for %d connections for ctxid %s", timeout, numConnections, id)
-		}
-
-		e.logger.Info(fmt.Sprintf("waiting for %d connections", numConnections), zap.String("ctxid", id))
-		events := e.GetByCtxID(id)
-		if len(events.Connections) >= numConnections {
-			return events, nil
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
 }


### PR DESCRIPTION
update the e2e event store to actually follow a factory pattern similar to real event stores so we can properly tag artifacts with connection ids