### PR TITLE
add detected probes to process struct

### DIFF
--- a/pkg/connection/auditlog.go
+++ b/pkg/connection/auditlog.go
@@ -96,6 +96,12 @@ func toEventStoreConnection(conn *Connection) *eventstore.Connection {
 		c.TLSVersion = conn.TLSClientHello.Version
 	}
 
+	// For TLS connections that have data events we can resolve
+	// that the connection was introspected by one of the probes
+	if conn.IsTLS && conn.dataEventCount > 0 {
+		c.TLSIntrospected = true
+	}
+
 	if conn.OpenEvent != nil {
 		c.SocketProtocol = toEventStoreSocketType(conn.OpenEvent.SocketType)
 		localEndpoint := &eventstore.ConnectionEndpointLocal{

--- a/pkg/connection/auditlog.go
+++ b/pkg/connection/auditlog.go
@@ -114,6 +114,9 @@ func toEventStoreConnection(conn *Connection) *eventstore.Connection {
 				pod, _ := proc.Pod() // pod can be nil
 				localEndpoint.Container = toEventStoreContainer(container, pod)
 			}
+			if tlsProbes := proc.TLSProbeTypesDetected; tlsProbes == nil || len(tlsProbes) > 0 {
+				c.TLSProbeTypesDetected = tlsProbes
+			}
 		}
 
 		remoteEndpoint := &eventstore.ConnectionEndpointRemote{

--- a/pkg/ebpf/tls/openssl/container.go
+++ b/pkg/ebpf/tls/openssl/container.go
@@ -31,6 +31,9 @@ type Container struct {
 	// initialized
 	initialized bool
 
+	// hasOpenSSL indicates if this container has OpenSSL libraries
+	hasOpenSSL bool
+
 	// mutex
 	mu sync.Mutex
 }
@@ -76,11 +79,17 @@ func (c *Container) Init(p *process.Process) error {
 		// add the target to the container
 		c.targets[lib] = target
 
+		// mark that this container has OpenSSL
+		c.hasOpenSSL = true
+
 		// debug
 		c.logger.Info("detected OpenSSL shared library",
 			zap.String("path", name),
 			zap.String("container_id", p.ContainerID),
 		)
+
+		// register that the process has been detected to contain openssl probe endpoints
+		p.AddDetectedTLSProbeType("openssl")
 	}
 
 	// set initialized
@@ -100,6 +109,12 @@ func (c *Container) RemoveProcess(pid int) {
 
 func (c *Container) IsEmpty() bool {
 	return c.pids.Len() == 0
+}
+
+func (c *Container) HasOpenSSL() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.hasOpenSSL
 }
 
 func (c *Container) Cleanup() error {

--- a/pkg/ebpf/tls/openssl/manager.go
+++ b/pkg/ebpf/tls/openssl/manager.go
@@ -148,6 +148,11 @@ func (m *OpenSSLManager) ProcessStarted(p *process.Process) error {
 	// increment the container process count
 	container.AddProcess(p.Pid)
 
+	// if the container has OpenSSL libraries, add as detected
+	if container.HasOpenSSL() {
+		p.AddDetectedTLSProbeType("openssl")
+	}
+
 	// determine if this process has statically linked libssl
 	staticOpenSSL := false
 	var err error
@@ -219,6 +224,9 @@ func (m *OpenSSLManager) ProcessStarted(p *process.Process) error {
 
 		// set the target version
 		m.targetVersions.Store(p.Pid, cacheKey)
+
+		// register that the process has been detected to contain openssl probe endpoints
+		p.AddDetectedTLSProbeType("openssl")
 
 		// debug
 		m.logger.Info("OpenSSL static symbols detected",

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -67,6 +67,9 @@ type Process struct {
 	PredatesQpoint bool
 	User           resolvable.V[*ProcessUser]
 
+	// TLSProbeTypesDetected are the the probes that have scanned the process binary and found matching hooks.
+	TLSProbeTypesDetected []string
+
 	Container resolvable.V[*Container]
 	Pod       resolvable.V[*Pod]
 
@@ -556,4 +559,12 @@ func (p *Process) IsFiltered(flag ...config.FilterLevel) bool {
 	}
 
 	return false
+}
+
+func (p *Process) AddDetectedTLSProbeType(t string) {
+	if p.TLSProbeTypesDetected == nil {
+		p.TLSProbeTypesDetected = make([]string, 0, 1)
+	}
+
+	p.TLSProbeTypesDetected = append(p.TLSProbeTypesDetected, t)
 }

--- a/pkg/services/eventstore/eventstore.go
+++ b/pkg/services/eventstore/eventstore.go
@@ -41,9 +41,10 @@ func (b *BaseEventStore) SetRegistry(registry services.RegistryAccessor) {
 }
 
 type meta struct {
-	ConnectionID string `json:"connectionId,omitzero"`
-	EndpointId   string `json:"endpointId,omitzero"`
-	RequestId    string `json:"requestId,omitzero"`
+	ConnectionID          string   `json:"connectionId,omitzero"`
+	EndpointId            string   `json:"endpointId,omitzero"`
+	RequestId             string   `json:"requestId,omitzero"`
+	TLSProbeTypesDetected []string `json:"tlsProbeTypesDetected,omitempty"`
 }
 
 func (m *meta) Fields() []zap.Field {

--- a/pkg/services/eventstore/eventstore.go
+++ b/pkg/services/eventstore/eventstore.go
@@ -44,7 +44,8 @@ type meta struct {
 	ConnectionID          string   `json:"connectionId,omitzero"`
 	EndpointId            string   `json:"endpointId,omitzero"`
 	RequestId             string   `json:"requestId,omitzero"`
-	TLSProbeTypesDetected []string `json:"tlsProbeTypesDetected,omitempty"`
+	TLSProbeTypesDetected []string `json:"tlsProbeTypesDetected,omitzero"`
+	TLSIntrospected       bool     `json:"tlsProbeIntrospected,omitzero"`
 }
 
 func (m *meta) Fields() []zap.Field {


### PR DESCRIPTION
This PR enhances the audit log with TLS probes that detected matches within the process binary. In addition, if a connection is recognized as using TLS and we receive and parse data events we set the tls introspected flag to indicate that we saw the traffic.

> These are separate because the process bin scanning and the connection introspection happen asynchronously and at different times. Detecting that a binary can be hooked and monitored does not necessarily mean the full introspection was successful. 