### PR TITLE
forked procs do not get their exes updated

### DIFF
--- a/bpf/tap/common.bpf.h
+++ b/bpf/tap/common.bpf.h
@@ -82,3 +82,13 @@ static inline __u64 _strlen(const char *s, __u64 max) {
 		len++;
 	return len;
 }
+
+static __always_inline __u32 bpf_get_current_pid() {
+	// Lower 32 bits = PID (thread ID in userspace)
+	return (__u32)bpf_get_current_pid_tgid();
+}
+
+static __always_inline __u32 bpf_get_current_tgid() {
+	// Upper 32 bits = TGID (process ID in userspace)
+	return bpf_get_current_pid_tgid() >> 32;
+}

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -149,20 +149,17 @@ func AllProcesses() ([]*Process, error) {
 
 func (p *Process) Discover(mountPoint string, envMask *synq.Map[string, bool]) error {
 	// extract the executable
-	if p.Exe == "" {
-		exe, err := Executable(p.Pid)
-		if err != nil {
-			return fmt.Errorf("extracting executable: %w", err)
-		}
-		p.Exe = exe
+	exe, err := Executable(p.Pid)
+	if err != nil {
+		return fmt.Errorf("extracting executable: %w", err)
 	}
+	p.Exe = exe
 
 	// apply process filters
 	p.filter = applyFilters(p)
 
-	if p.Binary == "" {
-		p.Binary = filepath.Base(p.Exe)
-	}
+	// set binary
+	p.Binary = filepath.Base(p.Exe)
 
 	// set the root path
 	if p.Root == "" {


### PR DESCRIPTION
If a fork occurs, for example:

/usr/bin/env node <script.js>

we were not updating the exe causing the rescan to scan the old binary.

> Note: the ebpf helper func additions are a drive by.

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Contributing Guide: https://github.com/qpoint-io/qtap/docs/CONTRIBUTING.md
     - 📖 Read the Contributor License Agreement (CLA): https://github.com/qpoint-io/qtap/docs/CLA.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Qpoint Team member.
-->
