### PR TITLE
Implement support for interim HTTP responses in parser and session management

### DIFF
--- a/pkg/stream/protocols/http1/parser.go
+++ b/pkg/stream/protocols/http1/parser.go
@@ -93,15 +93,8 @@ func (sp *StreamParser[T]) parse() error {
 		}
 		msg = req
 	case *http.Response:
-		var resp *http.Response
-		resp, err = http.ReadResponse(reader, nil)
-		if err == nil {
-			defer resp.Body.Close() // Close immediately after successful read
-		}
-		if resp != nil {
-			contentLength = resp.ContentLength
-		}
-		msg = resp
+		// For responses, we need to handle multiple responses (interim + final)
+		msg, contentLength, err = sp.parseResponseChain(reader)
 	default:
 		err = fmt.Errorf("unsupported type: %T", *(new(T)))
 	}
@@ -217,6 +210,58 @@ func (sp *StreamParser[T]) handleBody(body io.Reader, encoding []string, handler
 
 func (sp *StreamParser[T]) Write(data []byte) (int, error) {
 	return sp.reader.Write(data)
+}
+
+// parseResponseChain handles parsing multiple responses (interim + final)
+func (sp *StreamParser[T]) parseResponseChain(reader *bufio.Reader) (any, int64, error) {
+	var finalResponse *http.Response
+	var contentLength int64
+
+	// Keep reading responses until we get a non-1xx response
+	for {
+		resp, err := http.ReadResponse(reader, nil)
+		if err != nil {
+			return nil, 0, err
+		}
+
+		sp.logger.Debug("parsed response", zap.Int("status", resp.StatusCode))
+
+		// If this is an interim response (1xx), handle it and continue
+		if resp.StatusCode >= 100 && resp.StatusCode < 200 {
+			sp.logger.Debug("detected interim response", zap.Int("status", resp.StatusCode))
+
+			// Close the response body for interim responses (they shouldn't have bodies)
+			if resp.Body != nil {
+				resp.Body.Close()
+			}
+
+			// Call the header handler for interim response
+			if sp.headerHandler != nil {
+				sp.headerHandler(any(resp).(T), true) // interim responses have no body
+			}
+
+			// For protocol switching (101), this is the final response
+			if resp.StatusCode == http.StatusSwitchingProtocols {
+				finalResponse = resp
+				contentLength = resp.ContentLength
+				break
+			}
+
+			// For other interim responses (like 100 Continue), continue parsing for final response
+			sp.logger.Debug("continuing to parse for final response after interim", zap.Int("interim_status", resp.StatusCode))
+			continue
+		}
+
+		// This is a final response (non-1xx)
+		// Don't close the body here - let the main parse() method handle it
+		finalResponse = resp
+		if finalResponse != nil {
+			contentLength = finalResponse.ContentLength
+		}
+		break
+	}
+
+	return finalResponse, contentLength, nil
 }
 
 func (sp *StreamParser[T]) Close() error {

--- a/pkg/stream/protocols/http1/parser_test.go
+++ b/pkg/stream/protocols/http1/parser_test.go
@@ -12,6 +12,83 @@ import (
 	"go.uber.org/zap"
 )
 
+func TestStreamParser_InterimResponses(t *testing.T) {
+	t.Run("100 Continue response", func(t *testing.T) {
+		input := "HTTP/1.1 100 Continue\r\n" +
+			"\r\n" +
+			"HTTP/1.1 200 OK\r\n" +
+			"Content-Type: text/plain\r\n" +
+			"Content-Length: 5\r\n" +
+			"\r\n" +
+			"hello"
+
+		var gotResponses []*http.Response
+		var gotBodies [][]byte
+
+		headerHandler := func(msg *http.Response, noBody bool) {
+			gotResponses = append(gotResponses, msg)
+		}
+
+		bodyHandler := func(chunk []byte, done bool) {
+			if chunk != nil {
+				gotBodies = append(gotBodies, chunk)
+			}
+		}
+
+		ctx := context.Background()
+		logger := zap.NewNop()
+		parser := NewStreamParser(ctx, logger, headerHandler, bodyHandler)
+
+		_, err := parser.Write([]byte(input))
+		require.NoError(t, err)
+
+		err = parser.parse()
+		require.NoError(t, err)
+
+		// Should have both interim and final responses
+		require.Len(t, gotResponses, 2)
+
+		// First response should be 100 Continue
+		require.Equal(t, 100, gotResponses[0].StatusCode)
+		require.Equal(t, "100 Continue", gotResponses[0].Status)
+
+		// Second response should be 200 OK
+		require.Equal(t, 200, gotResponses[1].StatusCode)
+		require.Equal(t, "200 OK", gotResponses[1].Status)
+
+		// Should have body data from final response
+		require.Len(t, gotBodies, 1)
+		require.Equal(t, "hello", string(gotBodies[0]))
+	})
+
+	t.Run("101 Switching Protocols", func(t *testing.T) {
+		input := "HTTP/1.1 101 Switching Protocols\r\n" +
+			"Upgrade: websocket\r\n" +
+			"Connection: Upgrade\r\n" +
+			"\r\n"
+
+		var gotResponse *http.Response
+
+		headerHandler := func(msg *http.Response, noBody bool) {
+			gotResponse = msg
+		}
+
+		ctx := context.Background()
+		logger := zap.NewNop()
+		parser := NewStreamParser(ctx, logger, headerHandler, nil)
+
+		_, err := parser.Write([]byte(input))
+		require.NoError(t, err)
+
+		err = parser.parse()
+		require.NoError(t, err)
+
+		require.NotNil(t, gotResponse)
+		require.Equal(t, 101, gotResponse.StatusCode)
+		require.Equal(t, "websocket", gotResponse.Header.Get("Upgrade"))
+	})
+}
+
 func TestStreamParser_ProcessBytes(t *testing.T) {
 	t.Run("http requests", func(t *testing.T) {
 		tests := []struct {
@@ -81,6 +158,27 @@ Connection: close
 						"User-Agent": []string{"kube-probe/1.30"},
 						"Accept":     []string{"*/*"},
 						"Connection": []string{"close"},
+					},
+				},
+			},
+			{
+				name: "PUT request with Expect: 100-continue",
+				input: "PUT /upload HTTP/1.1\r\n" +
+					"Host: example.com\r\n" +
+					"Content-Length: 1024\r\n" +
+					"Expect: 100-continue\r\n" +
+					"\r\n",
+				wantReq: &http.Request{
+					Method: http.MethodPut,
+					URL: &url.URL{
+						Path: "/upload",
+					},
+					Proto:      "HTTP/1.1",
+					ProtoMajor: 1,
+					ProtoMinor: 1,
+					Header: http.Header{
+						"Content-Length": []string{"1024"},
+						"Expect":         []string{"100-continue"},
 					},
 				},
 			},

--- a/pkg/stream/protocols/http1/session.go
+++ b/pkg/stream/protocols/http1/session.go
@@ -2,8 +2,10 @@ package http1
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/qpoint-io/qtap/pkg/connection"
 	"github.com/qpoint-io/qtap/pkg/plugins"
@@ -19,10 +21,34 @@ type SessionState int
 const (
 	SessionStateRequestHeaders SessionState = iota
 	SessionStateRequestBody
+	SessionStateAwaitingInterim // Waiting for 100-Continue or other interim response
+	SessionStateInterimResponse // Processing 1xx response
 	SessionStateResponseHeaders
 	SessionStateResponseBody
+	SessionStateProtocolSwitch // Handling 101 Switching Protocols
 	SessionStateDone
 )
+
+// InterimResponse represents a 1xx informational response
+type InterimResponse struct {
+	StatusCode int
+	Status     string
+	Header     http.Header
+	Timestamp  time.Time
+}
+
+// UpgradeInfo contains information about protocol upgrades
+type UpgradeInfo struct {
+	Protocol string // "websocket", "h2c", etc.
+	Headers  http.Header
+}
+
+// ResponseChain tracks all responses for a single request
+type ResponseChain struct {
+	InterimResponses []*InterimResponse // All 1xx responses
+	FinalResponse    *http.Response     // The final non-1xx response
+	ProtocolUpgrade  *UpgradeInfo       // Protocol switch info (if any)
+}
 
 type Session struct {
 	mu sync.RWMutex
@@ -46,6 +72,13 @@ type Session struct {
 	// request/response
 	req *http.Request
 	res *http.Response
+
+	// response chain for handling interim responses
+	responseChain *ResponseChain
+
+	// flags for special handling
+	expectContinue   bool // true if request has Expect: 100-Continue
+	protocolUpgraded bool // true if protocol was upgraded (101 response)
 
 	// parsers
 	requestParser  *StreamParser[*http.Request]
@@ -85,6 +118,9 @@ func NewSession(ctx context.Context, logger *zap.Logger, domain string, conn *co
 		domain:        domain,
 		conn:          conn,
 		pluginManager: pluginManager,
+		responseChain: &ResponseChain{
+			InterimResponses: make([]*InterimResponse, 0),
+		},
 	}
 
 	// create the request parser
@@ -101,14 +137,31 @@ func NewSession(ctx context.Context, logger *zap.Logger, domain string, conn *co
 }
 
 func (s *Session) Run() {
-	err := s.requestParser.parse()
-	if err != nil {
-		s.logger.Error("error parsing request", zap.Error(err))
-	}
-	err = s.responseParser.parse()
-	if err != nil {
-		s.logger.Error("error parsing response", zap.Error(err))
-	}
+	// Run request and response parsers concurrently
+	// This allows for bidirectional communication like expect-continue
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Parse request
+	go func() {
+		defer wg.Done()
+		err := s.requestParser.parse()
+		if err != nil {
+			s.logger.Error("error parsing request", zap.Error(err))
+		}
+	}()
+
+	// Parse response
+	go func() {
+		defer wg.Done()
+		err := s.responseParser.parse()
+		if err != nil {
+			s.logger.Error("error parsing response", zap.Error(err))
+		}
+	}()
+
+	// Wait for both parsers to complete
+	wg.Wait()
 	s.Close()
 }
 
@@ -127,6 +180,8 @@ func (s *Session) CreateRequest(req *http.Request, noBody bool) {
 		return
 	}
 
+	s.logger.Debug("creating request", zap.String("method", s.req.Method), zap.String("url", s.req.URL.String()))
+
 	// set the Qpoint request ID
 	s.req.Header.Set("qpoint-request-id", s.id)
 
@@ -142,10 +197,19 @@ func (s *Session) CreateRequest(req *http.Request, noBody bool) {
 		s.conn.SetDomain(s.req.Host)
 	}
 
-	// set the state
-	if noBody {
+	// check for Expect: 100-Continue header
+	if s.req.Header.Get("Expect") == "100-continue" {
+		s.expectContinue = true
+		s.logger.Debug("detected Expect: 100-Continue header")
+	}
+
+	// set the state based on body and expect-continue
+	switch {
+	case noBody:
 		s.State = SessionStateResponseHeaders
-	} else {
+	case s.expectContinue:
+		s.State = SessionStateAwaitingInterim
+	default:
 		s.State = SessionStateRequestBody
 	}
 
@@ -172,18 +236,43 @@ func (s *Session) CreateRequest(req *http.Request, noBody bool) {
 func (s *Session) CreateResponse(res *http.Response, noBody bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.logger.Debug("creating response", zap.Int("status", res.StatusCode), zap.String("status", res.Status))
-
-	s.res = res
 
 	// if we don't have a response, create a 499 canceled response
 	// this typically happens when the connection is closed before the response is fully received
-	if s.res == nil {
-		s.res = &http.Response{
+	if res == nil {
+		res = &http.Response{
 			StatusCode: 499,
 			Status:     "Canceled",
 		}
 	}
+
+	s.logger.Debug("creating response", zap.Int("status", res.StatusCode), zap.String("status", res.Status))
+
+	// Handle interim responses (1xx) differently
+	if res.StatusCode >= 100 && res.StatusCode < 200 {
+		s.logger.Debug("detected interim response in CreateResponse", zap.Int("status", res.StatusCode))
+		// This is an interim response, handle it separately
+		if err := s.HandleInterimResponse(res); err != nil {
+			s.logger.Error("error handling interim response", zap.Error(err))
+		} else {
+			s.logger.Debug("successfully handled interim response", zap.Int("status", res.StatusCode))
+		}
+
+		// For protocol switches (101), this is the final response
+		if res.StatusCode == http.StatusSwitchingProtocols {
+			s.responseChain.FinalResponse = res
+			s.res = res
+			s.State = SessionStateProtocolSwitch
+		}
+
+		// For other interim responses, don't set as final response yet
+		s.logger.Debug("returning early after interim response", zap.Int("status", res.StatusCode))
+		return
+	}
+
+	// This is a final response (non-1xx)
+	s.res = res
+	s.responseChain.FinalResponse = res
 
 	// set the state
 	if noBody {
@@ -203,11 +292,95 @@ func (s *Session) CreateResponse(res *http.Response, noBody bool) {
 	}
 }
 
+// HandleInterimResponse processes 1xx informational responses
+func (s *Session) HandleInterimResponse(res *http.Response) error {
+	s.logger.Debug("HandleInterimResponse called", zap.Int("status", res.StatusCode))
+
+	// Note: Do not lock here as this is called from CreateResponse which already holds the lock
+
+	if res.StatusCode < 100 || res.StatusCode >= 200 {
+		s.logger.Error("invalid interim response status code", zap.Int("status", res.StatusCode))
+		return fmt.Errorf("not an interim response: %d", res.StatusCode)
+	}
+
+	s.logger.Debug("handling interim response", zap.Int("status", res.StatusCode), zap.String("status_text", res.Status), zap.String("current_state", s.StateString()))
+
+	// Create interim response record
+	interim := &InterimResponse{
+		StatusCode: res.StatusCode,
+		Status:     res.Status,
+		Header:     res.Header.Clone(),
+		Timestamp:  time.Now(),
+	}
+
+	// Add to response chain
+	s.responseChain.InterimResponses = append(s.responseChain.InterimResponses, interim)
+
+	// Handle specific interim response types
+	switch res.StatusCode {
+	case http.StatusContinue: // Continue
+		if s.expectContinue {
+			s.logger.Debug("received 100 Continue, ready for request body")
+			s.State = SessionStateRequestBody
+		} else {
+			s.logger.Warn("received unexpected 100 Continue response")
+		}
+
+	case http.StatusSwitchingProtocols: // Switching Protocols
+		s.logger.Debug("received 101 Switching Protocols")
+		s.protocolUpgraded = true
+		s.State = SessionStateProtocolSwitch
+
+		// Extract upgrade information
+		if upgrade := res.Header.Get("Upgrade"); upgrade != "" {
+			s.responseChain.ProtocolUpgrade = &UpgradeInfo{
+				Protocol: upgrade,
+				Headers:  res.Header.Clone(),
+			}
+		}
+
+	case http.StatusProcessing: // Processing (WebDAV)
+		s.logger.Debug("received 102 Processing")
+		// Stay in current state, continue waiting
+
+	case http.StatusEarlyHints: // Early Hints
+		s.logger.Debug("received 103 Early Hints")
+		// Stay in current state, continue waiting
+
+	default:
+		s.logger.Debug("received unknown 1xx response", zap.Int("status", res.StatusCode))
+	}
+
+	// Call plugin for interim response
+	if s.pluginConn != nil {
+		if err := s.pluginConn.OnHttpResponseHeaders(false); err != nil {
+			s.logger.Error("plugin interim response headers", zap.Error(err))
+		}
+	}
+
+	return nil
+}
+
 func (s *Session) WriteRequestBody(data []byte, done bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.logger.Debug("writing request body", zap.Int("length", len(data)))
+	s.logger.Debug("writing request body", zap.Int("length", len(data)), zap.Bool("done", done), zap.String("state", s.StateString()))
 
+	// If we're awaiting an interim response and haven't received 100 Continue yet,
+	// this shouldn't normally happen since clients wait for 100-Continue before sending body
+	if s.State == SessionStateAwaitingInterim && s.expectContinue {
+		s.logger.Warn("received request body while still awaiting 100-Continue - protocol violation or timing issue",
+			zap.Int("length", len(data)), zap.Bool("done", done))
+		// Just ignore the data - the client should resend after 100-Continue
+		return
+	}
+
+	// Process the body data normally
+	s.processRequestBody(data, done)
+}
+
+// processRequestBody handles the actual request body processing and plugin callbacks
+func (s *Session) processRequestBody(data []byte, done bool) {
 	if s.pluginConn != nil {
 		// call the request body callback
 		if err := s.pluginConn.OnHttpRequestBody(data, done); err != nil {
@@ -220,7 +393,8 @@ func (s *Session) WriteRequestBody(data []byte, done bool) {
 		return
 	}
 
-	// set the state
+	// set the state based on current state - always transition to expecting response
+	s.logger.Debug("request body complete, transitioning to response headers state")
 	s.State = SessionStateResponseHeaders
 }
 
@@ -314,7 +488,35 @@ func (s *Session) IsClosed() bool {
 }
 
 func (s *Session) IsParsingResponse() bool {
-	return s.State == SessionStateResponseHeaders || s.State == SessionStateResponseBody
+	return s.State == SessionStateResponseHeaders || s.State == SessionStateResponseBody ||
+		s.State == SessionStateAwaitingInterim || s.State == SessionStateInterimResponse
+}
+
+// CanAcceptRequestBody returns true if the session can accept request body data
+func (s *Session) CanAcceptRequestBody() bool {
+	return s.State == SessionStateRequestBody ||
+		(s.State == SessionStateAwaitingInterim && s.expectContinue)
+}
+
+// IsProtocolUpgraded returns true if the connection has switched protocols
+func (s *Session) IsProtocolUpgraded() bool {
+	return s.protocolUpgraded
+}
+
+// GetUpgradeInfo returns information about the protocol upgrade, if any
+func (s *Session) GetUpgradeInfo() *UpgradeInfo {
+	if s.responseChain != nil {
+		return s.responseChain.ProtocolUpgrade
+	}
+	return nil
+}
+
+// GetInterimResponses returns all interim responses received
+func (s *Session) GetInterimResponses() []*InterimResponse {
+	if s.responseChain != nil {
+		return s.responseChain.InterimResponses
+	}
+	return nil
 }
 
 func (s *Session) StateString() string {
@@ -323,10 +525,16 @@ func (s *Session) StateString() string {
 		return "request_headers"
 	case SessionStateRequestBody:
 		return "request_body"
+	case SessionStateAwaitingInterim:
+		return "awaiting_interim"
+	case SessionStateInterimResponse:
+		return "interim_response"
 	case SessionStateResponseHeaders:
 		return "response_headers"
 	case SessionStateResponseBody:
 		return "response_body"
+	case SessionStateProtocolSwitch:
+		return "protocol_switch"
 	case SessionStateDone:
 		return "done"
 	default:

--- a/pkg/stream/protocols/http1/session_test.go
+++ b/pkg/stream/protocols/http1/session_test.go
@@ -1,0 +1,793 @@
+package http1
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/qpoint-io/qtap/pkg/connection"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestSession_HandleInterimResponse(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop()
+
+	// Create session
+	session := NewSession(ctx, logger, "example.com", &connection.Connection{}, nil)
+	defer session.Close()
+
+	// Handle 100 Continue response
+	continueResp := &http.Response{
+		StatusCode: http.StatusContinue,
+		Status:     "100 Continue",
+		Header:     http.Header{},
+	}
+
+	err := session.HandleInterimResponse(continueResp)
+	require.NoError(t, err)
+
+	// Verify interim response was recorded
+	require.Len(t, session.responseChain.InterimResponses, 1)
+	require.Equal(t, 100, session.responseChain.InterimResponses[0].StatusCode)
+}
+
+// TestSession_SimpleGETRequest tests a basic GET request with no body
+func TestSession_SimpleGETRequest(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop()
+
+	conn := &connection.Connection{
+		IsTLS: false,
+	}
+
+	session := NewSession(ctx, logger, "example.com", conn, nil)
+	defer session.Close()
+
+	// Create a simple GET request
+	req := &http.Request{
+		Method: http.MethodGet,
+		URL:    &url.URL{Path: "/api/test"},
+		Header: http.Header{
+			"Host":       []string{"example.com"},
+			"User-Agent": []string{"test-client/1.0"},
+		},
+	}
+
+	// Process the request
+	session.CreateRequest(req, true) // no body
+
+	// Verify request state
+	require.Equal(t, SessionStateResponseHeaders, session.State)
+	require.Equal(t, "http", session.req.URL.Scheme)
+	require.Equal(t, session.id, session.req.Header.Get("qpoint-request-id"))
+
+	// Create a 200 OK response
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Status:     "200 OK",
+		Header: http.Header{
+			"Content-Type": []string{"application/json"},
+		},
+	}
+
+	session.CreateResponse(resp, true) // no body
+
+	// Verify response state
+	require.Equal(t, SessionStateDone, session.State)
+	require.Equal(t, http.StatusOK, session.res.StatusCode)
+}
+
+// TestSession_POSTWithBody tests a POST request with body data
+func TestSession_POSTWithBody(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop()
+
+	conn := &connection.Connection{
+		IsTLS: true,
+	}
+
+	session := NewSession(ctx, logger, "api.example.com", conn, nil)
+	defer session.Close()
+
+	// Create POST request
+	req := &http.Request{
+		Method: http.MethodPost,
+		URL:    &url.URL{Path: "/submit"},
+		Header: http.Header{
+			"Content-Type":   []string{"application/json"},
+			"Content-Length": []string{"25"},
+		},
+	}
+
+	session.CreateRequest(req, false) // has body
+
+	// Verify initial state
+	require.Equal(t, SessionStateRequestBody, session.State)
+	require.Equal(t, "https", session.req.URL.Scheme)
+
+	// Send request body
+	bodyData := `{"message": "hello"}`
+	session.WriteRequestBody([]byte(bodyData), true)
+
+	// Verify state after body
+	require.Equal(t, SessionStateResponseHeaders, session.State)
+
+	// Create response
+	resp := &http.Response{
+		StatusCode: http.StatusCreated,
+		Status:     "201 Created",
+		Header: http.Header{
+			"Content-Type": []string{"application/json"},
+		},
+	}
+
+	session.CreateResponse(resp, false) // has body
+
+	// Verify response state
+	require.Equal(t, SessionStateResponseBody, session.State)
+
+	// Send response body
+	session.WriteResponseBody([]byte(`{"id": 123}`), true)
+
+	// Verify final state
+	require.Equal(t, SessionStateDone, session.State)
+}
+
+// TestSession_ExpectContinue_Success tests successful Expect: 100-Continue flow
+func TestSession_ExpectContinue_Success(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop()
+
+	conn := &connection.Connection{
+		IsTLS: true,
+	}
+
+	session := NewSession(ctx, logger, "upload.example.com", conn, nil)
+	defer session.Close()
+
+	// Create PUT request with Expect: 100-Continue
+	req := &http.Request{
+		Method: http.MethodPut,
+		URL:    &url.URL{Path: "/upload/file.txt"},
+		Header: http.Header{
+			"Content-Length": []string{"1024"},
+			"Content-Type":   []string{"text/plain"},
+			"Expect":         []string{"100-continue"},
+		},
+	}
+
+	session.CreateRequest(req, false)
+
+	// Verify expect continue was detected
+	require.True(t, session.expectContinue)
+	require.Equal(t, SessionStateAwaitingInterim, session.State)
+
+	// Handle 100 Continue response
+	continueResp := &http.Response{
+		StatusCode: http.StatusContinue,
+		Status:     "100 Continue",
+		Header:     http.Header{},
+	}
+
+	err := session.HandleInterimResponse(continueResp)
+	require.NoError(t, err)
+
+	// Verify state transition to request body
+	require.Equal(t, SessionStateRequestBody, session.State)
+
+	// Verify interim response was recorded
+	require.Len(t, session.responseChain.InterimResponses, 1)
+	require.Equal(t, 100, session.responseChain.InterimResponses[0].StatusCode)
+
+	// Send request body after 100 Continue
+	session.WriteRequestBody([]byte("file content here"), true)
+
+	// Verify state after body
+	require.Equal(t, SessionStateResponseHeaders, session.State)
+
+	// Send final response
+	finalResp := &http.Response{
+		StatusCode: http.StatusOK,
+		Status:     "200 OK",
+		Header: http.Header{
+			"Content-Type": []string{"application/json"},
+		},
+	}
+
+	session.CreateResponse(finalResp, true)
+
+	// Verify final state
+	require.Equal(t, SessionStateDone, session.State)
+	require.Equal(t, finalResp, session.responseChain.FinalResponse)
+}
+
+// TestSession_ExpectContinue_Rejection tests server rejecting Expect: 100-Continue
+func TestSession_ExpectContinue_Rejection(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop()
+
+	conn := &connection.Connection{
+		IsTLS: false,
+	}
+
+	session := NewSession(ctx, logger, "api.example.com", conn, nil)
+	defer session.Close()
+
+	// Create request with Expect: 100-Continue
+	req := &http.Request{
+		Method: http.MethodPost,
+		URL:    &url.URL{Path: "/api/data"},
+		Header: http.Header{
+			"Content-Length": []string{"500"},
+			"Expect":         []string{"100-continue"},
+		},
+	}
+
+	session.CreateRequest(req, false)
+
+	// Verify expect continue state
+	require.True(t, session.expectContinue)
+	require.Equal(t, SessionStateAwaitingInterim, session.State)
+
+	// Server responds with 417 Expectation Failed instead of 100 Continue
+	rejectionResp := &http.Response{
+		StatusCode: http.StatusExpectationFailed,
+		Status:     "417 Expectation Failed",
+		Header: http.Header{
+			"Content-Type": []string{"text/plain"},
+		},
+	}
+
+	session.CreateResponse(rejectionResp, false)
+
+	// Should transition directly to response body (skipping interim)
+	require.Equal(t, SessionStateResponseBody, session.State)
+	require.Equal(t, rejectionResp, session.res)
+
+	// Send error response body
+	session.WriteResponseBody([]byte("Request entity too large"), true)
+
+	// Verify final state
+	require.Equal(t, SessionStateDone, session.State)
+}
+
+// TestSession_MultipleInterimResponses tests handling multiple 1xx responses
+func TestSession_MultipleInterimResponses(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop()
+
+	conn := &connection.Connection{
+		IsTLS: false,
+	}
+
+	session := NewSession(ctx, logger, "processing.example.com", conn, nil)
+	defer session.Close()
+
+	// Create request
+	req := &http.Request{
+		Method: http.MethodPost,
+		URL:    &url.URL{Path: "/long-process"},
+		Header: http.Header{
+			"Content-Length": []string{"100"},
+		},
+	}
+
+	session.CreateRequest(req, false)
+	session.WriteRequestBody([]byte("process this data"), true)
+
+	// Send 102 Processing
+	processingResp := &http.Response{
+		StatusCode: http.StatusProcessing,
+		Status:     "102 Processing",
+		Header:     http.Header{},
+	}
+
+	err := session.HandleInterimResponse(processingResp)
+	require.NoError(t, err)
+
+	// Send 103 Early Hints
+	hintsResp := &http.Response{
+		StatusCode: http.StatusEarlyHints,
+		Status:     "103 Early Hints",
+		Header: http.Header{
+			"Link": []string{"</style.css>; rel=preload; as=style"},
+		},
+	}
+
+	err = session.HandleInterimResponse(hintsResp)
+	require.NoError(t, err)
+
+	// Verify both interim responses recorded
+	require.Len(t, session.responseChain.InterimResponses, 2)
+	require.Equal(t, 102, session.responseChain.InterimResponses[0].StatusCode)
+	require.Equal(t, 103, session.responseChain.InterimResponses[1].StatusCode)
+	require.Equal(t, "</style.css>; rel=preload; as=style", session.responseChain.InterimResponses[1].Header.Get("Link"))
+
+	// Send final response
+	finalResp := &http.Response{
+		StatusCode: http.StatusOK,
+		Status:     "200 OK",
+		Header: http.Header{
+			"Content-Type": []string{"application/json"},
+		},
+	}
+
+	session.CreateResponse(finalResp, true)
+
+	require.Equal(t, SessionStateDone, session.State)
+	require.Equal(t, finalResp, session.responseChain.FinalResponse)
+}
+
+// TestSession_WebSocketUpgrade tests 101 Switching Protocols for WebSocket
+func TestSession_WebSocketUpgrade(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop()
+
+	conn := &connection.Connection{
+		IsTLS: true,
+	}
+
+	session := NewSession(ctx, logger, "ws.example.com", conn, nil)
+	defer session.Close()
+
+	// Create WebSocket upgrade request
+	req := &http.Request{
+		Method: http.MethodGet,
+		URL:    &url.URL{Path: "/ws"},
+		Header: http.Header{
+			"Connection":             []string{"Upgrade"},
+			"Upgrade":                []string{"websocket"},
+			"Sec-Websocket-Key":      []string{"dGhlIHNhbXBsZSBub25jZQ=="},
+			"Sec-Websocket-Version":  []string{"13"},
+			"Sec-Websocket-Protocol": []string{"chat"},
+		},
+	}
+
+	session.CreateRequest(req, true)
+
+	// Send 101 Switching Protocols response
+	upgradeResp := &http.Response{
+		StatusCode: http.StatusSwitchingProtocols,
+		Status:     "101 Switching Protocols",
+		Header: http.Header{
+			"Connection":             []string{"Upgrade"},
+			"Upgrade":                []string{"websocket"},
+			"Sec-Websocket-Accept":   []string{"s3pPLMBiTxaQ9kYGzzhZRbK+xOo="},
+			"Sec-Websocket-Protocol": []string{"chat"},
+		},
+	}
+
+	session.CreateResponse(upgradeResp, true)
+
+	// Verify protocol upgrade
+	require.Equal(t, SessionStateProtocolSwitch, session.State)
+	require.True(t, session.protocolUpgraded)
+	require.True(t, session.IsProtocolUpgraded())
+
+	// Verify upgrade info
+	upgradeInfo := session.GetUpgradeInfo()
+	require.NotNil(t, upgradeInfo)
+	require.Equal(t, "websocket", upgradeInfo.Protocol)
+	// Use direct access since the header was stored with this specific key
+	acceptHeaders := upgradeInfo.Headers["Sec-Websocket-Accept"]
+	require.Len(t, acceptHeaders, 1)
+	require.Equal(t, "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=", acceptHeaders[0])
+
+	// Verify response chain
+	require.Len(t, session.responseChain.InterimResponses, 1)
+	require.Equal(t, upgradeResp, session.responseChain.FinalResponse)
+}
+
+// TestSession_HTTP2Upgrade tests 101 Switching Protocols for HTTP/2
+func TestSession_HTTP2Upgrade(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop()
+
+	conn := &connection.Connection{
+		IsTLS: false,
+	}
+
+	session := NewSession(ctx, logger, "h2.example.com", conn, nil)
+	defer session.Close()
+
+	// Create HTTP/2 upgrade request
+	req := &http.Request{
+		Method: http.MethodGet,
+		URL:    &url.URL{Path: "/"},
+		Header: http.Header{
+			"Connection":     []string{"Upgrade, HTTP2-Settings"},
+			"Upgrade":        []string{"h2c"},
+			"HTTP2-Settings": []string{"AAMAAABkAARAAAAAAAIAAAAA"},
+		},
+	}
+
+	session.CreateRequest(req, true)
+
+	// Send 101 Switching Protocols response
+	upgradeResp := &http.Response{
+		StatusCode: http.StatusSwitchingProtocols,
+		Status:     "101 Switching Protocols",
+		Header: http.Header{
+			"Connection": []string{"Upgrade"},
+			"Upgrade":    []string{"h2c"},
+		},
+	}
+
+	session.CreateResponse(upgradeResp, true)
+
+	// Verify protocol upgrade
+	require.Equal(t, SessionStateProtocolSwitch, session.State)
+	require.True(t, session.IsProtocolUpgraded())
+
+	// Verify upgrade info
+	upgradeInfo := session.GetUpgradeInfo()
+	require.NotNil(t, upgradeInfo)
+	require.Equal(t, "h2c", upgradeInfo.Protocol)
+}
+
+// TestSession_PrematureClose tests connection closed before completion
+func TestSession_PrematureClose(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop()
+
+	conn := &connection.Connection{
+		IsTLS: false,
+	}
+
+	session := NewSession(ctx, logger, "example.com", conn, nil)
+
+	// Create request
+	req := &http.Request{
+		Method: http.MethodPost,
+		URL:    &url.URL{Path: "/api/data"},
+		Header: http.Header{
+			"Content-Length": []string{"100"},
+		},
+	}
+
+	session.CreateRequest(req, false)
+
+	// Verify initial state
+	require.Equal(t, SessionStateRequestBody, session.State)
+
+	// Close session before completing request/response
+	session.Close()
+
+	// Verify session marked as closed
+	require.True(t, session.IsClosed())
+
+	// Verify response was created as 499 Canceled
+	require.NotNil(t, session.res)
+	require.Equal(t, 499, session.res.StatusCode)
+	require.Equal(t, "Canceled", session.res.Status)
+}
+
+// TestSession_499ClientCanceled tests client disconnection scenario
+func TestSession_499ClientCanceled(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop()
+
+	conn := &connection.Connection{
+		IsTLS: false,
+	}
+
+	session := NewSession(ctx, logger, "example.com", conn, nil)
+	defer session.Close()
+
+	// Create request but don't provide response (simulating client disconnect)
+	req := &http.Request{
+		Method: http.MethodGet,
+		URL:    &url.URL{Path: "/slow-endpoint"},
+		Header: http.Header{},
+	}
+
+	session.CreateRequest(req, true)
+
+	// Simulate nil response (connection closed)
+	session.CreateResponse(nil, false)
+
+	// Verify 499 response was created
+	require.NotNil(t, session.res)
+	require.Equal(t, 499, session.res.StatusCode)
+	require.Equal(t, "Canceled", session.res.Status)
+}
+
+// TestSession_HEADRequest tests HEAD request (no response body expected)
+func TestSession_HEADRequest(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop()
+
+	conn := &connection.Connection{
+		IsTLS: false,
+	}
+
+	session := NewSession(ctx, logger, "example.com", conn, nil)
+	defer session.Close()
+
+	// Create HEAD request
+	req := &http.Request{
+		Method: http.MethodHead,
+		URL:    &url.URL{Path: "/resource"},
+		Header: http.Header{
+			"Host": []string{"example.com"},
+		},
+	}
+
+	session.CreateRequest(req, true)
+
+	// Create response with headers but no body
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Status:     "200 OK",
+		Header: http.Header{
+			"Content-Type":   []string{"text/html"},
+			"Content-Length": []string{"1234"}, // HEAD responses can include Content-Length
+		},
+	}
+
+	session.CreateResponse(resp, true) // no body for HEAD
+
+	// Verify response state goes directly to done
+	require.Equal(t, SessionStateDone, session.State)
+	require.Equal(t, "1234", session.res.Header.Get("Content-Length"))
+}
+
+// TestSession_StateTransitions tests all valid state transitions
+func TestSession_StateTransitions(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop()
+
+	conn := &connection.Connection{
+		IsTLS: false,
+	}
+
+	session := NewSession(ctx, logger, "example.com", conn, nil)
+	defer session.Close()
+
+	// Initial state
+	require.Equal(t, SessionStateRequestHeaders, session.State)
+
+	// Create request with body
+	req := &http.Request{
+		Method: http.MethodPost,
+		URL:    &url.URL{Path: "/test"},
+		Header: http.Header{
+			"Content-Length": []string{"10"},
+		},
+	}
+
+	session.CreateRequest(req, false)
+
+	// Should transition to request body
+	require.Equal(t, SessionStateRequestBody, session.State)
+
+	// Send request body
+	session.WriteRequestBody([]byte("test data"), true)
+
+	// Should transition to response headers
+	require.Equal(t, SessionStateResponseHeaders, session.State)
+
+	// Create response with body
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Status:     "200 OK",
+		Header: http.Header{
+			"Content-Type": []string{"text/plain"},
+		},
+	}
+
+	session.CreateResponse(resp, false)
+
+	// Should transition to response body
+	require.Equal(t, SessionStateResponseBody, session.State)
+
+	// Send response body
+	session.WriteResponseBody([]byte("response"), true)
+
+	// Should transition to done
+	require.Equal(t, SessionStateDone, session.State)
+}
+
+// TestSession_RequestBodyWhileAwaitingInterim tests protocol violation handling
+func TestSession_RequestBodyWhileAwaitingInterim(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop()
+
+	conn := &connection.Connection{
+		IsTLS: false,
+	}
+
+	session := NewSession(ctx, logger, "example.com", conn, nil)
+	defer session.Close()
+
+	// Create request with Expect: 100-Continue
+	req := &http.Request{
+		Method: http.MethodPost,
+		URL:    &url.URL{Path: "/upload"},
+		Header: http.Header{
+			"Content-Length": []string{"100"},
+			"Expect":         []string{"100-continue"},
+		},
+	}
+
+	session.CreateRequest(req, false)
+
+	// Verify awaiting interim state
+	require.Equal(t, SessionStateAwaitingInterim, session.State)
+
+	// Try to send body before receiving 100 Continue (protocol violation)
+	session.WriteRequestBody([]byte("premature body data"), false)
+
+	// Should still be in awaiting interim state (data ignored)
+	require.Equal(t, SessionStateAwaitingInterim, session.State)
+
+	// Now send 100 Continue
+	continueResp := &http.Response{
+		StatusCode: http.StatusContinue,
+		Status:     "100 Continue",
+		Header:     http.Header{},
+	}
+
+	err := session.HandleInterimResponse(continueResp)
+	require.NoError(t, err)
+
+	// Now should accept body
+	require.Equal(t, SessionStateRequestBody, session.State)
+
+	session.WriteRequestBody([]byte("proper body data"), true)
+	require.Equal(t, SessionStateResponseHeaders, session.State)
+}
+
+// TestSession_HostHeaderLogic tests host header logic without triggering SetDomain
+func TestSession_HostHeaderLogic(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop()
+
+	conn := &connection.Connection{
+		IsTLS: false,
+	}
+
+	session := NewSession(ctx, logger, "original.com", conn, nil)
+	defer session.Close()
+
+	// Create request with same host as domain (won't trigger SetDomain)
+	req := &http.Request{
+		Method: http.MethodGet,
+		URL:    &url.URL{Path: "/"},
+		Host:   "original.com", // Same as session domain
+		Header: http.Header{},
+	}
+
+	session.CreateRequest(req, true)
+
+	// Verify host header was preserved
+	require.Equal(t, "original.com", req.Host)
+	require.Equal(t, "http", req.URL.Scheme)
+}
+
+// TestSession_GetMethods tests various getter methods
+func TestSession_GetMethods(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop()
+
+	conn := &connection.Connection{
+		IsTLS: false,
+	}
+
+	session := NewSession(ctx, logger, "example.com", conn, nil)
+	defer session.Close()
+
+	// Test initial state
+	require.False(t, session.IsClosed())
+	require.False(t, session.IsParsingResponse())
+	require.False(t, session.IsProtocolUpgraded())
+	require.Nil(t, session.GetUpgradeInfo())
+	require.Empty(t, session.GetInterimResponses())
+
+	// Add some interim responses
+	interim1 := &InterimResponse{
+		StatusCode: 100,
+		Status:     "100 Continue",
+		Header:     http.Header{},
+		Timestamp:  time.Now(),
+	}
+	interim2 := &InterimResponse{
+		StatusCode: 102,
+		Status:     "102 Processing",
+		Header:     http.Header{},
+		Timestamp:  time.Now(),
+	}
+
+	session.responseChain.InterimResponses = append(session.responseChain.InterimResponses, interim1, interim2)
+
+	// Test getter methods
+	interims := session.GetInterimResponses()
+	require.Len(t, interims, 2)
+	require.Equal(t, 100, interims[0].StatusCode)
+	require.Equal(t, 102, interims[1].StatusCode)
+
+	// Test StateString method
+	require.Equal(t, "request_headers", session.StateString())
+
+	session.State = SessionStateRequestBody
+	require.Equal(t, "request_body", session.StateString())
+
+	session.State = SessionStateAwaitingInterim
+	require.Equal(t, "awaiting_interim", session.StateString())
+
+	session.State = SessionStateInterimResponse
+	require.Equal(t, "interim_response", session.StateString())
+
+	session.State = SessionStateResponseHeaders
+	require.Equal(t, "response_headers", session.StateString())
+
+	session.State = SessionStateResponseBody
+	require.Equal(t, "response_body", session.StateString())
+
+	session.State = SessionStateProtocolSwitch
+	require.Equal(t, "protocol_switch", session.StateString())
+
+	session.State = SessionStateDone
+	require.Equal(t, "done", session.StateString())
+
+	// Test unknown state
+	session.State = SessionState(999)
+	require.Equal(t, "unknown", session.StateString())
+}
+
+// TestSession_PluginManagerIntegration tests that plugin manager is properly called
+// Note: This test verifies the session works with nil plugin manager (common case)
+func TestSession_PluginManagerIntegration(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop()
+
+	conn := &connection.Connection{
+		IsTLS: false,
+	}
+
+	// Test with nil plugin manager (should work fine)
+	session := NewSession(ctx, logger, "example.com", conn, nil)
+	defer session.Close()
+
+	// Create request
+	req := &http.Request{
+		Method: http.MethodPost,
+		URL:    &url.URL{Path: "/api/test"},
+		Header: http.Header{
+			"Content-Type":   []string{"application/json"},
+			"Content-Length": []string{"13"},
+		},
+	}
+
+	session.CreateRequest(req, false)
+
+	// Verify no plugin connection was created
+	require.Nil(t, session.pluginConn)
+
+	// Send request body
+	bodyData := `{"test":true}`
+	session.WriteRequestBody([]byte(bodyData), true)
+
+	// Create response
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Status:     "200 OK",
+		Header: http.Header{
+			"Content-Type": []string{"application/json"},
+		},
+	}
+
+	session.CreateResponse(resp, false)
+
+	// Send response body
+	respBody := `{"success":true}`
+	session.WriteResponseBody([]byte(respBody), true)
+
+	// Verify session completed successfully
+	require.Equal(t, SessionStateDone, session.State)
+	require.Equal(t, resp, session.res)
+}

--- a/pkg/stream/protocols/http1/stream.go
+++ b/pkg/stream/protocols/http1/stream.go
@@ -80,6 +80,15 @@ func (t *HTTPStream) Process(event *connection.DataEvent) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
+	// Check if we need to handle protocol switch
+	if t.session != nil && t.session.IsProtocolUpgraded() {
+		t.logger.Debug("protocol has been upgraded, stopping HTTP/1.1 processing")
+		if upgrade := t.session.GetUpgradeInfo(); upgrade != nil {
+			t.logger.Debug("protocol switched", zap.String("protocol", upgrade.Protocol))
+		}
+		return nil // Stop processing as HTTP/1.1
+	}
+
 	// determine the phase
 	var phase Phase
 
@@ -96,13 +105,23 @@ func (t *HTTPStream) Process(event *connection.DataEvent) error {
 	}
 
 	// if we're processing a response and we get a request, we need to close
+	// unless we're awaiting an interim response like 100-Continue
 	if phase == PhaseRequest && t.session != nil && t.session.IsParsingResponse() {
-		t.session.Close()
+		// Allow new request if we're in protocol switch state (connection reuse)
+		if t.session.State != SessionStateProtocolSwitch && t.session.State != SessionStateAwaitingInterim {
+			t.session.Close()
+		}
 	}
 
 	// if we don't have a session and we get a response, we need to ignore
 	if phase == PhaseResponse && t.session == nil {
 		return nil
+	}
+
+	// Special case: if we're awaiting interim response and get response data, allow it
+	if phase == PhaseResponse && t.session != nil &&
+		(t.session.State == SessionStateAwaitingInterim || t.session.State == SessionStateRequestBody) {
+		t.logger.Debug("processing response while in request phase", zap.String("state", t.session.StateString()))
 	}
 
 	// create a session if we don't have one
@@ -129,6 +148,12 @@ func (t *HTTPStream) writeRequest(data []byte) {
 
 	// update the bytes
 	t.session.wrBytes += int64(len(data))
+
+	// Check if we can accept request body data in current state
+	if !t.session.CanAcceptRequestBody() && t.session.State != SessionStateRequestHeaders {
+		t.logger.Debug("cannot accept request body in current state", zap.String("state", t.session.StateString()))
+		return
+	}
 
 	_, err := t.session.requestParser.Write(data)
 	if err != nil {


### PR DESCRIPTION
tldr; add support for multiple responses/http continuations/protocol switches

- Added handling for 1xx interim responses (e.g., 100 Continue, 101 Switching Protocols) in the StreamParser and Session.
- Updated parser to manage multiple responses, allowing for interim responses before final ones.
- Introduced a ResponseChain struct to track interim and final responses.
- Enhanced session state management to accommodate awaiting interim responses and protocol upgrades.
- Added tests for interim response handling and state transitions in session management.

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Contributing Guide: https://github.com/qpoint-io/qtap/docs/CONTRIBUTING.md
     - 📖 Read the Contributor License Agreement (CLA): https://github.com/qpoint-io/qtap/docs/CLA.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Qpoint Team member.
-->
