### PR TITLE
sec(go): Bump Go to v1.24.4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.3'
+          go-version: '1.24.4'
           cache: true
 
       - name: Run CI

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.3'
+          go-version: '1.24.4'
           cache: true
 
       - name: Run E2E tests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/qpoint-io/qtap
 
-go 1.24.3
+go 1.24.4
 
 require (
 	github.com/andybalholm/brotli v1.1.1


### PR DESCRIPTION
- [GO-2025-3750 Inconsistent handling of O_CREATE|O_EXCL on Unix and Windows in os in syscall](https://pkg.go.dev/vuln/GO-2025-3750)
- [GO-2025-3749 Usage of ExtKeyUsageAny disables policy validation in crypto/x509](https://pkg.go.dev/vuln/GO-2025-3749)

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Contributing Guide: https://github.com/qpoint-io/qtap/docs/CONTRIBUTING.md
     - 📖 Read the Contributor License Agreement (CLA): https://github.com/qpoint-io/qtap/docs/CLA.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Qpoint Team member.
-->
