### PR TITLE
address process <-> connection manager race

### DIFF
--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -47,6 +47,7 @@ type ControlManager interface {
 type ErrStreamUnrecoverable error
 
 type Connection struct {
+	mu     sync.Mutex
 	logger *zap.Logger
 	// connecting reporting system
 	report
@@ -108,32 +109,7 @@ type ConnOpt func(c *Connection)
 
 func WithProcess(process *process.Process) ConnOpt {
 	return func(c *Connection) {
-		if process == nil {
-			return
-		}
-		c.process = process
-
-		// add tags
-		if c.tags != nil && c.process != nil {
-			c.tags.Merge(c.process.Tags())
-
-			// TODO: the tags below should be added to the processes
-			// tag list and merged (see above).
-			c.tags.Add("bin", c.process.Binary)
-			c.tags.Add("strategy", c.process.Strategy.String())
-			if hostname, _ := c.process.Hostname(); hostname != "" {
-				if c.process.PodID != "" {
-					c.tags.Add("pod", hostname)
-
-					parts := strings.Split(hostname, "-")
-					if len(parts) > 0 {
-						c.tags.Add("app", parts[0])
-					}
-				} else {
-					c.tags.Add("host", hostname)
-				}
-			}
-		}
+		c.setProcess(process)
 	}
 }
 
@@ -237,6 +213,53 @@ func NewConnection(ctx context.Context, logger *zap.Logger, openEvent *OpenEvent
 	}
 
 	return c
+}
+
+func (c *Connection) SetProcess(process *process.Process) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.setProcess(process)
+}
+
+func (c *Connection) Process() *process.Process {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.process
+}
+
+// setProcess sets the process and adds tags to the connection.
+// Note that this is not thread safe.
+func (c *Connection) setProcess(process *process.Process) {
+	c.process = process
+	if process == nil {
+		return
+	}
+
+	// add tags
+	if c.tags == nil {
+		c.tags = tags.New()
+	}
+
+	c.tags.Merge(c.process.Tags())
+
+	// TODO: the tags below should be added to the processes
+	// tag list and merged (see above).
+	c.tags.Add("bin", c.process.Binary)
+	c.tags.Add("strategy", c.process.Strategy.String())
+	if hostname, _ := c.process.Hostname(); hostname != "" {
+		if c.process.PodID != "" {
+			c.tags.Add("pod", hostname)
+
+			parts := strings.Split(hostname, "-")
+			if len(parts) > 0 {
+				c.tags.Add("app", parts[0])
+			}
+		} else {
+			c.tags.Add("host", hostname)
+		}
+	}
 }
 
 // Open initializes the connection monitoring
@@ -429,7 +452,7 @@ func (c *Connection) Proto() string {
 }
 
 func (c *Connection) ProcessMeta() map[string]any {
-	p := c.process
+	p := c.Process()
 	if p == nil {
 		return nil
 	}
@@ -532,12 +555,12 @@ func (c *Connection) ControlValues() map[string]any {
 	}
 
 	// src
-	if c.process != nil {
-		src["process"] = c.process.ControlValues()
+	if p := c.Process(); p != nil {
+		src["process"] = p.ControlValues()
 
-		if container := c.process.Container; container != nil && container.ID != "" {
+		if container := p.Container; container != nil && container.ID != "" {
 			src["container"] = container.ControlValues()
-			if pod := c.process.Pod; pod != nil && pod.Name != "" {
+			if pod := p.Pod; pod != nil && pod.Name != "" {
 				src["pod"] = pod.ControlValues()
 			}
 		}

--- a/pkg/connection/manager.go
+++ b/pkg/connection/manager.go
@@ -121,6 +121,19 @@ func (m *Manager) HandleEvent(event Keyer) {
 	}
 
 	if conn, exists := m.connections.Load(event.Key()); exists {
+		// In most cases, processOpenEvent() will set the process. Very rarely,
+		// a race will occur where the connection is created without the process.
+		// More details on this in processOpenEvent().
+		//
+		// As a backup, attempt to rediscover the process on following events.
+		if conn.Process() == nil && conn.OpenEvent != nil {
+			proc := m.processManager.Get(int(conn.OpenEvent.PID))
+			if proc != nil {
+				m.logger.Info("discovered process", zap.Int("pid", proc.Pid))
+				conn.SetProcess(proc)
+			}
+		}
+
 		if err := conn.eventQueue.Push(event); err != nil {
 			m.logger.Error("failed to push event to connection queue", zap.Error(err))
 		}

--- a/pkg/connection/reader.go
+++ b/pkg/connection/reader.go
@@ -3,6 +3,7 @@ package connection
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/qpoint-io/qtap/pkg/dns"
 	"go.uber.org/zap"
@@ -13,8 +14,21 @@ func (m *Manager) processOpenEvent(event OpenEvent) {
 		return
 	}
 
-	// get the process
-	proc := m.processManager.Get(int(event.PID))
+	// Because the process manager runs independently of the connection manager,
+	// very rarely a race will occur where we get the connection open event
+	// before the process manager has discovered the process.
+	//
+	// We give a 50ms buffer to avoid this race. If we time out we will proceed
+	// with creating the connection without the process. On following events,
+	// the connection manager will attempt to rediscover the process.
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	proc, err := m.processManager.Await(ctx, int(event.PID))
+	if err != nil {
+		m.logger.Warn("connection process has not been discovered yet",
+			zap.Error(err),
+			zap.Uint32("pid", event.PID))
+	}
 
 	// get associated dns record
 	var dnsRecord *dns.Record
@@ -146,7 +160,7 @@ func (c *Connection) processErrorEvent(event ErrorEvent) {
 
 	switch event.Type {
 	case ErrType_ClientTLSHandshake, ErrType_ClientTLSHandshakeTimeout:
-		if p := c.process; p != nil {
+		if p := c.Process(); p != nil {
 			c.logger.Warn(event.Message,
 				zap.String("domain", c.Domain()),
 				zap.Int("pid", p.Pid),

--- a/pkg/connection/report.go
+++ b/pkg/connection/report.go
@@ -27,7 +27,7 @@ func (c *Connection) logConnectionReport() {
 	span.SetAttributes(attribute.String("connection.handler", c.HandlerType.String()))
 
 	// add strategy
-	if proc := c.process; proc != nil {
+	if proc := c.Process(); proc != nil {
 		span.SetAttributes(attribute.String("connection.strategy", proc.Strategy.String()))
 		fields = append(fields, zap.String("strategy", proc.Strategy.String()))
 	}

--- a/pkg/process/manager.go
+++ b/pkg/process/manager.go
@@ -1,6 +1,7 @@
 package process
 
 import (
+	"context"
 	"fmt"
 	"slices"
 	"sync"
@@ -47,14 +48,17 @@ type Manager struct {
 	// internal
 	mu    sync.Mutex
 	procs *synq.Map[int, *Process]
+	// processWaiters is a map of pid to channels that are waiting for the process to be discovered
+	processWaiters map[int][]chan *Process
 }
 
 func NewProcessManager(logger *zap.Logger, procEventer Eventer) *Manager {
 	pm := &Manager{
-		Logger:      logger,
-		procEventer: procEventer,
-		procs:       synq.NewMap[int, *Process](),
-		envMask:     synq.NewMap[string, bool](),
+		Logger:         logger,
+		procEventer:    procEventer,
+		procs:          synq.NewMap[int, *Process](),
+		envMask:        synq.NewMap[string, bool](),
+		processWaiters: make(map[int][]chan *Process),
 	}
 
 	trackActiveProcessCount(pm.procs.Len)
@@ -102,6 +106,29 @@ func (m *Manager) Get(pid int) *Process {
 
 	// return the process
 	return process
+}
+
+// Await gets a process by pid. If it exists, it is returned immediately.
+// Otherwise, it will wait for it to be discovered and then return it.
+// The context can be used to set a timeout.
+func (m *Manager) Await(ctx context.Context, pid int) (*Process, error) {
+	m.mu.Lock()
+	if proc, exists := m.procs.Load(pid); exists {
+		m.mu.Unlock()
+		return proc, nil
+	}
+
+	waiter := make(chan *Process)
+	m.processWaiters[pid] = append(m.processWaiters[pid], waiter)
+	m.mu.Unlock()
+
+	// wait for the process to be discovered or the context to be done
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case p := <-waiter:
+		return p, nil
+	}
 }
 
 func (m *Manager) Observe(observer Observer) {
@@ -229,21 +256,22 @@ func (m *Manager) addProc(p *Process) error {
 	// add to the map
 	m.procs.Store(p.Pid, p)
 
+	// notify the waiters
+	waiters, ok := m.processWaiters[p.Pid]
+	if ok {
+		delete(m.processWaiters, p.Pid)
+		go func() {
+			for _, waiter := range waiters {
+				select {
+				case waiter <- p:
+				default:
+				}
+			}
+		}()
+	}
+
 	// initialize the observers
 	go m.initProcObservers(p, procChanged)
-
-	// debug
-	// if p.ContainerID != "root" {
-	// 	m.Logger.Debug("process discovered",
-	// 		zap.Int("pid", p.Pid),
-	// 		zap.String("exe", p.Exe),
-	// 		zap.String("container_id", p.ContainerID),
-	// 		zap.Uint64("root_id", p.RootID),
-	// 		zap.String("pod_id", p.PodID),
-	// 		zap.Int("total_procs", m.procs.Len()),
-	// 		zap.String("root_fs", p.RootFS()),
-	// 	)
-	// }
 
 	return nil
 }


### PR DESCRIPTION
Because the process manager runs independently of the connection manager, very rarely a race will occur where we get the connection open event before the process manager has discovered the process.

Allow a 50ms buffer to avoid this race. If we time out we will proceed with creating the connection without the process. On following events, the connection manager will attempt to rediscover the process.

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Contributing Guide: https://github.com/qpoint-io/qtap/docs/CONTRIBUTING.md
     - 📖 Read the Contributor License Agreement (CLA): https://github.com/qpoint-io/qtap/docs/CLA.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Qpoint Team member.
-->
