### PR TITLE
feat(plugins) use consistent control values from conn & proc

### DIFF
--- a/examples/sample-capture.yaml
+++ b/examples/sample-capture.yaml
@@ -26,6 +26,12 @@ stacks:
             - name: full log on 400
               expr: is_4xx() # see rulekit config below
               level: full
+            - name: full log on container label
+              expr: src.container.labels.qpoint_debug_level == "debug"
+              level: full
+            - name: full log on pod label
+              expr: src.pod.labels.qpoint_debug_level == "debug"
+              level: full
 
 # rulekit config
 rulekit:

--- a/pkg/plugins/connection.go
+++ b/pkg/plugins/connection.go
@@ -42,6 +42,7 @@ type Connection struct {
 	stackInstance StackInstance
 	metadata      map[string]MetadataValue
 	tags          tags.List
+	controlValues map[string]any
 	bufferSize    int
 }
 
@@ -105,6 +106,10 @@ func (c *Connection) SetResponse(res *http.Response) {
 	// set the response and response body
 	c.resp = res
 	c.resHeaderMap = NewHeaders(res.Header)
+}
+
+func (c *Connection) SetControlValues(values map[string]any) {
+	c.controlValues = values
 }
 
 // session is done

--- a/pkg/plugins/context.go
+++ b/pkg/plugins/context.go
@@ -59,3 +59,7 @@ func (c *ConnectionContext) Tags() tags.List {
 func (c *ConnectionContext) Context() context.Context {
 	return c.connection.ctx
 }
+
+func (c *ConnectionContext) ControlValues() map[string]any {
+	return c.connection.controlValues
+}

--- a/pkg/plugins/httpcapture/httpcapture_http.go
+++ b/pkg/plugins/httpcapture/httpcapture_http.go
@@ -86,15 +86,15 @@ func (i *instance) Destroy() {
 		// Create rule evaluation pairs from request, response headers and metadata
 		reqPairs := tools.NewHeaderMap(i.reqheaders).RulePairs("request")
 		resPairs := tools.NewHeaderMap(i.resheaders).RulePairs("response")
-		metaPairs := tools.MetadataRulePairs(i.conn.Metadata())
+		connPairs := i.conn.ControlValues()
 
 		// Combine all pairs for rule evaluation
-		allPairs := make(map[string]any, len(reqPairs)+len(resPairs)+len(metaPairs))
+		allPairs := make(map[string]any, len(reqPairs)+len(resPairs)+len(connPairs))
 
 		// Add all pairs using maps.Copy
 		maps.Copy(allPairs, reqPairs)
 		maps.Copy(allPairs, resPairs)
-		maps.Copy(allPairs, metaPairs)
+		maps.Copy(allPairs, connPairs)
 
 		var (
 			macros    map[string]rulekit.Rule

--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -57,6 +57,7 @@ type PluginContext interface {
 	GetMetadata(key string) MetadataValue
 	Tags() tags.List
 	Context() context.Context
+	ControlValues() map[string]any
 }
 
 type Headers interface {

--- a/pkg/plugins/plugintest/helpers.go
+++ b/pkg/plugins/plugintest/helpers.go
@@ -114,12 +114,13 @@ func Headers(kv map[string]string) *plugins.HttpHeaderMap {
 }
 
 type Context struct {
-	T         *testing.T
-	VReqBody  []byte
-	VResBody  []byte
-	VMetadata map[string]any
-	VTags     map[string]string
-	VContext  context.Context
+	T              *testing.T
+	VReqBody       []byte
+	VResBody       []byte
+	VMetadata      map[string]any
+	VTags          map[string]string
+	VContext       context.Context
+	VControlValues map[string]any
 }
 
 // plugins.HttpPluginInstance interface implementation
@@ -163,6 +164,10 @@ func (c *Context) Context() context.Context {
 		return c.VContext
 	}
 	return context.TODO()
+}
+
+func (c *Context) ControlValues() map[string]any {
+	return c.VControlValues
 }
 
 func Buffer[T string | []byte](data T) *synq.LinkedBuffer {

--- a/pkg/stream/protocols/http1/session.go
+++ b/pkg/stream/protocols/http1/session.go
@@ -176,6 +176,9 @@ func (s *Session) CreateRequest(req *http.Request, noBody bool) {
 			s.pluginConn.AppendMetadata("process-"+k, fmt.Sprintf("%v", v))
 		}
 
+		// set the control values
+		s.pluginConn.SetControlValues(s.conn.ControlValues())
+
 		// call the request headers callback
 		if err := s.pluginConn.OnHttpRequestHeaders(true); err != nil {
 			s.logger.Error("plugin request headers", zap.Error(err))

--- a/pkg/stream/protocols/http2/session.go
+++ b/pkg/stream/protocols/http2/session.go
@@ -182,6 +182,9 @@ func (s *Session) CreateRequest(headers []hpack.HeaderField, endOfStream bool) e
 			s.pluginConn.AppendMetadata("process-"+k, fmt.Sprintf("%v", v))
 		}
 
+		// set the control values
+		s.pluginConn.SetControlValues(s.conn.ControlValues())
+
 		// call the request headers callback
 		if err := s.pluginConn.OnHttpRequestHeaders(endOfStream); err != nil {
 			s.logger.Error("plugin request headers", zap.Error(err))


### PR DESCRIPTION
- Inject Connection control values (which contain process CVs) into plugin context
- Update httpcapture to use these new CVs

These changes improve the observability and flexibility of logging and control data management across the application.

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Contributing Guide: https://github.com/qpoint-io/qtap/docs/CONTRIBUTING.md
     - 📖 Read the Contributor License Agreement (CLA): https://github.com/qpoint-io/qtap/docs/CLA.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Qpoint Team member.
-->
