### PR TITLE
feat(eventstore): Add OpenTelemetry eventstore

### DIFF
--- a/examples/sample-otel-grpc-eventstore.yaml
+++ b/examples/sample-otel-grpc-eventstore.yaml
@@ -10,6 +10,10 @@ services:
       protocol: grpc                 # "grpc", "http", or "stdout"
       service_name: "qtap"
       environment: "production"
+      # headers:
+      #   api-key:
+      #     type: env
+      #     value: OTEL_API_KEY
       tls:
         enabled: false
   object_stores:

--- a/examples/sample-otel-grpc-eventstore.yaml
+++ b/examples/sample-otel-grpc-eventstore.yaml
@@ -1,0 +1,41 @@
+# This is a simple example of a qtap config that captures HTTP transactions and
+# stores writes them to stdout. This includes headers and bodies if the level is
+# set to details or full.
+#
+version: 2
+services:
+  event_stores:
+    - type: otel
+      endpoint: "host.docker.internal:4317"    # gRPC endpoint
+      protocol: grpc                 # "grpc", "http", or "stdout"
+      service_name: "qtap"
+      environment: "production"
+      tls:
+        enabled: false
+  object_stores:
+    - type: stdout
+stacks:
+  basic_reporting:
+    plugins:
+      - type: http_capture
+        config:
+          level: summary # (none|summary|details|full)
+          format: json # (json|text)
+          rules:
+            - name: full log httpbin.org
+              expr: request.host == "httpbin.org"
+              level: full
+            - name: details log on 500
+              expr: response.status >= 500
+              level: details
+            - name: full log on 400
+              expr: response.status >= 400 && response.status < 500
+              level: full
+
+      - type: report_usage
+tap:
+  direction: egress # (egress|egress-external|egress-internal)
+  ignore_loopback: true
+  audit_include_dns: false
+  http:
+    stack: basic_reporting

--- a/examples/sample-otel-http-eventstore.yaml
+++ b/examples/sample-otel-http-eventstore.yaml
@@ -10,6 +10,10 @@ services:
       protocol: http                 # "grpc", "http", or "stdout"
       service_name: "qtap"
       environment: "production"
+      # headers:
+      #   api-key:
+      #     type: env
+      #     value: OTEL_API_KEY
       tls:
         enabled: false
   object_stores:

--- a/examples/sample-otel-http-eventstore.yaml
+++ b/examples/sample-otel-http-eventstore.yaml
@@ -1,0 +1,41 @@
+# This is a simple example of a qtap config that captures HTTP transactions and
+# stores writes them to stdout. This includes headers and bodies if the level is
+# set to details or full.
+#
+version: 2
+services:
+  event_stores:
+    - type: otel
+      endpoint: "host.docker.internal:4318"    # http endpoint
+      protocol: http                 # "grpc", "http", or "stdout"
+      service_name: "qtap"
+      environment: "production"
+      tls:
+        enabled: false
+  object_stores:
+    - type: stdout
+stacks:
+  basic_reporting:
+    plugins:
+      - type: http_capture
+        config:
+          level: summary # (none|summary|details|full)
+          format: json # (json|text)
+          rules:
+            - name: full log httpbin.org
+              expr: request.host == "httpbin.org"
+              level: full
+            - name: details log on 500
+              expr: response.status >= 500
+              level: details
+            - name: full log on 400
+              expr: response.status >= 400 && response.status < 500
+              level: full
+
+      - type: report_usage
+tap:
+  direction: egress # (egress|egress-external|egress-internal)
+  ignore_loopback: true
+  audit_include_dns: false
+  http:
+    stack: basic_reporting

--- a/examples/sample-otel-stdout-eventstore.yaml
+++ b/examples/sample-otel-stdout-eventstore.yaml
@@ -1,0 +1,38 @@
+# This is a simple example of a qtap config that captures HTTP transactions and
+# stores writes them to stdout. This includes headers and bodies if the level is
+# set to details or full.
+#
+version: 2
+services:
+  event_stores:
+    - type: otel
+      protocol: stdout
+      service_name: "qtap-sample"
+      environment: "development"
+  object_stores:
+    - type: stdout
+stacks:
+  basic_reporting:
+    plugins:
+      - type: http_capture
+        config:
+          level: summary # (none|summary|details|full)
+          format: text # (json|text)
+          rules:
+            - name: full log httpbin.org
+              expr: request.host == "httpbin.org"
+              level: full
+            - name: details log on 500
+              expr: response.status >= 500
+              level: details
+            - name: full log on 400
+              expr: response.status >= 400 && response.status < 500
+              level: full
+
+      - type: report_usage
+tap:
+  direction: egress # (egress|egress-external|egress-internal)
+  ignore_loopback: true
+  audit_include_dns: false
+  http:
+    stack: basic_reporting

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,10 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0
 	go.opentelemetry.io/contrib/propagators/autoprop v0.60.0
 	go.opentelemetry.io/otel v1.36.0
+	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.11.0
+	go.opentelemetry.io/otel/log v0.11.0
 	go.opentelemetry.io/otel/sdk v1.36.0
+	go.opentelemetry.io/otel/sdk/log v0.11.0
 	go.opentelemetry.io/otel/trace v1.36.0
 	go.uber.org/mock v0.5.0
 	go.uber.org/zap v1.27.0
@@ -303,7 +306,6 @@ require (
 	go.opentelemetry.io/contrib/propagators/b3 v1.35.0 // indirect
 	go.opentelemetry.io/contrib/propagators/jaeger v1.35.0 // indirect
 	go.opentelemetry.io/contrib/propagators/ot v1.35.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.11.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.11.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.35.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.35.0 // indirect
@@ -314,9 +316,7 @@ require (
 	go.opentelemetry.io/otel/exporters/stdout/stdoutlog v0.11.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.35.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.35.0 // indirect
-	go.opentelemetry.io/otel/log v0.11.0 // indirect
 	go.opentelemetry.io/otel/metric v1.36.0 // indirect
-	go.opentelemetry.io/otel/sdk/log v0.11.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.36.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.5.0 // indirect
 	go.uber.org/automaxprocs v1.6.0 // indirect

--- a/pkg/cmd/tap_linux.go
+++ b/pkg/cmd/tap_linux.go
@@ -35,6 +35,7 @@ import (
 	eventstoreaxiom "github.com/qpoint-io/qtap/pkg/services/eventstore/axiom"
 	eventstoreconsole "github.com/qpoint-io/qtap/pkg/services/eventstore/console"
 	eventstorenoop "github.com/qpoint-io/qtap/pkg/services/eventstore/noop"
+	eventstoreotel "github.com/qpoint-io/qtap/pkg/services/eventstore/otel"
 	objectstoreconsole "github.com/qpoint-io/qtap/pkg/services/objectstore/console"
 	objectstorenoop "github.com/qpoint-io/qtap/pkg/services/objectstore/noop"
 	objecstores3 "github.com/qpoint-io/qtap/pkg/services/objectstore/s3"
@@ -65,6 +66,7 @@ var (
 		func() services.ServiceFactory { return &eventstoreconsole.Factory{} },
 		func() services.ServiceFactory { return &eventstorenoop.Factory{} },
 		func() services.ServiceFactory { return &eventstoreaxiom.Factory{} },
+		func() services.ServiceFactory { return &eventstoreotel.Factory{} },
 
 		// Objectstore services
 		func() services.ServiceFactory { return &objectstoreconsole.Factory{} },

--- a/pkg/config/eventstore.go
+++ b/pkg/config/eventstore.go
@@ -58,12 +58,12 @@ type EventStoreAxiomConfig struct {
 }
 
 type EventStoreOTelConfig struct {
-	Endpoint    string            `yaml:"endpoint"`
-	Protocol    string            `yaml:"protocol"` // "grpc", "http", "stdout"
-	Headers     map[string]string `yaml:"headers"`  // Optional headers for auth
-	ServiceName string            `yaml:"service_name"`
-	Environment string            `yaml:"environment"`
-	TLS         EventStoreOTelTLS `yaml:"tls"`
+	Endpoint    string                 `yaml:"endpoint"`
+	Protocol    string                 `yaml:"protocol"` // "grpc", "http", "stdout"
+	Headers     map[string]ValueSource `yaml:"headers"`  // Optional headers for auth
+	ServiceName string                 `yaml:"service_name"`
+	Environment string                 `yaml:"environment"`
+	TLS         EventStoreOTelTLS      `yaml:"tls"`
 }
 
 type EventStoreOTelTLS struct {

--- a/pkg/config/eventstore.go
+++ b/pkg/config/eventstore.go
@@ -9,6 +9,7 @@ const (
 	EventStoreType_PULSE_STREAMING EventStoreType = "pulse-streaming"
 	EventStoreType_PULSE_LEGACY    EventStoreType = "pulse-legacy"
 	EventStoreType_AXIOM           EventStoreType = "axiom"
+	EventStoreType_OTEL            EventStoreType = "otel"
 )
 
 type ServiceEventStore struct {
@@ -31,6 +32,8 @@ func (s ServiceEventStore) ServiceType() string {
 		return "eventstore.noop"
 	case EventStoreType_AXIOM:
 		return "eventstore.axiom"
+	case EventStoreType_OTEL:
+		return "eventstore.otel"
 	case "e2e": // TODO(e2e)
 		return "eventstore.e2e"
 	default:
@@ -42,6 +45,7 @@ type EventStoreConfig struct {
 	Token                 ValueSource `yaml:"token"`
 	EventStorePulseConfig `yaml:",inline,omitempty"`
 	EventStoreAxiomConfig `yaml:",inline,omitempty"`
+	EventStoreOTelConfig  `yaml:",inline,omitempty"`
 }
 
 type EventStorePulseConfig struct {
@@ -51,4 +55,18 @@ type EventStorePulseConfig struct {
 
 type EventStoreAxiomConfig struct {
 	Dataset ValueSource `yaml:"dataset"`
+}
+
+type EventStoreOTelConfig struct {
+	Endpoint    string            `yaml:"endpoint"`
+	Protocol    string            `yaml:"protocol"` // "grpc", "http", "stdout"
+	Headers     map[string]string `yaml:"headers"`  // Optional headers for auth
+	ServiceName string            `yaml:"service_name"`
+	Environment string            `yaml:"environment"`
+	TLS         EventStoreOTelTLS `yaml:"tls"`
+}
+
+type EventStoreOTelTLS struct {
+	Enabled            bool `yaml:"enabled"`
+	InsecureSkipVerify bool `yaml:"insecure_skip_verify"`
 }

--- a/pkg/config/eventstore_test.go
+++ b/pkg/config/eventstore_test.go
@@ -63,8 +63,11 @@ func TestEventStoreUnmarshal(t *testing.T) {
 						Protocol:    "grpc",
 						ServiceName: "qtap-test",
 						Environment: "test",
-						Headers: map[string]string{
-							"api-key": "test-key",
+						Headers: map[string]ValueSource{
+							"api-key": {
+								Type:  "text",
+								Value: "test-key",
+							},
 						},
 						TLS: EventStoreOTelTLS{
 							Enabled:            false,

--- a/pkg/config/eventstore_test.go
+++ b/pkg/config/eventstore_test.go
@@ -51,6 +51,30 @@ func TestEventStoreUnmarshal(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name:     "otel eventstore",
+			filename: "testdata/eventstore_otel.yaml",
+			want: ServiceEventStore{
+				Type: EventStoreType_OTEL,
+				ID:   "otel-store",
+				EventStoreConfig: EventStoreConfig{
+					EventStoreOTelConfig: EventStoreOTelConfig{
+						Endpoint:    "localhost:4317",
+						Protocol:    "grpc",
+						ServiceName: "qtap-test",
+						Environment: "test",
+						Headers: map[string]string{
+							"api-key": "test-key",
+						},
+						TLS: EventStoreOTelTLS{
+							Enabled:            false,
+							InsecureSkipVerify: false,
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/config/testdata/eventstore_otel.yaml
+++ b/pkg/config/testdata/eventstore_otel.yaml
@@ -5,7 +5,9 @@ protocol: "grpc"
 service_name: "qtap-test"
 environment: "test"
 headers:
-  api-key: "test-key"
+  api-key:
+    type: text
+    value: test-key
 tls:
   enabled: false
   insecure_skip_verify: false

--- a/pkg/config/testdata/eventstore_otel.yaml
+++ b/pkg/config/testdata/eventstore_otel.yaml
@@ -1,0 +1,11 @@
+type: otel
+id: otel-store
+endpoint: "localhost:4317"
+protocol: "grpc"
+service_name: "qtap-test"
+environment: "test"
+headers:
+  api-key: "test-key"
+tls:
+  enabled: false
+  insecure_skip_verify: false

--- a/pkg/services/eventstore/otel/README.md
+++ b/pkg/services/eventstore/otel/README.md
@@ -1,0 +1,118 @@
+# OpenTelemetry EventStore
+
+The OpenTelemetry EventStore service exports events to OTLP (OpenTelemetry Protocol) endpoints using structured logging.
+
+## Features
+
+- **Multiple Protocol Support**: Supports gRPC, HTTP, and stdout protocols
+- **Flexible Endpoint Configuration**: Accepts both host:port and full URL formats
+- **Comprehensive Event Types**: Handles all qtap event types (Request, Issue, PIIEntity, ArtifactRecord, Connection)
+- **Authentication Support**: Configurable headers for API keys and authentication
+- **TLS Configuration**: Supports secure and insecure connections
+
+## Configuration
+
+### Basic Configuration
+
+```yaml
+eventstore:
+  - type: otel
+    endpoint: "localhost:4317"    # gRPC endpoint
+    protocol: grpc                 # "grpc", "http", or "stdout"
+    service_name: "qtap"
+    environment: "production"
+```
+
+### HTTP Protocol Configuration
+
+```yaml
+eventstore:
+  - type: otel
+    endpoint: "localhost:4318"    # HTTP endpoint
+    protocol: http
+    service_name: "qtap"
+    environment: "production"
+    headers:
+      authorization: "Bearer ${OTEL_API_TOKEN}"
+    tls:
+      enabled: false
+```
+
+### Full URL Configuration
+
+```yaml
+eventstore:
+  - type: otel
+    endpoint: "https://otel.example.com:4318/v1/logs"
+    protocol: http
+    service_name: "qtap"
+    environment: "production"
+    headers:
+      x-api-key: "${OTEL_API_KEY}"
+```
+
+### Stdout Protocol Configuration
+
+```yaml
+eventstore:
+  - type: otel
+    protocol: stdout
+    service_name: "qtap"
+    environment: "development"
+    # Note: endpoint, headers, and TLS are ignored for stdout
+```
+
+## Configuration Options
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `endpoint` | string | `localhost:4317` (gRPC), `localhost:4318` (HTTP), N/A (stdout) | OTLP endpoint |
+| `protocol` | string | `grpc` | Protocol: `grpc`, `http`, or `stdout` |
+| `service_name` | string | `qtap` | Service name in telemetry data |
+| `environment` | string | `production` | Environment identifier |
+| `headers` | map | `{}` | Custom headers for authentication |
+| `tls.enabled` | bool | `true` | Enable TLS |
+| `tls.insecure_skip_verify` | bool | `false` | Skip TLS certificate verification |
+
+## Protocol Differences
+
+### gRPC Protocol
+- Default port: 4317
+- Binary protocol, typically more efficient
+- Requires explicit TLS configuration
+- Better for high-throughput scenarios
+
+### HTTP Protocol
+- Default port: 4318
+- JSON over HTTP, easier to debug
+- TLS auto-detected from URL scheme (https://)
+- Better firewall/proxy compatibility
+- Supports custom URL paths
+
+### Stdout Protocol
+- No endpoint required
+- JSON output to stdout, ideal for debugging
+- Pretty-printed by default for readability
+- Ignores endpoint, headers, and TLS configuration
+- Intended for testing and development only
+
+## Event Mapping
+
+All qtap event types are converted to OTLP log records with:
+
+- **Timestamp**: Extracted from event timestamp field
+- **Severity**: 
+  - `Info`: Request, ArtifactRecord, Connection events
+  - `Warn`: PIIEntity events
+  - `Error`: Issue events
+- **Body**: Human-readable message describing the event
+- **Attributes**: All event fields converted via JSON marshaling
+- **Event Type**: Added as `event.type` attribute
+
+## Examples
+
+For complete configuration examples, see:
+
+- `examples/otel-grpc-eventstore.yaml` 
+- `examples/otel-stdout-eventstore.yaml` 
+- `examples/otel-http-eventstore.yaml`

--- a/pkg/services/eventstore/otel/factory.go
+++ b/pkg/services/eventstore/otel/factory.go
@@ -184,9 +184,14 @@ func (f *Factory) createGRPCExporter(ctx context.Context, endpoint string, c con
 		opts = append(opts, otlploggrpc.WithInsecure())
 	}
 
+	headers := make(map[string]string)
+	for k, v := range c.Headers {
+		headers[k] = v.String()
+	}
+
 	// Add headers if configured
-	if len(c.Headers) > 0 {
-		opts = append(opts, otlploggrpc.WithHeaders(c.Headers))
+	if len(headers) > 0 {
+		opts = append(opts, otlploggrpc.WithHeaders(headers))
 	}
 
 	return otlploggrpc.New(ctx, opts...)
@@ -212,9 +217,14 @@ func (f *Factory) createHTTPExporter(ctx context.Context, endpoint string, c con
 	}
 	// Note: When using WithEndpointURL, TLS is determined by the URL scheme
 
+	headers := make(map[string]string)
+	for k, v := range c.Headers {
+		headers[k] = v.String()
+	}
+
 	// Add headers if configured
-	if len(c.Headers) > 0 {
-		opts = append(opts, otlploghttp.WithHeaders(c.Headers))
+	if len(headers) > 0 {
+		opts = append(opts, otlploghttp.WithHeaders(headers))
 	}
 
 	return otlploghttp.New(ctx, opts...)

--- a/pkg/services/eventstore/otel/factory.go
+++ b/pkg/services/eventstore/otel/factory.go
@@ -1,0 +1,245 @@
+// pkg/services/eventstore/otel/factory.go
+package otel
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/qpoint-io/qtap/pkg/buildinfo"
+	"github.com/qpoint-io/qtap/pkg/config"
+	"github.com/qpoint-io/qtap/pkg/services"
+	"github.com/qpoint-io/qtap/pkg/services/eventstore"
+	"github.com/qpoint-io/qtap/pkg/services/objectstore"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp"
+	"go.opentelemetry.io/otel/exporters/stdout/stdoutlog"
+	sdklog "go.opentelemetry.io/otel/sdk/log"
+	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
+	"go.uber.org/zap"
+	"golang.org/x/term"
+)
+
+// Sample config:
+// eventstore:
+//   - type: otel
+//     endpoint: "localhost:4317"  # OTLP endpoint (gRPC: 4317, HTTP: 4318)
+//     protocol: grpc              # "grpc", "http", or "stdout"
+//     headers:                    # Optional headers for auth
+//       api-key: "${OTEL_API_KEY}"
+//     service_name: "qtap"
+//     environment: "production"
+//     tls:
+//       enabled: true
+//       insecure_skip_verify: false
+
+const (
+	Type services.ServiceType = "otel"
+)
+
+type Factory struct {
+	eventstore.BaseEventStore
+
+	logger      *zap.Logger
+	logProvider *sdklog.LoggerProvider
+	serviceName string
+	environment string
+}
+
+func (f *Factory) Init(ctx context.Context, cfg any) error {
+	c, ok := cfg.(config.ServiceEventStore)
+	if !ok {
+		return fmt.Errorf("invalid config type: %T wanted config.ServiceEventStore", cfg)
+	}
+
+	f.logger = zap.L().With(zap.String("service_factory", f.FactoryType().String()))
+
+	// Extract configuration with protocol-specific defaults
+	protocol := "grpc" // Default protocol
+	if c.Protocol != "" {
+		protocol = c.Protocol
+	}
+
+	// Set default endpoint based on protocol
+	var endpoint string
+	switch protocol {
+	case "http":
+		endpoint = "localhost:4318" // Default OTLP HTTP endpoint
+	case "stdout":
+		endpoint = "" // stdout doesn't use endpoints
+	default:
+		endpoint = "localhost:4317" // Default OTLP gRPC endpoint
+	}
+	if c.Endpoint != "" {
+		endpoint = c.Endpoint
+	}
+
+	// Service name and environment from config
+	f.serviceName = "qtap"
+	if c.ServiceName != "" {
+		f.serviceName = c.ServiceName
+	}
+
+	f.environment = "production"
+	if c.Environment != "" {
+		f.environment = c.Environment
+	}
+
+	// Create resource without merging to avoid schema conflicts
+	res := resource.NewWithAttributes(
+		semconv.SchemaURL,
+		semconv.ServiceName(f.serviceName),
+		semconv.ServiceVersion(buildinfo.Version()),
+		attribute.String("environment", f.environment),
+	)
+
+	// Create exporter based on protocol
+	var exporter sdklog.Exporter
+	var err error
+	switch protocol {
+	case "http":
+		exporter, err = f.createHTTPExporter(ctx, endpoint, c.EventStoreOTelConfig)
+	case "grpc":
+		exporter, err = f.createGRPCExporter(ctx, endpoint, c.EventStoreOTelConfig)
+	case "stdout":
+		exporter, err = f.createStdoutExporter(c.EventStoreOTelConfig)
+	default:
+		return fmt.Errorf("unsupported protocol: %s, supported protocols are 'grpc', 'http', and 'stdout'", protocol)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to create OTLP log exporter: %w", err)
+	}
+
+	// log provider
+	f.logProvider = sdklog.NewLoggerProvider(
+		sdklog.WithResource(res),
+		sdklog.WithProcessor(
+			sdklog.NewBatchProcessor(exporter,
+				sdklog.WithExportInterval(time.Second),
+				sdklog.WithExportMaxBatchSize(512),
+			),
+		),
+	)
+
+	f.logger.Info("OpenTelemetry service factory initialized",
+		zap.String("endpoint", endpoint),
+		zap.String("protocol", protocol),
+		zap.String("service_name", f.serviceName),
+		zap.String("environment", f.environment))
+
+	return nil
+}
+
+func (f *Factory) Create(ctx context.Context) (services.Service, error) {
+	of := f.Registry.Get(objectstore.TypeObjectStore)
+	s, err := of.Create(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("creating object store: %w", err)
+	}
+	o, ok := s.(objectstore.ObjectStore)
+	if !ok {
+		return nil, errors.New("object store service is not an objectstore.ObjectStore")
+	}
+
+	// Create logger for this service
+	logger := f.logProvider.Logger("qtap.eventstore")
+
+	es := &EventStore{
+		logger:      logger,
+		objectStore: o,
+		serviceName: f.serviceName,
+		environment: f.environment,
+	}
+
+	// Initialize LogHelper
+	es.SetLogger(f.logger)
+
+	return es, nil
+}
+
+// FactoryType returns the service factory type
+func (f *Factory) FactoryType() services.ServiceType {
+	return services.ServiceType(fmt.Sprintf("%s.%s", eventstore.TypeEventStore, Type))
+}
+
+// createGRPCExporter creates a gRPC OTLP log exporter
+func (f *Factory) createGRPCExporter(ctx context.Context, endpoint string, c config.EventStoreOTelConfig) (sdklog.Exporter, error) {
+	// Create exporter options
+	opts := []otlploggrpc.Option{
+		otlploggrpc.WithEndpoint(endpoint),
+	}
+
+	// Configure TLS
+	if c.TLS.Enabled {
+		if c.TLS.InsecureSkipVerify {
+			opts = append(opts, otlploggrpc.WithTLSCredentials(nil))
+		}
+		// For production, you'd configure proper TLS here
+	} else {
+		opts = append(opts, otlploggrpc.WithInsecure())
+	}
+
+	// Add headers if configured
+	if len(c.Headers) > 0 {
+		opts = append(opts, otlploggrpc.WithHeaders(c.Headers))
+	}
+
+	return otlploggrpc.New(ctx, opts...)
+}
+
+// createHTTPExporter creates an HTTP OTLP log exporter
+func (f *Factory) createHTTPExporter(ctx context.Context, endpoint string, c config.EventStoreOTelConfig) (sdklog.Exporter, error) {
+	// Create exporter options
+	var opts []otlploghttp.Option
+
+	// Determine if endpoint is a full URL or just host:port
+	if strings.HasPrefix(endpoint, "http://") || strings.HasPrefix(endpoint, "https://") {
+		// Full URL provided
+		opts = append(opts, otlploghttp.WithEndpointURL(endpoint))
+	} else {
+		// Host:port provided
+		opts = append(opts, otlploghttp.WithEndpoint(endpoint))
+
+		// Configure TLS only when using WithEndpoint
+		if !c.TLS.Enabled {
+			opts = append(opts, otlploghttp.WithInsecure())
+		}
+	}
+	// Note: When using WithEndpointURL, TLS is determined by the URL scheme
+
+	// Add headers if configured
+	if len(c.Headers) > 0 {
+		opts = append(opts, otlploghttp.WithHeaders(c.Headers))
+	}
+
+	return otlploghttp.New(ctx, opts...)
+}
+
+// createStdoutExporter creates a stdout OTLP log exporter
+func (f *Factory) createStdoutExporter(_ config.EventStoreOTelConfig) (sdklog.Exporter, error) {
+	// Create exporter options
+	var opts []stdoutlog.Option
+
+	if term.IsTerminal(int(os.Stdout.Fd())) {
+		// Enable pretty printing by default for better readability
+		opts = append(opts, stdoutlog.WithPrettyPrint())
+	}
+
+	return stdoutlog.New(opts...)
+}
+
+// Close cleans up resources
+func (f *Factory) Close() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if f.logProvider != nil {
+		return f.logProvider.Shutdown(ctx)
+	}
+	return nil
+}

--- a/pkg/services/eventstore/otel/factory_test.go
+++ b/pkg/services/eventstore/otel/factory_test.go
@@ -24,8 +24,11 @@ func TestFactory_Init_ValidConfig_GRPC(t *testing.T) {
 				Protocol:    "grpc",
 				ServiceName: "test-qtap",
 				Environment: "test",
-				Headers: map[string]string{
-					"api-key": "test-key",
+				Headers: map[string]config.ValueSource{
+					"api-key": {
+						Type:  "text",
+						Value: "test-key",
+					},
 				},
 				TLS: config.EventStoreOTelTLS{
 					Enabled:            false,
@@ -52,8 +55,11 @@ func TestFactory_Init_ValidConfig_HTTP(t *testing.T) {
 				Protocol:    "http",
 				ServiceName: "test-qtap-http",
 				Environment: "test",
-				Headers: map[string]string{
-					"authorization": "Bearer test-token",
+				Headers: map[string]config.ValueSource{
+					"authorization": {
+						Type:  "text",
+						Value: "Bearer test-token",
+					},
 				},
 				TLS: config.EventStoreOTelTLS{
 					Enabled:            false,

--- a/pkg/services/eventstore/otel/factory_test.go
+++ b/pkg/services/eventstore/otel/factory_test.go
@@ -1,0 +1,300 @@
+package otel
+
+import (
+	"context"
+	"testing"
+
+	"github.com/qpoint-io/qtap/pkg/config"
+	"github.com/qpoint-io/qtap/pkg/services"
+	"github.com/qpoint-io/qtap/pkg/services/mocks"
+	"github.com/qpoint-io/qtap/pkg/services/objectstore"
+	"github.com/qpoint-io/qtap/pkg/services/objectstore/noop"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestFactory_Init_ValidConfig_GRPC(t *testing.T) {
+	f := &Factory{}
+	cfg := config.ServiceEventStore{
+		Type: "otel",
+		EventStoreConfig: config.EventStoreConfig{
+			EventStoreOTelConfig: config.EventStoreOTelConfig{
+				Endpoint:    "localhost:4317",
+				Protocol:    "grpc",
+				ServiceName: "test-qtap",
+				Environment: "test",
+				Headers: map[string]string{
+					"api-key": "test-key",
+				},
+				TLS: config.EventStoreOTelTLS{
+					Enabled:            false,
+					InsecureSkipVerify: false,
+				},
+			},
+		},
+	}
+	err := f.Init(context.Background(), cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "test-qtap", f.serviceName)
+	assert.Equal(t, "test", f.environment)
+	assert.NotNil(t, f.logProvider)
+	assert.NotNil(t, f.logger)
+}
+
+func TestFactory_Init_ValidConfig_HTTP(t *testing.T) {
+	f := &Factory{}
+	cfg := config.ServiceEventStore{
+		Type: "otel",
+		EventStoreConfig: config.EventStoreConfig{
+			EventStoreOTelConfig: config.EventStoreOTelConfig{
+				Endpoint:    "localhost:4318",
+				Protocol:    "http",
+				ServiceName: "test-qtap-http",
+				Environment: "test",
+				Headers: map[string]string{
+					"authorization": "Bearer test-token",
+				},
+				TLS: config.EventStoreOTelTLS{
+					Enabled:            false,
+					InsecureSkipVerify: false,
+				},
+			},
+		},
+	}
+	err := f.Init(context.Background(), cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "test-qtap-http", f.serviceName)
+	assert.Equal(t, "test", f.environment)
+	assert.NotNil(t, f.logProvider)
+	assert.NotNil(t, f.logger)
+}
+
+func TestFactory_Init_DefaultValues_GRPC(t *testing.T) {
+	f := &Factory{}
+	cfg := config.ServiceEventStore{
+		Type: "otel",
+		EventStoreConfig: config.EventStoreConfig{
+			EventStoreOTelConfig: config.EventStoreOTelConfig{
+				// Using defaults - should default to gRPC
+			},
+		},
+	}
+	err := f.Init(context.Background(), cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "qtap", f.serviceName)
+	assert.Equal(t, "production", f.environment)
+}
+
+func TestFactory_Init_DefaultValues_HTTP(t *testing.T) {
+	f := &Factory{}
+	cfg := config.ServiceEventStore{
+		Type: "otel",
+		EventStoreConfig: config.EventStoreConfig{
+			EventStoreOTelConfig: config.EventStoreOTelConfig{
+				Protocol: "http", // Explicitly set to HTTP
+				// Other fields use defaults
+			},
+		},
+	}
+	err := f.Init(context.Background(), cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "qtap", f.serviceName)
+	assert.Equal(t, "production", f.environment)
+}
+
+func TestFactory_Init_ValidConfig_Stdout(t *testing.T) {
+	f := &Factory{}
+	cfg := config.ServiceEventStore{
+		Type: "otel",
+		EventStoreConfig: config.EventStoreConfig{
+			EventStoreOTelConfig: config.EventStoreOTelConfig{
+				Protocol:    "stdout",
+				ServiceName: "test-qtap-stdout",
+				Environment: "test",
+				// Note: endpoint, headers, and TLS are ignored for stdout
+			},
+		},
+	}
+	err := f.Init(context.Background(), cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "test-qtap-stdout", f.serviceName)
+	assert.Equal(t, "test", f.environment)
+	assert.NotNil(t, f.logProvider)
+	assert.NotNil(t, f.logger)
+}
+
+func TestFactory_Init_DefaultValues_Stdout(t *testing.T) {
+	f := &Factory{}
+	cfg := config.ServiceEventStore{
+		Type: "otel",
+		EventStoreConfig: config.EventStoreConfig{
+			EventStoreOTelConfig: config.EventStoreOTelConfig{
+				Protocol: "stdout", // Explicitly set to stdout
+				// Other fields use defaults
+			},
+		},
+	}
+	err := f.Init(context.Background(), cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "qtap", f.serviceName)
+	assert.Equal(t, "production", f.environment)
+}
+
+func TestFactory_Init_InvalidConfig(t *testing.T) {
+	f := &Factory{}
+	err := f.Init(context.Background(), "invalid config")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid config type")
+}
+
+func TestFactory_Create(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	f := &Factory{}
+
+	// Initialize with valid config first
+	cfg := config.ServiceEventStore{
+		Type: "otel",
+		EventStoreConfig: config.EventStoreConfig{
+			EventStoreOTelConfig: config.EventStoreOTelConfig{
+				Endpoint:    "localhost:4317",
+				ServiceName: "test-qtap",
+				Environment: "test",
+			},
+		},
+	}
+	err := f.Init(context.Background(), cfg)
+	require.NoError(t, err)
+
+	// Set up mock registry with noop object store factory
+	mockRegistry := mocks.NewMockRegistryAccessor(ctrl)
+	noopFactory := &noop.Factory{}
+	mockRegistry.EXPECT().Get(objectstore.TypeObjectStore).Return(noopFactory)
+	f.SetRegistry(mockRegistry)
+
+	// Now test Create
+	svc, err := f.Create(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, svc)
+
+	// Verify it's the correct type
+	es, ok := svc.(*EventStore)
+	require.True(t, ok)
+	assert.Equal(t, "test-qtap", es.serviceName)
+	assert.Equal(t, "test", es.environment)
+	assert.NotNil(t, es.logger)
+	assert.NotNil(t, es.objectStore)
+}
+
+func TestFactory_FactoryType(t *testing.T) {
+	f := &Factory{}
+	expected := services.ServiceType("eventstore.otel")
+	assert.Equal(t, expected, f.FactoryType())
+}
+
+func TestFactory_Close(t *testing.T) {
+	f := &Factory{}
+
+	// Test close without initialization
+	err := f.Close()
+	require.NoError(t, err)
+
+	// Test close after initialization
+	cfg := config.ServiceEventStore{
+		Type: "otel",
+		EventStoreConfig: config.EventStoreConfig{
+			EventStoreOTelConfig: config.EventStoreOTelConfig{},
+		},
+	}
+	err = f.Init(context.Background(), cfg)
+	require.NoError(t, err)
+
+	err = f.Close()
+	assert.NoError(t, err)
+}
+
+func TestFactory_Init_UnsupportedProtocol(t *testing.T) {
+	f := &Factory{}
+	cfg := config.ServiceEventStore{
+		Type: "otel",
+		EventStoreConfig: config.EventStoreConfig{
+			EventStoreOTelConfig: config.EventStoreOTelConfig{
+				Protocol: "websocket", // Unsupported protocol
+			},
+		},
+	}
+	err := f.Init(context.Background(), cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported protocol: websocket")
+	require.Contains(t, err.Error(), "supported protocols are 'grpc', 'http', and 'stdout'")
+}
+
+func TestFactory_ProtocolDefaults(t *testing.T) {
+	testCases := []struct {
+		name                string
+		protocol            string
+		endpoint            string
+		expectedDefaultPort string
+	}{
+		{
+			name:                "grpc_default",
+			protocol:            "grpc",
+			endpoint:            "", // Empty to test default
+			expectedDefaultPort: "4317",
+		},
+		{
+			name:                "http_default",
+			protocol:            "http",
+			endpoint:            "", // Empty to test default
+			expectedDefaultPort: "4318",
+		},
+		{
+			name:                "explicit_endpoint_grpc",
+			protocol:            "grpc",
+			endpoint:            "custom.example.com:9999",
+			expectedDefaultPort: "9999", // Should use explicit endpoint
+		},
+		{
+			name:                "explicit_endpoint_http",
+			protocol:            "http",
+			endpoint:            "custom.example.com:8888",
+			expectedDefaultPort: "8888", // Should use explicit endpoint
+		},
+		{
+			name:                "stdout_default",
+			protocol:            "stdout",
+			endpoint:            "", // Empty to test default
+			expectedDefaultPort: "", // stdout doesn't use ports
+		},
+		{
+			name:                "stdout_with_endpoint_ignored",
+			protocol:            "stdout",
+			endpoint:            "ignored.example.com:9999", // Should be ignored
+			expectedDefaultPort: "",                         // stdout doesn't use ports
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := &Factory{}
+			cfg := config.ServiceEventStore{
+				Type: "otel",
+				EventStoreConfig: config.EventStoreConfig{
+					EventStoreOTelConfig: config.EventStoreOTelConfig{
+						Protocol: tc.protocol,
+						Endpoint: tc.endpoint,
+					},
+				},
+			}
+			err := f.Init(context.Background(), cfg)
+			require.NoError(t, err)
+			// We can't easily test the internal endpoint selection without exposing it
+			// but we can verify the factory initializes successfully
+			assert.NotNil(t, f.logProvider)
+
+			// Cleanup
+			err = f.Close()
+			assert.NoError(t, err)
+		})
+	}
+}

--- a/pkg/services/eventstore/otel/integration_test.go
+++ b/pkg/services/eventstore/otel/integration_test.go
@@ -126,9 +126,15 @@ func TestOTelEventStore_ConfigTypes(t *testing.T) {
 				Protocol:    "grpc",
 				ServiceName: "custom-service",
 				Environment: "staging",
-				Headers: map[string]string{
-					"authorization": "Bearer token123",
-					"x-custom":      "custom-value",
+				Headers: map[string]config.ValueSource{
+					"authorization": {
+						Type:  "text",
+						Value: "Bearer token123",
+					},
+					"x-custom": {
+						Type:  "text",
+						Value: "custom-value",
+					},
 				},
 				TLS: config.EventStoreOTelTLS{
 					Enabled:            true,
@@ -143,9 +149,15 @@ func TestOTelEventStore_ConfigTypes(t *testing.T) {
 				Protocol:    "http",
 				ServiceName: "custom-service-http",
 				Environment: "staging",
-				Headers: map[string]string{
-					"authorization": "Bearer token456",
-					"x-custom":      "custom-http-value",
+				Headers: map[string]config.ValueSource{
+					"authorization": {
+						Type:  "text",
+						Value: "Bearer token456",
+					},
+					"x-custom": {
+						Type:  "text",
+						Value: "custom-http-value",
+					},
 				},
 				TLS: config.EventStoreOTelTLS{
 					Enabled:            true,
@@ -172,8 +184,11 @@ func TestOTelEventStore_ConfigTypes(t *testing.T) {
 				Protocol:    "http",
 				ServiceName: "full-url-test",
 				Environment: "test",
-				Headers: map[string]string{
-					"x-api-key": "test-key",
+				Headers: map[string]config.ValueSource{
+					"x-api-key": {
+						Type:  "text",
+						Value: "test-key",
+					},
 				},
 				TLS: config.EventStoreOTelTLS{
 					Enabled:            true,

--- a/pkg/services/eventstore/otel/integration_test.go
+++ b/pkg/services/eventstore/otel/integration_test.go
@@ -1,0 +1,242 @@
+package otel
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/qpoint-io/qtap/pkg/config"
+	"github.com/qpoint-io/qtap/pkg/services"
+	"github.com/qpoint-io/qtap/pkg/services/eventstore"
+	"github.com/qpoint-io/qtap/pkg/services/objectstore/noop"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	noopotel "go.opentelemetry.io/otel/log/noop"
+	"go.uber.org/zap"
+)
+
+// TestOTelEventStore_Integration tests the complete flow without network dependencies
+func TestOTelEventStore_Integration(t *testing.T) {
+	// Create EventStore directly for integration testing
+	es := &EventStore{
+		logger:      noopotel.NewLoggerProvider().Logger("integration-test"),
+		objectStore: &noop.ObjectStore{},
+		serviceName: "integration-test",
+		environment: "test",
+	}
+
+	// Initialize LogHelper to avoid nil pointer issues
+	es.SetLogger(zap.L().With(zap.String("service", "eventstore.otel")))
+
+	// Verify service type
+	assert.Equal(t, services.ServiceType("eventstore"), es.ServiceType())
+
+	// Test saving various event types
+	ctx := context.Background()
+
+	// Test Request event
+	req := &eventstore.Request{
+		Timestamp:   time.Now(),
+		Direction:   "ingress",
+		Url:         "https://api.example.com/users",
+		URLPath:     "/users",
+		Method:      "GET",
+		Status:      200,
+		Duration:    150,
+		ContentType: "application/json",
+		Category:    "api",
+		Agent:       "curl/7.68.0",
+		WrBytes:     0,
+		RdBytes:     2048,
+	}
+	req.ConnectionID = "conn-integration-test"
+	req.EndpointId = "endpoint-integration-test"
+	req.RequestId = "req-integration-test"
+	req.Tags = []string{"integration", "test"}
+
+	assert.NotPanics(t, func() {
+		es.Save(ctx, req)
+	})
+
+	// Test Issue event
+	issue := &eventstore.Issue{
+		Timestamp: time.Now(),
+		Direction: "ingress",
+		Error:     "Integration test error",
+		URL:       "https://api.example.com/error",
+		URLPath:   "/error",
+		Method:    "POST",
+		Status:    500,
+		TriggerConditions: []eventstore.IssueTriggerCondition{
+			{Plugin: eventstore.PluginNameDetectErrors, Condition: "http_5xx"},
+		},
+		TriggerReasons: []string{"server_error", "integration_test"},
+	}
+	issue.ConnectionID = "conn-integration-test"
+	issue.Tags = []string{"integration", "error"}
+
+	assert.NotPanics(t, func() {
+		es.Save(ctx, issue)
+	})
+
+	// Test Connection event
+	conn := &eventstore.Connection{
+		Timestamp:      time.Now(),
+		Finalized:      true,
+		Direction:      eventstore.Direction_Ingress,
+		VendorID:       "vendor-integration",
+		Part:           1,
+		SocketProtocol: eventstore.SocketProtocol_TCP,
+		L7Protocol:     eventstore.L7Protocol_HTTP1,
+		BytesSent:      2048,
+		BytesReceived:  4096,
+		System: &eventstore.ConnectionSystem{
+			Hostname:      "integration-host",
+			Agent:         "qtap",
+			AgentInstance: "qtap-integration",
+		},
+		Tags: map[string][]string{
+			"test": {"integration"},
+			"env":  {"test"},
+		},
+	}
+	conn.ConnectionID = "conn-integration-test"
+
+	assert.NotPanics(t, func() {
+		es.Save(ctx, conn)
+	})
+}
+
+// TestOTelEventStore_ConfigTypes tests that different configuration values are handled correctly
+func TestOTelEventStore_ConfigTypes(t *testing.T) {
+	testCases := []struct {
+		name   string
+		config config.EventStoreOTelConfig
+	}{
+		{
+			name:   "minimal_config",
+			config: config.EventStoreOTelConfig{
+				// All defaults
+			},
+		},
+		{
+			name: "full_config_grpc",
+			config: config.EventStoreOTelConfig{
+				Endpoint:    "https://otel.example.com:4317",
+				Protocol:    "grpc",
+				ServiceName: "custom-service",
+				Environment: "staging",
+				Headers: map[string]string{
+					"authorization": "Bearer token123",
+					"x-custom":      "custom-value",
+				},
+				TLS: config.EventStoreOTelTLS{
+					Enabled:            true,
+					InsecureSkipVerify: false,
+				},
+			},
+		},
+		{
+			name: "full_config_http",
+			config: config.EventStoreOTelConfig{
+				Endpoint:    "otel.example.com:4318",
+				Protocol:    "http",
+				ServiceName: "custom-service-http",
+				Environment: "staging",
+				Headers: map[string]string{
+					"authorization": "Bearer token456",
+					"x-custom":      "custom-http-value",
+				},
+				TLS: config.EventStoreOTelTLS{
+					Enabled:            true,
+					InsecureSkipVerify: false,
+				},
+			},
+		},
+		{
+			name: "insecure_config_http",
+			config: config.EventStoreOTelConfig{
+				Endpoint:    "localhost:4318",
+				Protocol:    "http",
+				ServiceName: "insecure-test-http",
+				TLS: config.EventStoreOTelTLS{
+					Enabled:            false,
+					InsecureSkipVerify: true,
+				},
+			},
+		},
+		{
+			name: "full_url_http",
+			config: config.EventStoreOTelConfig{
+				Endpoint:    "https://otel.example.com:4318/custom/path",
+				Protocol:    "http",
+				ServiceName: "full-url-test",
+				Environment: "test",
+				Headers: map[string]string{
+					"x-api-key": "test-key",
+				},
+				TLS: config.EventStoreOTelTLS{
+					Enabled:            true,
+					InsecureSkipVerify: false,
+				},
+			},
+		},
+		{
+			name: "insecure_config",
+			config: config.EventStoreOTelConfig{
+				Endpoint:    "localhost:4317",
+				ServiceName: "insecure-test",
+				TLS: config.EventStoreOTelTLS{
+					Enabled:            false,
+					InsecureSkipVerify: true,
+				},
+			},
+		},
+		{
+			name: "stdout_config",
+			config: config.EventStoreOTelConfig{
+				Protocol:    "stdout",
+				ServiceName: "stdout-test",
+				Environment: "test",
+				// Note: endpoint, headers, and TLS are ignored for stdout
+			},
+		},
+		{
+			name: "stdout_minimal",
+			config: config.EventStoreOTelConfig{
+				Protocol: "stdout",
+				// Use all defaults with stdout protocol
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			factory := &Factory{}
+			cfg := config.ServiceEventStore{
+				Type:             "otel",
+				EventStoreConfig: config.EventStoreConfig{EventStoreOTelConfig: tc.config},
+			}
+
+			err := factory.Init(context.Background(), cfg)
+			require.NoError(t, err)
+
+			// Verify factory state
+			if tc.config.ServiceName != "" {
+				assert.Equal(t, tc.config.ServiceName, factory.serviceName)
+			} else {
+				assert.Equal(t, "qtap", factory.serviceName)
+			}
+
+			if tc.config.Environment != "" {
+				assert.Equal(t, tc.config.Environment, factory.environment)
+			} else {
+				assert.Equal(t, "production", factory.environment)
+			}
+
+			// Cleanup
+			err = factory.Close()
+			assert.NoError(t, err)
+		})
+	}
+}

--- a/pkg/services/eventstore/otel/metrics.go
+++ b/pkg/services/eventstore/otel/metrics.go
@@ -1,0 +1,12 @@
+// pkg/services/eventstore/otel/metrics.go
+package otel
+
+import "github.com/qpoint-io/qtap/pkg/telemetry"
+
+var submittedRecords = telemetry.Counter(
+	"tap_otel_records_submitted",
+	telemetry.WithDescription("The number of records submitted to OpenTelemetry"))
+
+func incrementSubmittedRecords() {
+	submittedRecords(1)
+}

--- a/pkg/services/eventstore/otel/otel.go
+++ b/pkg/services/eventstore/otel/otel.go
@@ -106,7 +106,10 @@ func (s *EventStore) logEvent(ctx context.Context, item any, severity log.Severi
 	}
 
 	// Add event type
-	attrs = append([]log.KeyValue{log.String("event.type", s.getEventType(item))}, attrs...)
+	logAttrs := []log.KeyValue{
+		log.String("event.type", s.getEventType(item)),
+		log.Map("event", attrs...),
+	}
 
 	// Extract timestamp from the item
 	timestamp := s.extractTimestamp(item)
@@ -115,7 +118,7 @@ func (s *EventStore) logEvent(ctx context.Context, item any, severity log.Severi
 	record.SetTimestamp(timestamp)
 	record.SetSeverity(severity)
 	record.SetBody(log.StringValue(bodyMessage))
-	record.AddAttributes(attrs...)
+	record.AddAttributes(logAttrs...)
 
 	s.logger.Emit(ctx, record)
 	incrementSubmittedRecords()

--- a/pkg/services/eventstore/otel/otel.go
+++ b/pkg/services/eventstore/otel/otel.go
@@ -1,0 +1,247 @@
+// pkg/services/eventstore/otel/otel.go
+package otel
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/qpoint-io/qtap/pkg/connection"
+	"github.com/qpoint-io/qtap/pkg/services"
+	"github.com/qpoint-io/qtap/pkg/services/eventstore"
+	"github.com/qpoint-io/qtap/pkg/services/objectstore"
+	"go.opentelemetry.io/otel/log"
+	"go.uber.org/zap"
+)
+
+type EventStore struct {
+	services.LogHelper
+	eventstore.BaseEventStore
+
+	conn        *connection.Connection
+	logger      log.Logger
+	objectStore objectstore.ObjectStore
+	serviceName string
+	environment string
+}
+
+type connidable interface {
+	SetConnectionID(id string)
+}
+
+type taggable interface {
+	AddTags(tag ...string)
+}
+
+// Save submits an event to OpenTelemetry
+func (s *EventStore) Save(ctx context.Context, item any) {
+	// Add connection metadata if available
+	if s.conn != nil {
+		if c, ok := item.(connidable); ok {
+			c.SetConnectionID(s.conn.ID())
+		}
+		if t, ok := item.(taggable); ok {
+			t.AddTags(s.conn.Tags().List()...)
+		}
+	}
+
+	switch i := item.(type) {
+	case *eventstore.Request:
+		s.logEvent(ctx, i, log.SeverityInfo, fmt.Sprintf("HTTP %s (%d) %s", i.Method, i.Status, i.Url))
+	case *eventstore.Issue:
+		s.logEvent(ctx, i, log.SeverityError, fmt.Sprintf("HTTP Error: %s (%d) %s :: %s", i.Method, i.Status, i.URL, i.Error))
+	case *eventstore.PIIEntity:
+		s.logEvent(ctx, i, log.SeverityWarn, fmt.Sprintf("PII detected: %s (score: %.2f)", i.EntityType, i.Score))
+	case *eventstore.ArtifactRecord:
+		s.logEvent(ctx, i, log.SeverityInfo, fmt.Sprintf("Artifact stored: %s", i.Type))
+	case *eventstore.Connection:
+		host := "unknown"
+		if i.System != nil {
+			host = i.System.Hostname
+		}
+		s.logEvent(ctx, i, log.SeverityInfo, fmt.Sprintf("Connection: [%s via %s] %s → %s", i.Direction, i.SocketProtocol, host, i.EndpointId))
+	case *eventstore.Artifact:
+		go func() {
+			ar, err := s.objectStore.Put(*i)
+			if err != nil {
+				// Use zap.L() as fallback if LogHelper not initialized
+				if s.Log() != nil {
+					s.Log().Error("failed to put artifact", zap.Error(err))
+				} else {
+					zap.L().Error("failed to put artifact", zap.Error(err))
+				}
+				return
+			}
+			// Only save artifact record if it's not nil
+			if ar != nil {
+				s.Save(ctx, ar)
+			}
+		}()
+	default:
+		// Safely log unsupported event type
+		if s.Log() != nil {
+			s.Log().Warn("unsupported event type",
+				zap.String("type", fmt.Sprintf("%T", i)),
+				zap.Any("item", i))
+		} else {
+			zap.L().Warn("unsupported event type",
+				zap.String("type", fmt.Sprintf("%T", i)),
+				zap.Any("item", i))
+		}
+	}
+}
+
+// logEvent is a generic method that converts any event struct to OTEL attributes using JSON marshaling
+func (s *EventStore) logEvent(ctx context.Context, item any, severity log.Severity, bodyMessage string) {
+	attrs, err := s.structToAttributes(item)
+	if err != nil {
+		if s.Log() != nil {
+			s.Log().Error("failed to convert item to attributes", zap.Error(err))
+		} else {
+			zap.L().Error("failed to convert item to attributes", zap.Error(err))
+		}
+		return
+	}
+
+	// Add event type
+	attrs = append([]log.KeyValue{log.String("event.type", s.getEventType(item))}, attrs...)
+
+	// Extract timestamp from the item
+	timestamp := s.extractTimestamp(item)
+
+	record := log.Record{}
+	record.SetTimestamp(timestamp)
+	record.SetSeverity(severity)
+	record.SetBody(log.StringValue(bodyMessage))
+	record.AddAttributes(attrs...)
+
+	s.logger.Emit(ctx, record)
+	incrementSubmittedRecords()
+}
+
+// structToAttributes converts any struct to OTEL log attributes using JSON marshaling
+func (s *EventStore) structToAttributes(item any) ([]log.KeyValue, error) {
+	// Convert struct to map using JSON marshaling
+	data, err := json.Marshal(item)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal item: %w", err)
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal to map: %w", err)
+	}
+
+	// Convert map to OTEL attributes
+	return s.mapToAttributes(m, ""), nil
+}
+
+// mapToAttributes recursively converts a map to OTEL log attributes
+//
+// Note: I'm not sure how I feel about this method of creating attributes.
+func (s *EventStore) mapToAttributes(m map[string]any, prefix string) []log.KeyValue {
+	var attrs []log.KeyValue
+
+	for k, v := range m {
+		key := k
+		if prefix != "" {
+			key = prefix + "." + k
+		}
+
+		// Skip empty values to reduce noise
+		if v == nil || (reflect.ValueOf(v).Kind() == reflect.String && v.(string) == "") {
+			continue
+		}
+
+		switch val := v.(type) {
+		case string:
+			attrs = append(attrs, log.String(key, val))
+		case bool:
+			attrs = append(attrs, log.Bool(key, val))
+		case float64:
+			// JSON unmarshaling converts all numbers to float64
+			if val == float64(int64(val)) {
+				// It's an integer
+				attrs = append(attrs, log.Int64(key, int64(val)))
+			} else {
+				// It's a float
+				attrs = append(attrs, log.Float64(key, val))
+			}
+		case []any:
+			// Convert slice to OTEL slice
+			values := make([]log.Value, len(val))
+			for i, item := range val {
+				values[i] = s.anyToLogValue(item)
+			}
+			attrs = append(attrs, log.Slice(key, values...))
+		case map[string]any:
+			// Recursively handle nested maps
+			attrs = append(attrs, s.mapToAttributes(val, key)...)
+		default:
+			// Fallback to string representation
+			attrs = append(attrs, log.String(key, fmt.Sprintf("%v", val)))
+		}
+	}
+
+	return attrs
+}
+
+// anyToLogValue converts any value to OTEL log.Value
+func (s *EventStore) anyToLogValue(v any) log.Value {
+	switch val := v.(type) {
+	case string:
+		return log.StringValue(val)
+	case bool:
+		return log.BoolValue(val)
+	case float64:
+		if val == float64(int64(val)) {
+			return log.Int64Value(int64(val))
+		}
+		return log.Float64Value(val)
+	default:
+		return log.StringValue(fmt.Sprintf("%v", val))
+	}
+}
+
+// getEventType extracts the event type from the item
+func (s *EventStore) getEventType(item any) string {
+	switch item.(type) {
+	case *eventstore.Request:
+		return "request"
+	case *eventstore.Issue:
+		return "issue"
+	case *eventstore.PIIEntity:
+		return "pii_entity"
+	case *eventstore.ArtifactRecord:
+		return "artifact_record"
+	case *eventstore.Connection:
+		return "connection"
+	default:
+		return fmt.Sprintf("%T", item)
+	}
+}
+
+// extractTimestamp extracts the timestamp from the item
+func (s *EventStore) extractTimestamp(item any) time.Time {
+	switch i := item.(type) {
+	case *eventstore.Request:
+		return i.Timestamp
+	case *eventstore.Issue:
+		return i.Timestamp
+	case *eventstore.PIIEntity:
+		return i.Timestamp
+	case *eventstore.ArtifactRecord:
+		return i.Timestamp
+	case *eventstore.Connection:
+		return i.Timestamp
+	default:
+		return time.Now()
+	}
+}
+
+// SetConnection sets the connection context for events
+func (s *EventStore) SetConnection(conn *connection.Connection) {
+	s.conn = conn
+}

--- a/pkg/services/eventstore/otel/otel_test.go
+++ b/pkg/services/eventstore/otel/otel_test.go
@@ -1,0 +1,268 @@
+package otel
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/qpoint-io/qtap/pkg/services/eventstore"
+	"github.com/qpoint-io/qtap/pkg/services/objectstore/noop"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	noopotel "go.opentelemetry.io/otel/log/noop"
+)
+
+func TestEventStore_Save_Request(t *testing.T) {
+	// Use noop logger to avoid actual OTLP export in tests
+	es := &EventStore{
+		logger:      noopotel.NewLoggerProvider().Logger("test"),
+		objectStore: &noop.ObjectStore{},
+		serviceName: "test-qtap",
+		environment: "test",
+	}
+
+	req := &eventstore.Request{
+		Timestamp:   time.Now(),
+		Direction:   "ingress",
+		Url:         "https://api.example.com/users",
+		URLPath:     "/users",
+		Method:      "GET",
+		Status:      200,
+		Duration:    125,
+		ContentType: "application/json",
+		Category:    "api",
+		Agent:       "curl/7.68.0",
+		WrBytes:     0,
+		RdBytes:     1024,
+	}
+	req.ConnectionID = "conn-123"
+	req.EndpointId = "endpoint-456"
+	req.RequestId = "req-789"
+	req.Tags = []string{"tag1", "tag2"}
+	req.AuthTokenMask = "****1234"
+	req.AuthTokenHash = "abc123def456"
+	req.AuthTokenSource = "header"
+	req.AuthTokenType = "bearer"
+
+	// Should not panic or error
+	assert.NotPanics(t, func() {
+		es.Save(context.Background(), req)
+	})
+}
+
+func TestEventStore_Save_Issue(t *testing.T) {
+	es := &EventStore{
+		logger:      noopotel.NewLoggerProvider().Logger("test"),
+		objectStore: &noop.ObjectStore{},
+		serviceName: "test-qtap",
+		environment: "test",
+	}
+
+	issue := &eventstore.Issue{
+		Timestamp: time.Now(),
+		Direction: "ingress",
+		Error:     "Authentication failed",
+		URL:       "https://api.example.com/secure",
+		URLPath:   "/secure",
+		Method:    "POST",
+		Status:    401,
+		TriggerConditions: []eventstore.IssueTriggerCondition{
+			{Plugin: eventstore.PluginNameDetectErrors, Condition: "http_4xx"},
+		},
+		TriggerReasons: []string{"unauthorized_access", "invalid_token"},
+	}
+	issue.ConnectionID = "conn-123"
+	issue.Tags = []string{"security", "error"}
+
+	assert.NotPanics(t, func() {
+		es.Save(context.Background(), issue)
+	})
+}
+
+func TestEventStore_Save_PIIEntity(t *testing.T) {
+	es := &EventStore{
+		logger:      noopotel.NewLoggerProvider().Logger("test"),
+		objectStore: &noop.ObjectStore{},
+		serviceName: "test-qtap",
+		environment: "test",
+	}
+
+	pii := &eventstore.PIIEntity{
+		Timestamp:    time.Now(),
+		EntityType:   "email",
+		Score:        0.95,
+		EntitySource: "request_body",
+		FieldPath:    "user.email",
+		ValueHash:    "hash123456",
+	}
+	pii.ConnectionID = "conn-123"
+	pii.Tags = []string{"pii", "sensitive"}
+
+	assert.NotPanics(t, func() {
+		es.Save(context.Background(), pii)
+	})
+}
+
+func TestEventStore_Save_ArtifactRecord(t *testing.T) {
+	es := &EventStore{
+		logger:      noopotel.NewLoggerProvider().Logger("test"),
+		objectStore: &noop.ObjectStore{},
+		serviceName: "test-qtap",
+		environment: "test",
+	}
+
+	ar := &eventstore.ArtifactRecord{
+		Timestamp: time.Now(),
+		Type:      eventstore.ArtifactType_RequestBody,
+		Digest:    "sha1:abcdef123456",
+		URL:       "s3://bucket/path/to/artifact",
+		Summary: map[string]any{
+			"size":       1024,
+			"compressed": true,
+		},
+	}
+	ar.ConnectionID = "conn-123"
+
+	assert.NotPanics(t, func() {
+		es.Save(context.Background(), ar)
+	})
+}
+
+func TestEventStore_Save_Connection(t *testing.T) {
+	es := &EventStore{
+		logger:      noopotel.NewLoggerProvider().Logger("test"),
+		objectStore: &noop.ObjectStore{},
+		serviceName: "test-qtap",
+		environment: "test",
+	}
+
+	conn := &eventstore.Connection{
+		Timestamp:      time.Now(),
+		Finalized:      true,
+		Direction:      eventstore.Direction_Ingress,
+		VendorID:       "vendor-123",
+		Part:           1,
+		SocketProtocol: eventstore.SocketProtocol_TCP,
+		L7Protocol:     eventstore.L7Protocol_HTTP1,
+		BytesSent:      1024,
+		BytesReceived:  2048,
+		System: &eventstore.ConnectionSystem{
+			Hostname:      "test-host",
+			Agent:         "qtap",
+			AgentInstance: "qtap-001",
+		},
+		Tags: map[string][]string{
+			"env":    {"test"},
+			"region": {"us-east-1"},
+		},
+	}
+	conn.ConnectionID = "conn-123"
+
+	assert.NotPanics(t, func() {
+		es.Save(context.Background(), conn)
+	})
+}
+
+func TestEventStore_Save_Artifact(t *testing.T) {
+	es := &EventStore{
+		logger:      noopotel.NewLoggerProvider().Logger("test"),
+		objectStore: &noop.ObjectStore{},
+		serviceName: "test-qtap",
+		environment: "test",
+	}
+
+	artifact := &eventstore.Artifact{
+		Type:        eventstore.ArtifactType_RequestBody,
+		Data:        []byte(`{"user": "test", "email": "test@example.com"}`),
+		ContentType: "application/json",
+		Summary: map[string]any{
+			"parsed": true,
+		},
+	}
+	artifact.ConnectionID = "conn-123"
+
+	// Should not panic - artifact saving is async via goroutine
+	assert.NotPanics(t, func() {
+		es.Save(context.Background(), artifact)
+	})
+
+	// Give goroutine time to complete
+	time.Sleep(10 * time.Millisecond)
+}
+
+func TestEventStore_Save_UnsupportedType(t *testing.T) {
+	es := &EventStore{
+		logger:      noopotel.NewLoggerProvider().Logger("test"),
+		objectStore: &noop.ObjectStore{},
+		serviceName: "test-qtap",
+		environment: "test",
+	}
+
+	// Test with unsupported type
+	unsupported := struct {
+		Field string
+	}{Field: "test"}
+
+	// Should not panic, just log warning
+	assert.NotPanics(t, func() {
+		es.Save(context.Background(), unsupported)
+	})
+}
+
+func TestEventStore_SetConnection(t *testing.T) {
+	es := &EventStore{
+		logger:      noopotel.NewLoggerProvider().Logger("test"),
+		objectStore: &noop.ObjectStore{},
+		serviceName: "test-qtap",
+		environment: "test",
+	}
+
+	// Test that connection can be set (just basic functionality)
+	// We'll skip the complex connection creation for this test
+	// and just test the basic Save functionality without connection
+
+	// Test that events can be saved without connection
+	req := &eventstore.Request{
+		Timestamp: time.Now(),
+		Method:    "GET",
+		URLPath:   "/test",
+		Status:    200,
+	}
+
+	// Save should work without connection
+	assert.NotPanics(t, func() {
+		es.Save(context.Background(), req)
+	})
+}
+
+func TestEventStore_StructToAttributes(t *testing.T) {
+	es := &EventStore{
+		logger:      noopotel.NewLoggerProvider().Logger("test"),
+		objectStore: &noop.ObjectStore{},
+		serviceName: "test-qtap",
+		environment: "test",
+	}
+
+	// Test with a simple request struct
+	req := &eventstore.Request{
+		Timestamp: time.Now(),
+		Method:    "GET",
+		URLPath:   "/test",
+		Status:    200,
+	}
+	req.ConnectionID = "conn-123"
+
+	attrs, err := es.structToAttributes(req)
+	require.NoError(t, err)
+	require.NotEmpty(t, attrs)
+
+	// Should contain basic fields
+	found := false
+	for _, attr := range attrs {
+		if attr.Key == "method" {
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "Should contain method attribute")
+}


### PR DESCRIPTION
- Introduced a new event store type for OpenTelemetry, allowing events to be exported to OTLP endpoints using structured logging.
- Added support for multiple protocols: gRPC, HTTP, and stdout, with flexible endpoint configuration.
- Implemented comprehensive event handling for various qtap event types, including Request, Issue, PIIEntity, ArtifactRecord, and Connection.
- Configurable headers for authentication and TLS settings for secure connections.
- Added integration and unit tests to validate functionality and configuration handling.
- Updated documentation with configuration examples and usage details.

### Testing:

For gRPC / http testing, start a LGTM container:

```
docker run -p 3000:3000 -p 4317:4317 -p 4318:4318 --rm -ti grafana/otel-lgtm
```

and use the grpc or http example otel configs. 

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Contributing Guide: https://github.com/qpoint-io/qtap/docs/CONTRIBUTING.md
     - 📖 Read the Contributor License Agreement (CLA): https://github.com/qpoint-io/qtap/docs/CLA.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Qpoint Team member.
-->
