### PR TITLE
add `/qtap` to default list of process filters

### DIFF
--- a/pkg/process/filter_groups.go
+++ b/pkg/process/filter_groups.go
@@ -58,5 +58,6 @@ var predefinedFilters = map[string][]Filter{
 	"qpoint": {
 		// Filter out the current qtap process
 		&PIDFilter{PID: os.Getpid(), bitmask: config.SkipAllFlag},
+		&ExeFilter{pattern: "/qtap", strategy: config.MatchStrategy_SUFFIX, bitmask: config.SkipAllFlag},
 	},
 }


### PR DESCRIPTION
The `os.Getpid()` approach doesn't seem to be working consistently so I'm re-adding the process name based filter to the qpoint group.