### PR TITLE
Moves ReadResponse/Request log to debug level

### DIFF
--- a/pkg/stream/protocols/http1/parser.go
+++ b/pkg/stream/protocols/http1/parser.go
@@ -16,6 +16,10 @@ import (
 	"go.uber.org/zap"
 )
 
+var (
+	ErrMalformedRequest = errors.New("malformed HTTP request")
+)
+
 var tracer = telemetry.Tracer()
 
 // HeaderHandler is a callback function type for handling parsed HTTP messages
@@ -105,8 +109,10 @@ func (sp *StreamParser[T]) parse() error {
 		if errors.Is(err, io.ErrUnexpectedEOF) {
 			sp.logger.Warn("connection closed before complete payload transfer or stream blocked due to unread data", zap.Error(err))
 		} else {
-			sp.logger.Error("error parsing message", zap.Error(err))
+			sp.logger.Debug("malformed HTTP message", zap.Error(err))
+			return ErrMalformedRequest
 		}
+
 		return err
 	}
 


### PR DESCRIPTION
Go http.ReadResponse/Request will attach the entire byte slice when it fails to read. Updating to a typed error without the body and only logging the payload in debug level.

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Contributing Guide: https://github.com/qpoint-io/qtap/docs/CONTRIBUTING.md
     - 📖 Read the Contributor License Agreement (CLA): https://github.com/qpoint-io/qtap/docs/CLA.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Qpoint Team member.
-->
