### PR TITLE
feat(config): Add URL config download support

### DIFF
--- a/pkg/cmd/tap_linux.go
+++ b/pkg/cmd/tap_linux.go
@@ -87,7 +87,7 @@ func init() {
 	// Common options
 	rootCmd.Flags().StringVar(&qpointConfig, "config",
 		getEnvOr("QPOINT_CONFIG", ""),
-		"Configuration file path")
+		"Configuration file path or URL (starting with http:// or https://)")
 	_ = rootCmd.Flags().Int("audit-log-buffer-size", 0, "[deprecated]")
 	_ = rootCmd.Flags().MarkDeprecated("audit-log-buffer-size", "this flag is no longer applicable to the new audit log implementation")
 	rootCmd.Flags().StringVar(&deploymentTags, "tags",

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -2,11 +2,15 @@ package config
 
 import (
 	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"testing"
 
 	validator "github.com/go-playground/validator/v10"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 // TestValidConfig tests the unmarshaling and validation of a valid YAML configuration
@@ -207,4 +211,175 @@ func validatorErrors(errs validator.ValidationErrors) []string {
 		errors = append(errors, err.Error())
 	}
 	return errors
+}
+
+// Tests for LocalConfigProvider URL functionality
+
+func TestIsURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		{"http URL", "http://example.com/config.yaml", true},
+		{"https URL", "https://example.com/config.yaml", true},
+		{"http URL case insensitive", "HTTP://example.com/config.yaml", true},
+		{"https URL case insensitive", "HTTPS://example.com/config.yaml", true},
+		{"local file", "/path/to/config.yaml", false},
+		{"relative file", "config.yaml", false},
+		{"ftp URL", "ftp://example.com/config.yaml", false},
+		{"empty string", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isURL(tt.path)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGenerateCacheKey(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		expected string
+	}{
+		{"simple URL", "https://example.com/config.yaml", "example.com-config-yaml"},
+		{"URL with port", "https://example.com:8080/config.yaml", "example.com-8080-config-yaml"},
+		{"URL with path", "https://example.com/api/v1/config.yaml", "example.com-api-v1-config-yaml"},
+		{"URL with no path", "https://example.com", "example.comindex"},
+		{"URL with root path", "https://example.com/", "example.com-"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := generateCacheKey(tt.url)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestLocalConfigProviderWithURL(t *testing.T) {
+	// Create a test HTTP server that serves a config
+	testConfig := `
+services:
+  event_stores:
+  - type: stdout
+  object_stores:
+  - type: stdout
+tap:
+  default_stack: complete
+`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/yaml")
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write([]byte(testConfig)); err != nil {
+			t.Error("failed to write response:", err)
+		}
+	}))
+	defer server.Close()
+
+	// Create a logger for testing
+	logger := zap.NewNop()
+
+	// Create the provider with the test server URL
+	provider := NewLocalConfigProvider(logger, server.URL)
+
+	// Verify it detected it as a URL
+	assert.True(t, provider.isURL)
+	assert.NotEmpty(t, provider.cacheFile)
+
+	// Set up a callback to capture the loaded config
+	var loadedConfig *Config
+	provider.OnConfigChange(func(cfg *Config) (func(), error) {
+		loadedConfig = cfg
+		return func() {}, nil
+	})
+
+	// Start the provider (this should download and load the config)
+	err := provider.Start()
+	require.NoError(t, err)
+
+	// Verify the config was loaded correctly
+	assert.NotNil(t, loadedConfig)
+	assert.NotNil(t, loadedConfig.Services)
+	assert.Len(t, loadedConfig.Services.EventStores, 1)
+	assert.Equal(t, EventStoreType_CONSOLE, loadedConfig.Services.EventStores[0].Type)
+
+	// Verify the cache file was created
+	_, err = os.Stat(provider.cacheFile)
+	require.NoError(t, err)
+
+	// Test reload functionality
+	err = provider.Reload()
+	require.NoError(t, err)
+
+	// Clean up
+	provider.Stop()
+
+	// Verify the cache file was cleaned up
+	_, err = os.Stat(provider.cacheFile)
+	require.True(t, os.IsNotExist(err))
+}
+
+func TestLocalConfigProviderURLFallbackToCache(t *testing.T) {
+	testConfig := `
+services:
+  event_stores:
+  - type: stdout
+  object_stores:
+  - type: stdout
+tap:
+  default_stack: complete
+`
+
+	// Create a server that initially works, then fails
+	var serverResponds bool = true
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if serverResponds {
+			w.Header().Set("Content-Type", "application/yaml")
+			w.WriteHeader(http.StatusOK)
+			if _, err := w.Write([]byte(testConfig)); err != nil {
+				t.Error("failed to write response:", err)
+			}
+		} else {
+			w.WriteHeader(http.StatusInternalServerError)
+			if _, err := w.Write([]byte("Server error")); err != nil {
+				t.Error("failed to write error response:", err)
+			}
+		}
+	}))
+	defer server.Close()
+
+	logger := zap.NewNop()
+	provider := NewLocalConfigProvider(logger, server.URL)
+
+	var loadedConfig *Config
+	provider.OnConfigChange(func(cfg *Config) (func(), error) {
+		loadedConfig = cfg
+		return func() {}, nil
+	})
+
+	// First load should succeed and create cache
+	err := provider.Start()
+	require.NoError(t, err)
+	assert.NotNil(t, loadedConfig)
+
+	// Verify cache file exists
+	_, err = os.Stat(provider.cacheFile)
+	require.NoError(t, err)
+
+	// Now make the server fail
+	serverResponds = false
+
+	// Reload should fall back to cache
+	err = provider.Reload()
+	require.NoError(t, err) // Should succeed using cached config
+
+	// Verify config is still available
+	assert.NotNil(t, loadedConfig)
+	assert.Equal(t, EventStoreType_CONSOLE, loadedConfig.Services.EventStores[0].Type)
+
+	provider.Stop()
 }

--- a/pkg/config/local_provider.go
+++ b/pkg/config/local_provider.go
@@ -1,17 +1,24 @@
 package config
 
 import (
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
+	"path/filepath"
+	"strings"
 	"sync"
 	"syscall"
 
+	"github.com/qpoint-io/qtap/pkg/services/client"
 	"go.uber.org/zap"
 )
 
-// LocalConfigProvider loads configuration from a local file and reloads on SIGHUP
+// LocalConfigProvider loads configuration from a local file or URL and reloads on SIGHUP
 type LocalConfigProvider struct {
 	logger     *zap.Logger
 	configPath string
@@ -19,14 +26,33 @@ type LocalConfigProvider struct {
 	sigChan    chan os.Signal
 	done       chan struct{}
 	mu         sync.Mutex
+	// URL-specific fields
+	isURL     bool
+	cacheFile string // temp file for caching downloaded configs
 }
 
-// NewLocalConfigProvider creates a new provider for local config files
+// NewLocalConfigProvider creates a new provider for local config files or URLs.
+// When a URL is provided (http:// or https://), the config will be downloaded
+// and cached locally for SIGHUP reloads. If the download fails during reload,
+// it will fall back to the cached version.
 func NewLocalConfigProvider(logger *zap.Logger, configPath string) *LocalConfigProvider {
+	isURL := isURL(configPath)
+	var cacheFile string
+
+	if isURL {
+		// Create a temp file for caching downloaded configs
+		cacheFile = filepath.Join(os.TempDir(), fmt.Sprintf("qtap-config-%s.yaml", generateCacheKey(configPath)))
+		logger.Info("URL config detected, will cache to temp file",
+			zap.String("url", configPath),
+			zap.String("cache_file", cacheFile))
+	}
+
 	return &LocalConfigProvider{
 		logger:     logger,
 		configPath: configPath,
 		done:       make(chan struct{}),
+		isURL:      isURL,
+		cacheFile:  cacheFile,
 	}
 }
 
@@ -67,6 +93,15 @@ func (p *LocalConfigProvider) Stop() {
 	close(p.done)
 	close(p.sigChan)
 	p.sigChan = nil
+
+	// Clean up cache file if it exists
+	if p.isURL && p.cacheFile != "" {
+		if err := os.Remove(p.cacheFile); err != nil && !os.IsNotExist(err) {
+			p.logger.Warn("Failed to remove cache file",
+				zap.String("cache_file", p.cacheFile),
+				zap.Error(err))
+		}
+	}
 }
 
 // OnConfigChange registers a callback for config changes
@@ -98,9 +133,30 @@ func (p *LocalConfigProvider) watchSignals() {
 
 // loadAndNotify loads the config and calls the registered callback
 func (p *LocalConfigProvider) loadAndNotify() error {
-	data, err := os.ReadFile(p.configPath)
-	if err != nil {
-		return fmt.Errorf("reading config file: %w", err)
+	var data []byte
+	var err error
+
+	if p.isURL {
+		// Download config from URL and cache it
+		data, err = p.downloadAndCache()
+		if err != nil {
+			// Try to fall back to cached file if download fails
+			if p.cacheFile != "" {
+				p.logger.Warn("Failed to download config, trying cached version", zap.Error(err))
+				data, err = os.ReadFile(p.cacheFile)
+				if err != nil {
+					return fmt.Errorf("downloading config and reading cached file failed: %w", err)
+				}
+			} else {
+				return fmt.Errorf("downloading config: %w", err)
+			}
+		}
+	} else {
+		// Read from local file
+		data, err = os.ReadFile(p.configPath)
+		if err != nil {
+			return fmt.Errorf("reading config file: %w", err)
+		}
 	}
 
 	conf, err := UnmarshalConfig(data)
@@ -126,4 +182,82 @@ func (p *LocalConfigProvider) loadAndNotify() error {
 	}
 
 	return nil
+}
+
+// isURL checks if the given path is a URL (starts with http:// or https://)
+func isURL(path string) bool {
+	u, err := url.Parse(strings.TrimSpace(path))
+	return err == nil && (u.Scheme == "http" || u.Scheme == "https")
+}
+
+// generateCacheKey creates a safe filename from a URL
+func generateCacheKey(urlStr string) string {
+	u, err := url.Parse(urlStr)
+	if err != nil {
+		// Fallback to a simple hash-like approach
+		return hex.EncodeToString([]byte(urlStr))
+	}
+
+	// Create a safe filename from host and path
+	safeHost := strings.ReplaceAll(u.Host, ":", "-")
+	safePath := strings.ReplaceAll(strings.ReplaceAll(u.Path, "/", "-"), ".", "-")
+	// Handle empty path or root path
+	switch u.Path {
+	case "":
+		safePath = "index"
+	case "/":
+		safePath = "-"
+	default:
+		if safePath == "" || safePath == "-" {
+			safePath = "index"
+		}
+	}
+
+	return fmt.Sprintf("%s%s", safeHost, safePath)
+}
+
+// downloadAndCache downloads the config from URL and caches it to a temp file
+func (p *LocalConfigProvider) downloadAndCache() ([]byte, error) {
+	p.logger.Info("Downloading config from URL", zap.String("url", p.configPath))
+
+	// Create HTTP client
+	httpClient := client.NewHttpClient()
+
+	// Make the request
+	resp, err := httpClient.Get(p.configPath)
+	if err != nil {
+		return nil, fmt.Errorf("HTTP GET failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Check status code
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP request failed with status %d: %s", resp.StatusCode, resp.Status)
+	}
+
+	// Read response body
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response body: %w", err)
+	}
+
+	// Cache the downloaded config to temp file for SIGHUP reloads
+	if p.cacheFile != "" {
+		// Ensure the directory exists
+		if err := os.MkdirAll(filepath.Dir(p.cacheFile), 0755); err != nil {
+			p.logger.Warn("Failed to create cache directory", zap.Error(err))
+		} else {
+			if err := os.WriteFile(p.cacheFile, data, 0644); err != nil {
+				p.logger.Warn("Failed to cache config file", zap.Error(err))
+			} else {
+				p.logger.Debug("Config cached successfully", zap.String("cache_file", p.cacheFile))
+			}
+		}
+	}
+
+	p.logger.Info("Config downloaded successfully",
+		zap.String("url", p.configPath),
+		zap.Int("size_bytes", len(data)))
+
+	return data, nil
 }


### PR DESCRIPTION
Extend LocalConfigProvider to support downloading configuration files from HTTP/HTTPS URLs. When a URL is provided via --config flag, the provider will:

* Auto-detect URLs by checking for http:// or https:// schemes
* Download configs using the existing HTTP client utilities
* Cache downloaded configs to temp files for SIGHUP reloads
* Fall back to cached versions if download fails during reload
* Clean up cache files on provider shutdown

This maintains full backward compatibility with existing file-based configs while adding seamless URL support.

* **URL Detection**: Automatically detects URLs vs local file paths
* **HTTP Client Integration**: Uses existing HTTP client with telemetry
* **Caching Strategy**: Downloads cached to temp files for reliability
* **Fallback Support**: Falls back to cache if URL becomes unavailable
* **SIGHUP Support**: Preserves reload functionality for URL configs
* **Clean Shutdown**: Automatic cache file cleanup
* **Comprehensive Tests**: Full test coverage including fallback scenarios

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Contributing Guide: https://github.com/qpoint-io/qtap/docs/CONTRIBUTING.md
     - 📖 Read the Contributor License Agreement (CLA): https://github.com/qpoint-io/qtap/docs/CLA.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Qpoint Team member.
-->
