### PR TITLE
Adds backoff to containerd and docker event scanners

### DIFF
--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -11,7 +11,6 @@ import (
 const (
 	DefaultRuntimeTimeout  = time.Second * 2
 	DefaultStartupTimeout  = time.Second * 5
-	DefaultWatchInterval   = time.Second * 15
 	HumanContainerIDLength = 12
 )
 

--- a/pkg/container/containerd.go
+++ b/pkg/container/containerd.go
@@ -217,6 +217,9 @@ func (c *Containerd) buildContainerRecord(ctx context.Context, container contain
 }
 
 func (c *Containerd) watchContainerEventsWithRetry(ctx context.Context) {
+	backoff := time.Second
+	maxBackoff := time.Minute
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -224,13 +227,26 @@ func (c *Containerd) watchContainerEventsWithRetry(ctx context.Context) {
 		default:
 		}
 
-		c.watchContainerEvents(ctx)
-
-		time.Sleep(DefaultWatchInterval)
+		if c.watchContainerEvents(ctx) {
+			backoff = time.Second
+		} else {
+			c.logger.Error("container event subscription failed", zap.Duration("backoff", backoff))
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(backoff):
+				if backoff < maxBackoff {
+					backoff *= 2
+					if backoff > maxBackoff {
+						backoff = maxBackoff
+					}
+				}
+			}
+		}
 	}
 }
 
-func (c *Containerd) watchContainerEvents(ctx context.Context) {
+func (c *Containerd) watchContainerEvents(ctx context.Context) bool {
 	cl := c.client
 
 	var chMsg <-chan *events.Envelope
@@ -242,13 +258,13 @@ func (c *Containerd) watchContainerEvents(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
-			return
+			return true
 		case err := <-chErr:
 			if errors.Is(err, context.Canceled) {
-				return
+				return true
 			}
 			c.logger.Error("container event subscription error", zap.Error(err))
-			return
+			return false
 		case msg = <-chMsg:
 		}
 

--- a/pkg/container/docker.go
+++ b/pkg/container/docker.go
@@ -181,6 +181,9 @@ func (d *docker) inspectContainer(ctx context.Context, containerID string) (*Con
 }
 
 func (d *docker) watchContainerEventsWithRetry(ctx context.Context) {
+	backoff := time.Second
+	maxBackoff := time.Minute
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -188,13 +191,26 @@ func (d *docker) watchContainerEventsWithRetry(ctx context.Context) {
 		default:
 		}
 
-		d.watchContainerEvents(ctx)
-
-		time.Sleep(DefaultWatchInterval)
+		if d.watchContainerEvents(ctx) {
+			backoff = time.Second
+		} else {
+			d.logger.Error("docker event subscription failed", zap.Duration("backoff", backoff))
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(backoff):
+				if backoff < maxBackoff {
+					backoff *= 2
+					if backoff > maxBackoff {
+						backoff = maxBackoff
+					}
+				}
+			}
+		}
 	}
 }
 
-func (d *docker) watchContainerEvents(ctx context.Context) {
+func (d *docker) watchContainerEvents(ctx context.Context) bool {
 	c := d.client
 
 	var chMsg <-chan events.Message
@@ -206,12 +222,13 @@ func (d *docker) watchContainerEvents(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
-			return
+			return true
 		case err := <-chErr:
 			if errors.Is(err, context.Canceled) {
-				return
+				return true
 			}
-			return
+			d.logger.Error("docker event subscription error", zap.Error(err))
+			return false
 		case msg = <-chMsg:
 		}
 


### PR DESCRIPTION
This PR brings in optimizations for our container connectors. The main improvement is that if a docker socket is not available then we back off on retries. In addition:

- Fewer syscalls
- More respectful network polling
- Fewer reads overall

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Contributing Guide: https://github.com/qpoint-io/qtap/docs/CONTRIBUTING.md
     - 📖 Read the Contributor License Agreement (CLA): https://github.com/qpoint-io/qtap/docs/CLA.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Qpoint Team member.
-->
