### PR TITLE
Increase plugin command queue size

### DIFF
--- a/pkg/plugins/connection.go
+++ b/pkg/plugins/connection.go
@@ -28,7 +28,7 @@ const (
 )
 
 const (
-	commandQueueSize = 100
+	commandQueueSize = 8192
 )
 
 // Command represents a unit of work to be processed asynchronously


### PR DESCRIPTION
The plugin command queue adds back-pressure to the data stream. The plugin reads commands out of the queue and then processes the events. To ensure the queue doesn't get too big, the max commands limit keeps too much data from being added that will overwhelm the process. 

This PR increases that limit to a reasonable size.
