### PR TITLE
Identify and remove wasteful CPU usage - Part 1

### DIFF
--- a/pkg/container/containerd.go
+++ b/pkg/container/containerd.go
@@ -111,8 +111,6 @@ func (c *Containerd) loadNamespacedContainers(ctx context.Context) error {
 }
 
 func (c *Containerd) Start(ctx context.Context) error {
-	c.logger.Info("loading containerd containers")
-
 	if err := c.loadNamespacedContainers(ctx); err != nil {
 		return fmt.Errorf("load namespaced containers: %w", err)
 	}

--- a/pkg/container/containerd.go
+++ b/pkg/container/containerd.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -36,6 +37,11 @@ type Containerd struct {
 func NewContainerdAccessor(logger *zap.Logger, endpoint string) (*Containerd, error) {
 	if endpoint == "" {
 		endpoint = DefaultContainerdSocketPath
+	}
+
+	// check if the endpoint exists and is a socket
+	if _, err := os.Stat(endpoint); err != nil {
+		return nil, fmt.Errorf("endpoint %s does not exist or is not a socket: %w", endpoint, err)
 	}
 
 	// create global client
@@ -105,6 +111,8 @@ func (c *Containerd) loadNamespacedContainers(ctx context.Context) error {
 }
 
 func (c *Containerd) Start(ctx context.Context) error {
+	c.logger.Info("loading containerd containers")
+
 	if err := c.loadNamespacedContainers(ctx); err != nil {
 		return fmt.Errorf("load namespaced containers: %w", err)
 	}

--- a/pkg/container/docker.go
+++ b/pkg/container/docker.go
@@ -49,6 +49,11 @@ func NewDockerAccessor(logger *zap.Logger, endpoint string) (*docker, error) {
 		client.WithAPIVersionNegotiation(),
 	}
 
+	// check if the endpoint exists and is a socket
+	if _, err := os.Stat(endpoint); err != nil {
+		return nil, fmt.Errorf("endpoint %s does not exist or is not a socket: %w", endpoint, err)
+	}
+
 	if endpoint != "" {
 		opts = append(opts, client.WithHost(endpoint))
 	} else if os.Getenv(DefaultDockerHostEnv) == "" {

--- a/pkg/container/kubernetes.go
+++ b/pkg/container/kubernetes.go
@@ -43,6 +43,11 @@ func NewKubernetesAccessor(logger *zap.Logger, criRuntimeEndpoint string) (*Kube
 		return nil, "", errs
 	}
 
+	// verify the endpoint exists and is a socket
+	if _, err := os.Stat(endpoint); err != nil {
+		return nil, "", []error{fmt.Errorf("endpoint %s does not exist or is not a socket: %w", endpoint, err)}
+	}
+
 	podCache := expirable.NewLRU[string, *podCacheEntry](podCacheSize, nil, podCacheTTL)
 
 	return &KubernetesAccessor{logger: logger, rs: rs, podCache: podCache}, endpoint, nil

--- a/pkg/ebpf/process/manager.go
+++ b/pkg/ebpf/process/manager.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/ringbuf"
-	"github.com/hashicorp/golang-lru/v2/expirable"
+	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/qpoint-io/qtap/pkg/ebpf/common"
 	"github.com/qpoint-io/qtap/pkg/process"
 	"go.uber.org/zap"
@@ -31,7 +31,7 @@ var recordPool = sync.Pool{
 type Manager struct {
 	logger   *zap.Logger
 	reciever process.Receiver
-	cache    *expirable.LRU[int32, *process.Process]
+	cache    *lru.Cache[int32, *process.Process]
 
 	// bridge to the bpf probes
 	tracepoints []*common.Tracepoint
@@ -40,12 +40,17 @@ type Manager struct {
 }
 
 func New(logger *zap.Logger, mmap *ebpf.Map, rb *ringbuf.Reader, tps []*common.Tracepoint) *Manager {
+	cache, err := lru.New[int32, *process.Process](cacheSize)
+	if err != nil {
+		panic(err)
+	}
+
 	return &Manager{
 		logger:      logger,
 		rb:          rb,
 		metaMap:     mmap,
 		tracepoints: tps,
-		cache:       expirable.NewLRU[int32, *process.Process](cacheSize, nil, cacheTTL),
+		cache:       cache,
 	}
 }
 

--- a/pkg/ebpf/process/reader_test.go
+++ b/pkg/ebpf/process/reader_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/binary"
 	"testing"
 
-	"github.com/hashicorp/golang-lru/v2/expirable"
+	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/qpoint-io/qtap/pkg/process"
 	"github.com/qpoint-io/qtap/pkg/process/mocks"
 	"github.com/stretchr/testify/require"
@@ -53,10 +53,14 @@ func TestHandleExecStartEvent(t *testing.T) {
 			require.NoError(t, binary.Write(buf, binary.NativeEndian, event))
 			require.NoError(t, binary.Write(buf, binary.NativeEndian, []byte(tt.exePath)))
 
+			cache, err := lru.New[int32, *process.Process](cacheSize)
+			if err != nil {
+				panic(err)
+			}
 			// Create manager
 			m := &Manager{
 				logger: zap.NewNop(),
-				cache:  expirable.NewLRU[int32, *process.Process](cacheSize, nil, cacheTTL),
+				cache:  cache,
 			}
 
 			if tt.receiver {
@@ -65,7 +69,7 @@ func TestHandleExecStartEvent(t *testing.T) {
 			}
 
 			// Test handler
-			err := m.handleExecStartEvent(bytes.NewReader(buf.Bytes()))
+			err = m.handleExecStartEvent(bytes.NewReader(buf.Bytes()))
 			if tt.wantErr {
 				require.Error(t, err)
 				return
@@ -122,10 +126,15 @@ func TestHandleExecArgvEvent(t *testing.T) {
 			require.NoError(t, binary.Write(buf, binary.NativeEndian, event))
 			require.NoError(t, binary.Write(buf, binary.NativeEndian, []byte(tt.arg)))
 
+			cache, err := lru.New[int32, *process.Process](cacheSize)
+			if err != nil {
+				panic(err)
+			}
+
 			// Create manager with receiver
 			m := &Manager{
 				logger:   zap.NewNop(),
-				cache:    expirable.NewLRU[int32, *process.Process](cacheSize, nil, cacheTTL),
+				cache:    cache,
 				reciever: mocks.NewMockReceiver(ctrl),
 			}
 
@@ -137,7 +146,7 @@ func TestHandleExecArgvEvent(t *testing.T) {
 			}
 
 			// Test handler
-			err := m.handleExecArgvEvent(bytes.NewReader(buf.Bytes()))
+			err = m.handleExecArgvEvent(bytes.NewReader(buf.Bytes()))
 			if tt.wantErr {
 				require.Error(t, err)
 				return
@@ -197,6 +206,11 @@ func TestHandleExecEndEvent(t *testing.T) {
 			buf := new(bytes.Buffer)
 			require.NoError(t, binary.Write(buf, binary.NativeEndian, event))
 
+			cache, err := lru.New[int32, *process.Process](cacheSize)
+			if err != nil {
+				panic(err)
+			}
+
 			// Create mock receiver
 			mockRcv := mocks.NewMockReceiver(ctrl)
 			if tt.setupPid {
@@ -206,7 +220,7 @@ func TestHandleExecEndEvent(t *testing.T) {
 			// Create manager
 			m := &Manager{
 				logger:   zap.NewNop(),
-				cache:    expirable.NewLRU[int32, *process.Process](cacheSize, nil, cacheTTL),
+				cache:    cache,
 				reciever: mockRcv,
 			}
 
@@ -216,7 +230,7 @@ func TestHandleExecEndEvent(t *testing.T) {
 			}
 
 			// Test handler
-			err := m.handleExecEndEvent(bytes.NewReader(buf.Bytes()))
+			err = m.handleExecEndEvent(bytes.NewReader(buf.Bytes()))
 			if tt.wantErr {
 				require.Error(t, err)
 				return
@@ -266,6 +280,11 @@ func TestHandleExitEvent(t *testing.T) {
 			buf := new(bytes.Buffer)
 			require.NoError(t, binary.Write(buf, binary.NativeEndian, event))
 
+			cache, err := lru.New[int32, *process.Process](cacheSize)
+			if err != nil {
+				panic(err)
+			}
+
 			// Create mock receiver
 			mockRcv := mocks.NewMockReceiver(ctrl)
 			mockRcv.EXPECT().UnregisterProcess(int(tt.pid), 0).Return(tt.endProcErr)
@@ -273,12 +292,12 @@ func TestHandleExitEvent(t *testing.T) {
 			// Create manager
 			m := &Manager{
 				logger:   zap.NewNop(),
-				cache:    expirable.NewLRU[int32, *process.Process](cacheSize, nil, cacheTTL),
+				cache:    cache,
 				reciever: mockRcv,
 			}
 
 			// Test handler
-			err := m.handleExitEvent(bytes.NewReader(buf.Bytes()))
+			err = m.handleExitEvent(bytes.NewReader(buf.Bytes()))
 			if tt.wantErr {
 				require.Error(t, err)
 				return


### PR DESCRIPTION
This PR is the first pass at identifying areas within Qtap that cause unnecessary CPU spend. 

Qtap on an idle system: 
Prior to this PR: ~10-15% CPU
After this PR: 0.3-1.3% CPU

There are certainly still wasteful CPU cycles that need to be discovered and rooted out. This PR is the first pass with a fairly productive cut. 
