### PR TITLE
feat(eventstore): Add env var expansion for otel endpoints

### DIFF
--- a/pkg/services/eventstore/otel/README.md
+++ b/pkg/services/eventstore/otel/README.md
@@ -23,6 +23,28 @@ eventstore:
     environment: "production"
 ```
 
+### Environment Variable Support
+
+Environment variables can be referenced in the endpoint configuration using mustache-style syntax:
+
+```yaml
+eventstore:
+  - type: otel
+    endpoint: "{{ OTEL_ENDPOINT }}"
+    protocol: grpc
+    service_name: "qtap"
+    environment: "production"
+```
+
+```yaml
+eventstore:
+  - type: otel
+    endpoint: "https://example.com/org/{{ OTEL_ORG_ID }}/dataset/{{ OTEL_DATASET_ID }}"
+    protocol: grpc
+    service_name: "qtap"
+    environment: "production"
+```
+
 ### HTTP Protocol Configuration
 
 ```yaml

--- a/pkg/services/eventstore/otel/factory.go
+++ b/pkg/services/eventstore/otel/factory.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -51,6 +52,20 @@ type Factory struct {
 	environment string
 }
 
+func expandEnvVarsInBraces(s string) string {
+	re := regexp.MustCompile(`\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}`)
+	return re.ReplaceAllStringFunc(s, func(str string) string {
+		matches := re.FindStringSubmatch(str)
+		if len(matches) == 2 {
+			key := matches[1]
+			if val, ok := os.LookupEnv(key); ok {
+				return val
+			}
+		}
+		return str
+	})
+}
+
 func (f *Factory) Init(ctx context.Context, cfg any) error {
 	c, ok := cfg.(config.ServiceEventStore)
 	if !ok {
@@ -75,8 +90,9 @@ func (f *Factory) Init(ctx context.Context, cfg any) error {
 	default:
 		endpoint = "localhost:4317" // Default OTLP gRPC endpoint
 	}
+
 	if c.Endpoint != "" {
-		endpoint = c.Endpoint
+		endpoint = expandEnvVarsInBraces(c.Endpoint)
 	}
 
 	// Service name and environment from config

--- a/pkg/services/eventstore/otel/factory.go
+++ b/pkg/services/eventstore/otel/factory.go
@@ -52,10 +52,11 @@ type Factory struct {
 	environment string
 }
 
+var mustacheRegex = regexp.MustCompile(`\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}`)
+
 func expandEnvVarsInBraces(s string) string {
-	re := regexp.MustCompile(`\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}`)
-	return re.ReplaceAllStringFunc(s, func(str string) string {
-		matches := re.FindStringSubmatch(str)
+	return mustacheRegex.ReplaceAllStringFunc(s, func(str string) string {
+		matches := mustacheRegex.FindStringSubmatch(str)
 		if len(matches) == 2 {
 			key := matches[1]
 			if val, ok := os.LookupEnv(key); ok {

--- a/pkg/services/eventstore/otel/factory_test.go
+++ b/pkg/services/eventstore/otel/factory_test.go
@@ -304,3 +304,33 @@ func TestFactory_ProtocolDefaults(t *testing.T) {
 		})
 	}
 }
+
+func TestExpandEnvVarsInBraces(t *testing.T) {
+	t.Setenv("FOO", "bar")
+	t.Setenv("BAZ", "qux")
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"no vars", "hello world", "hello world"},
+		{"single var", "foo={{FOO}}", "foo=bar"},
+		{"single var with spaces", "foo={{ FOO }}", "foo=bar"},
+		{"var with spaces", "foo={{   FOO   }}", "foo=bar"},
+		{"multiple vars", "a={{FOO}},b={{BAZ}}", "a=bar,b=qux"},
+		{"unknown var", "foo={{UNKNOWN}}", "foo={{UNKNOWN}}"},
+		{"mixed known/unknown", "foo={{FOO}},x={{UNKNOWN}}", "foo=bar,x={{UNKNOWN}}"},
+		{"nested braces", "foo={{{FOO}}}", "foo={bar}"},
+		{"empty", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := expandEnvVarsInBraces(tt.in)
+			if got != tt.want {
+				t.Errorf("expandEnvVarsInBraces(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implemented `expandEnvVarsInBraces` function to support mustache-style syntax for environment variables in endpoint strings.

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Contributing Guide: https://github.com/qpoint-io/qtap/docs/CONTRIBUTING.md
     - 📖 Read the Contributor License Agreement (CLA): https://github.com/qpoint-io/qtap/docs/CLA.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Qpoint Team member.
-->
