### PR TITLE
e2e: bidirectional process readiness handshake

### DIFF
--- a/e2e/http_test.go
+++ b/e2e/http_test.go
@@ -152,8 +152,7 @@ func TestLanguages(t *testing.T) {
 		WithHTTPProtocols(e2e.HTTPProtocolHTTP1_1, e2e.HTTPProtocolHTTP2_0).
 		WithBothTLSAndPlaintext().
 		WithHeader("Content-Type", "application/json").
-		WithStartupDelay(1000*time.Millisecond). // TODO(Jon): this is a hack to ensure the process is started before we start the test
-		WithWaitForFile("/tmp/wait-for-file", 5*time.Second).
+		WithReadinessHandshake("/tmp/readiness-signal", 15*time.Second).
 		WithValidation(func(t *testing.T, ctx e2e.ValidationContext) error {
 			events := ctx.TestContext.Events(1)
 			require.Len(t, events.Connections, 1)
@@ -233,7 +232,7 @@ func TestLanguageNonIntrospective(t *testing.T) {
 		WithURL("/api/health").
 		WithHTTPProtocols(e2e.HTTPProtocolHTTP1_1, e2e.HTTPProtocolHTTP2_0).
 		WithTLSOnly().
-		WithStartupDelay(100 * time.Millisecond).
+		WithReadinessHandshake("/tmp/readiness-signal", 15*time.Second).
 		WithValidation(func(t *testing.T, ctx e2e.ValidationContext) error {
 			events := ctx.TestContext.Events(1)
 			require.Len(t, events.Connections, 1)

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -24,21 +23,22 @@ import (
 var AwaitEventsTimeout = 10 * time.Second
 
 type Context struct {
-	ctx          context.Context
-	closers      []func() error
-	machineIP    net.IP
-	Start        time.Time
-	EventStore   *EventStoreFactory
-	ConfProvider *ConfigProvider
-	L            *zap.Logger
-	TestConfig   func(mut func(*config.Config)) *config.Config
-	testContexts []*TestContext
+	ctx           context.Context
+	closers       []func() error
+	machineIP     net.IP
+	Start         time.Time
+	EventStore    *EventStoreFactory
+	ConfProvider  *ConfigProvider
+	L             *zap.Logger
+	TestConfig    func(mut func(*config.Config)) *config.Config
+	ProcessWaiter *ProcessWaiter
 }
 
 func NewContext(ctx context.Context) *Context {
 	return &Context{
-		ctx:        ctx,
-		TestConfig: DefaultTestConfig,
+		ctx:           ctx,
+		TestConfig:    DefaultTestConfig,
+		ProcessWaiter: NewProcessWaiter(),
 	}
 }
 
@@ -136,13 +136,11 @@ func DefaultTestConfig(mut func(*config.Config)) *config.Config {
 func (c *Context) TestCtx(t *testing.T) *TestContext {
 	id := NewID()
 	ctx := &TestContext{
-		ID:       id,
-		e2ectx:   c,
-		T:        t,
-		L:        c.L.With(zap.String("ctxid", id)),
-		requests: make([]*HTTPRequest, 0),
+		ID:     id,
+		e2ectx: c,
+		T:      t,
+		L:      c.L.With(zap.String("ctxid", id)),
 	}
-	c.testContexts = append(c.testContexts, ctx)
 	ctx.L.Info("🔧 test context created")
 	return ctx
 }
@@ -156,12 +154,25 @@ func (c *Context) SetConfig(conf *config.Config) {
 }
 
 type TestContext struct {
-	e2ectx   *Context
-	ID       string
-	T        *testing.T
-	L        *zap.Logger
-	requests []*HTTPRequest
-	mu       sync.RWMutex // protects requests slice
+	e2ectx *Context
+	ID     string
+	T      *testing.T
+	L      *zap.Logger
+}
+
+type processKey struct {
+	containerID string
+	pid         int
+}
+
+func newProcessKey(containerID string, pid int) processKey {
+	if len(containerID) > 12 {
+		containerID = containerID[:12]
+	}
+	return processKey{
+		containerID: containerID,
+		pid:         pid,
+	}
 }
 
 type ExecResult struct {
@@ -224,13 +235,6 @@ func (c *TestContext) MachineIP() net.IP {
 	return c.e2ectx.MachineIP()
 }
 
-// RegisterRequest adds an HTTP request to the test context's request list
-func (c *TestContext) RegisterRequest(req *HTTPRequest) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.requests = append(c.requests, req)
-}
-
 func (c *Context) SetMachineIP(ip net.IP) {
 	c.machineIP = ip
 }
@@ -258,101 +262,83 @@ func NewLogger(start time.Time) *zap.Logger {
 }
 
 func (c *Context) ProcessStarted(proc *process.Process) error {
-	for _, testCtx := range c.testContexts {
-		if err := testCtx.ProcessStarted(proc); err != nil {
-			return err
-		}
-	}
-	return nil
+	return c.ProcessWaiter.Signal(newProcessKey(proc.ContainerID, proc.Pid))
 }
 
 func (c *Context) ProcessReplaced(proc *process.Process) error {
-	for _, testCtx := range c.testContexts {
-		if err := testCtx.ProcessReplaced(proc); err != nil {
-			return err
-		}
-	}
-	return nil
+	return c.ProcessWaiter.Reset(newProcessKey(proc.ContainerID, proc.Pid))
 }
 
 func (c *Context) ProcessStopped(proc *process.Process) error {
-	for _, testCtx := range c.testContexts {
-		if err := testCtx.ProcessStopped(proc); err != nil {
-			return err
-		}
+	return c.ProcessWaiter.Reset(newProcessKey(proc.ContainerID, proc.Pid))
+}
+
+func (c *TestContext) WaitForProcess(key processKey, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(c.T.Context(), timeout)
+	defer cancel()
+	return c.e2ectx.ProcessWaiter.Wait(ctx, key)
+}
+
+// ProcessWaiter is used to track and wait for processes to become ready.
+type ProcessWaiter struct {
+	waiters map[processKey]chan struct{} // channel per process: open = not registered, closed = registered
+	mu      sync.RWMutex                 // protects waiters map
+}
+
+func NewProcessWaiter() *ProcessWaiter {
+	return &ProcessWaiter{
+		waiters: make(map[processKey]chan struct{}),
+		mu:      sync.RWMutex{},
 	}
+}
+
+// Signal signals that the process has started and is ready to be used
+func (w *ProcessWaiter) Signal(key processKey) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	waiter, exists := w.waiters[key]
+	if !exists {
+		// First time seeing this process - create already-closed channel
+		waiter = make(chan struct{})
+		w.waiters[key] = waiter
+		close(waiter)
+		return nil
+	}
+
+	// Check if channel is already closed by trying a non-blocking receive
+	select {
+	case <-waiter:
+		// Channel already closed, nothing to do
+		return nil
+	default:
+		// Channel is open, close it to notify waiters
+		close(waiter)
+		return nil
+	}
+}
+
+func (w *ProcessWaiter) Reset(key processKey) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.waiters[key] = make(chan struct{})
 	return nil
 }
 
-func (c *TestContext) ProcessStarted(proc *process.Process) error {
-	// c.L.Info("⭕ process started", zap.String("container_id", proc.ContainerID), zap.Int("pid", proc.Pid), zap.String("process_binary", proc.Binary), zap.String("exe", proc.Exe), zap.String("exe_filename", proc.ExeFilename))
-
-	// Find the container by searching through active requests
-	c.mu.RLock()
-	var req *HTTPRequest
-	for _, r := range c.requests {
-		if r.container != nil {
-			// Not our container
-			if !strings.HasPrefix(r.container.GetContainerID(), proc.ContainerID) {
-				return nil
-			}
-
-			{
-				// TODO(Jon): This a pretty bad hack to ensure we are creating the continuation file
-				// on binary processes that we expect, and not the creation processes.
-				//
-				// It's not uncommon to get several bin calls for an expected binary "php" shows
-				// up 4 or 5 times and we may or may not be finishing processing it before the first.
-				//
-				// This might indicate that we need to have a binary processing pipeline, I imagine that
-				// if a "php" binary is called 3 or 4 times really quickly, we might try and scan it multiple
-				// times concurrently because it's not in the cache yet. This could be a general resource
-				// improvement opportunity.
-				//
-				// Check that this is the binary we expect
-				exeFilename := filepath.Base(proc.ExeFilename) // We use this because it's the original binary path (could be a symlink)
-
-				var expectedExe string
-				containerCtx, err := r.container.Inspect(c.T.Context())
-				if err != nil {
-					return fmt.Errorf("inspecting container: %w", err)
-				}
-				switch {
-				case len(containerCtx.Config.Entrypoint) > 0:
-					expectedExe = containerCtx.Config.Entrypoint[0]
-				case len(containerCtx.Config.Cmd) > 0:
-					expectedExe = containerCtx.Config.Cmd[0]
-				default:
-					return errors.New("could not determine container entrypoint")
-				}
-				expectedExe = filepath.Base(expectedExe)
-
-				if expectedExe != exeFilename {
-					c.L.Info("🆕 process binary mismatch", zap.String("container_id", proc.ContainerID), zap.String("binary", proc.Binary), zap.String("expected", expectedExe))
-					return nil
-				}
-			}
-
-			req = r
-			break
-		}
+func (w *ProcessWaiter) Wait(ctx context.Context, key processKey) error {
+	w.mu.Lock()
+	waiter, exists := w.waiters[key]
+	if !exists {
+		// First time seeing this processID - create channel
+		waiter = make(chan struct{})
+		w.waiters[key] = waiter
 	}
-	c.mu.RUnlock()
+	w.mu.Unlock()
 
-	if req != nil && req.WaitForFile != "" {
-		c.L.Info("🆕 creating file in container", zap.String("binary", proc.Binary), zap.String("file", req.WaitForFile))
-		if err := req.container.CopyToContainer(c.T.Context(), []byte("Q"), req.WaitForFile, 0644); err != nil {
-			return fmt.Errorf("creating file in container: %w", err)
-		}
+	// Block on channel - returns immediately if already closed
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-waiter:
+		return nil
 	}
-
-	return nil
-}
-
-func (c *TestContext) ProcessReplaced(proc *process.Process) error {
-	return nil
-}
-
-func (c *TestContext) ProcessStopped(proc *process.Process) error {
-	return nil
 }

--- a/pkg/e2e/request.go
+++ b/pkg/e2e/request.go
@@ -440,6 +440,8 @@ func (m *HTTPRequest) Run(ctx context.Context, l *zap.Logger) *Container {
 
 	c.Container = cntnr
 	go func() {
+		ctx, cancel := context.WithTimeout(ctx, m.ReadinessTimeout)
+		defer cancel()
 		// Start the container
 		err := cntnr.Start(ctx)
 		if err != nil {
@@ -453,6 +455,11 @@ func (m *HTTPRequest) Run(ctx context.Context, l *zap.Logger) *Container {
 		if m.ReadinessFile != "" {
 			var pid int
 			for {
+				if ctx.Err() != nil {
+					l.Warn("readiness handshake timed out", zap.Error(ctx.Err()))
+					return
+				}
+
 				pidFile, err := cntnr.CopyFileFromContainer(ctx, m.ReadinessFile+".pid")
 				if err == nil {
 					pidTxt, err := io.ReadAll(pidFile)

--- a/pkg/e2e/request.go
+++ b/pkg/e2e/request.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"maps"
 	"strconv"
 	"strings"
@@ -12,7 +13,6 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
 	"go.uber.org/zap"
 )
 
@@ -118,9 +118,9 @@ func (m *HTTPRequestBuilder) WithOutputFormat(format string) *HTTPRequestBuilder
 	return m
 }
 
-func (m *HTTPRequestBuilder) WithWaitForFile(file string, timeout time.Duration) *HTTPRequestBuilder {
-	m.req.WaitForFile = file
-	m.req.WaitForFileTimeout = timeout
+func (m *HTTPRequestBuilder) WithReadinessHandshake(file string, timeout time.Duration) *HTTPRequestBuilder {
+	m.req.ReadinessFile = file
+	m.req.ReadinessTimeout = timeout
 	return m
 }
 
@@ -216,8 +216,8 @@ func (m *HTTPRequest) toEnvVars() map[string]string {
 	if m.StartupDelay > 0 {
 		envVars["STARTUP_DELAY"] = strconv.FormatInt(m.StartupDelay.Milliseconds(), 10)
 	}
-	if m.WaitForFile != "" {
-		envVars["WAIT_FOR_FILE"] = fmt.Sprintf("%s:%d", m.WaitForFile, m.WaitForFileTimeout.Milliseconds())
+	if m.ReadinessFile != "" {
+		envVars["READINESS_HANDSHAKE"] = fmt.Sprintf("%s.ready:%s.pid:%d", m.ReadinessFile, m.ReadinessFile, m.ReadinessTimeout.Milliseconds())
 	}
 
 	// Output control
@@ -293,8 +293,8 @@ type HTTPRequest struct {
 	ConcurrentRequests   int
 	DelayBetweenRequests time.Duration
 	StartupDelay         time.Duration // Milliseconds
-	WaitForFile          string
-	WaitForFileTimeout   time.Duration
+	ReadinessFile        string
+	ReadinessTimeout     time.Duration
 
 	// Output control
 	OutputFormat string // "json" or other for human-readable
@@ -305,9 +305,6 @@ type HTTPRequest struct {
 
 	// Container configuration
 	ImageURL string
-
-	// Private field to store the running container
-	container *Container
 }
 
 type HTTPRequestBuilder struct {
@@ -340,8 +337,8 @@ func (m *HTTPRequestBuilder) Build() (*HTTPRequest, error) {
 		ConcurrentRequests:   m.req.ConcurrentRequests,
 		DelayBetweenRequests: m.req.DelayBetweenRequests,
 		StartupDelay:         m.req.StartupDelay,
-		WaitForFile:          m.req.WaitForFile,
-		WaitForFileTimeout:   m.req.WaitForFileTimeout,
+		ReadinessFile:        m.req.ReadinessFile,
+		ReadinessTimeout:     m.req.ReadinessTimeout,
 
 		OutputFormat: m.req.OutputFormat,
 		Verbose:      m.req.Verbose,
@@ -397,7 +394,8 @@ func BuildHTTPRequest() *HTTPRequestBuilder {
 func (m *HTTPRequest) Run(ctx context.Context, l *zap.Logger) *Container {
 	result := ContainerResult{}
 	c := &Container{
-		resultCh: make(chan ContainerResult),
+		resultCh:   make(chan ContainerResult),
+		processPID: make(chan int, 1),
 	}
 
 	envVars := m.toEnvVars()
@@ -409,15 +407,15 @@ func (m *HTTPRequest) Run(ctx context.Context, l *zap.Logger) *Container {
 			Env:   envVars,
 			HostConfigModifier: func(hc *container.HostConfig) {
 				hc.NetworkMode = network.NetworkHost
+				// pid mode host is required for the readiness handshake
+				hc.PidMode = "host"
 			},
 			LogConsumerCfg: &testcontainers.LogConsumerConfig{
 				Opts:      []testcontainers.LogProductionOption{testcontainers.WithLogProductionTimeout(10 * time.Second)},
 				Consumers: []testcontainers.LogConsumer{&result},
 			},
-			WaitingFor: wait.ForExit().WithPollInterval(10 * time.Millisecond),
 			AutoRemove: true, // Clean up container when it exits
 		},
-		// Started: true,
 	}
 
 	// TODO(Jon): test this
@@ -432,7 +430,7 @@ func (m *HTTPRequest) Run(ctx context.Context, l *zap.Logger) *Container {
 
 	// Start the container
 	l.Info("🕹️ starting container", zap.String("image", m.ImageURL), zap.Any("env", envVars))
-	container, err := testcontainers.GenericContainer(ctx, req)
+	cntnr, err := testcontainers.GenericContainer(ctx, req)
 	if err != nil {
 		l.Error("start container error", zap.Error(err))
 		result.Error = fmt.Errorf("starting container %s: %w", m.ImageURL, err)
@@ -440,14 +438,10 @@ func (m *HTTPRequest) Run(ctx context.Context, l *zap.Logger) *Container {
 		return nil
 	}
 
-	c.Container = container
-
-	// Store the container reference on the request so ProcessStarted can find it
-	m.container = c
-
+	c.Container = cntnr
 	go func() {
 		// Start the container
-		err := container.Start(ctx)
+		err := cntnr.Start(ctx)
 		if err != nil {
 			l.Error("start container error", zap.Error(err))
 			result.Error = fmt.Errorf("starting container %s: %w", m.ImageURL, err)
@@ -456,13 +450,46 @@ func (m *HTTPRequest) Run(ctx context.Context, l *zap.Logger) *Container {
 			return
 		}
 
-		state, err := container.State(ctx)
-		if err != nil {
-			l.Error("get container state error", zap.Error(err))
-			result.Error = fmt.Errorf("getting container state: %w", err)
-			result.ExitCode = -1
-			c.resultCh <- result
-			return
+		if m.ReadinessFile != "" {
+			var pid int
+			for {
+				pidFile, err := cntnr.CopyFileFromContainer(ctx, m.ReadinessFile+".pid")
+				if err == nil {
+					pidTxt, err := io.ReadAll(pidFile)
+					if err == nil {
+						pid, err = strconv.Atoi(string(pidTxt))
+						if err == nil {
+							break
+						}
+						l.Warn("failed to parse pid from file", zap.String("pid", string(pidTxt)), zap.Error(err))
+					} else {
+						l.Warn("read pid file error", zap.Error(err))
+					}
+				}
+				l.Warn("waiting for pid file", zap.Error(err))
+				time.Sleep(1 * time.Second)
+			}
+			l.Warn("got pid", zap.Int("pid", pid))
+			c.processPID <- pid
+		}
+
+		var state *container.State
+		for {
+			var err error
+			state, err = cntnr.State(ctx)
+			if err != nil {
+				l.Error("get container state error", zap.Error(err))
+				result.Error = fmt.Errorf("getting container state: %w", err)
+				result.ExitCode = -1
+				c.resultCh <- result
+				return
+			}
+
+			if state.Running {
+				time.Sleep(10 * time.Millisecond)
+				continue
+			}
+			break
 		}
 
 		l.Debug("container state", zap.Any("state", state))

--- a/pkg/e2e/runner.go
+++ b/pkg/e2e/runner.go
@@ -126,14 +126,37 @@ func (r *TestSuiteRunner) runSingleTest(t *testing.T, tctx *TestContext, tc Test
 	// Update request URL to point to test server
 	tc.Request.URL = server.URL + tc.Request.URL
 
-	// Register the request with the test context so ProcessStarted can find its container
-	tctx.RegisterRequest(tc.Request)
-
 	// Run the container
 	container := tc.Request.Run(ctx, r.Logger)
 
 	// Wait for any async operations
 	// time.Sleep(100 * time.Millisecond)
+
+	if tc.Request.ReadinessFile != "" {
+		containerID := container.GetContainerID()
+		if len(containerID) > 12 {
+			containerID = containerID[:12]
+		}
+
+		r.Logger.Info("Waiting for process information", zap.String("container_id", containerID))
+		var pid int
+		select {
+		case pid = <-container.processPID:
+		case <-ctx.Done():
+			t.Errorf("%v", ctx.Err())
+			return
+		}
+
+		r.Logger.Info("Waiting for process to be ready", zap.Int("pid", pid), zap.String("container_id", containerID))
+		if err := tctx.WaitForProcess(newProcessKey(containerID, pid), tc.Request.ReadinessTimeout); err != nil {
+			r.Logger.Warn("Failed to wait for process", zap.Error(err))
+		} else {
+			r.Logger.Info("🆕 creating readiness signal in container")
+			if err := container.Container.CopyToContainer(ctx, []byte("Q"), tc.Request.ReadinessFile+".ready", 0644); err != nil {
+				r.Logger.Warn("Failed to create file in container", zap.Error(err))
+			}
+		}
+	}
 
 	var containerResult ContainerResult = <-container.resultCh
 

--- a/pkg/e2e/suite.go
+++ b/pkg/e2e/suite.go
@@ -152,9 +152,9 @@ func (b *TestSuiteBuilder) WithStartupDelay(delay time.Duration) *TestSuiteBuild
 	return b
 }
 
-// Wait for file configuration
-func (b *TestSuiteBuilder) WithWaitForFile(file string, timeout time.Duration) *TestSuiteBuilder {
-	b.requestBuilder.WithWaitForFile(file, timeout)
+// Readiness handshake configuration
+func (b *TestSuiteBuilder) WithReadinessHandshake(file string, timeout time.Duration) *TestSuiteBuilder {
+	b.requestBuilder.WithReadinessHandshake(file, timeout)
 	return b
 }
 

--- a/pkg/e2e/types.go
+++ b/pkg/e2e/types.go
@@ -21,7 +21,8 @@ const (
 
 type Container struct {
 	testcontainers.Container
-	resultCh chan ContainerResult
+	resultCh   chan ContainerResult
+	processPID chan int
 	// Request  *HTTPRequest
 }
 

--- a/pkg/ebpf/tls/manager.go
+++ b/pkg/ebpf/tls/manager.go
@@ -1,6 +1,7 @@
 package tls
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -67,9 +68,12 @@ func (m *TlsManager) Stop() error {
 }
 
 func (m *TlsManager) ProcessStarted(proc *process.Process) error {
-	// ensure only one scan process happening at a time per process
-	proc.ScanLock()
-	defer proc.ScanUnlock()
+	// start a new scan, cancelling any in-progress scan and waiting for it to finish
+	ctx, err := proc.StartScan(context.Background())
+	if err != nil {
+		return fmt.Errorf("starting scan: %w", err)
+	}
+	defer proc.FinishScan()
 
 	// check if process is still active
 	if proc.Exited() {
@@ -95,6 +99,13 @@ func (m *TlsManager) ProcessStarted(proc *process.Process) error {
 
 	// inform all probes
 	for _, p := range m.probes {
+		// check if scan was cancelled
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+
 		if proc.Exited() {
 			return nil
 		}
@@ -110,6 +121,13 @@ func (m *TlsManager) ProcessStarted(proc *process.Process) error {
 	}
 
 	if m.final != nil {
+		// check if scan was cancelled before final observer
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+
 		if err := m.final.ProcessStarted(proc); err != nil {
 			return fmt.Errorf("starting process on final observer: %w", err)
 		}
@@ -119,6 +137,14 @@ func (m *TlsManager) ProcessStarted(proc *process.Process) error {
 }
 
 func (m *TlsManager) ProcessReplaced(proc *process.Process) error {
+	proc.CancelScan() // cancel any in-progress scan
+
+	if m.final != nil {
+		if err := m.final.ProcessReplaced(proc); err != nil {
+			return fmt.Errorf("replacing process on final observer: %w", err)
+		}
+	}
+
 	// inform all probes
 	for _, p := range m.probes {
 		if err := p.ProcessReplaced(proc); err != nil {
@@ -131,8 +157,8 @@ func (m *TlsManager) ProcessReplaced(proc *process.Process) error {
 }
 
 func (m *TlsManager) ProcessStopped(proc *process.Process) error {
-	proc.ScanLock()
-	defer proc.ScanUnlock()
+	// cancel any in-progress scan since the process is stopping
+	proc.CancelScan()
 
 	for _, p := range m.probes {
 		if err := p.ProcessStopped(proc); err != nil {

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -77,17 +77,20 @@ type Process struct {
 	Pod       resolvable.V[*Pod]
 
 	// internal
-	hostname  string
-	filter    uint8
-	elf       *binutils.Elf
-	exited    atomic.Bool
-	tlsOk     bool
-	startTime time.Time
-	mu        sync.Mutex
-	scanMu    sync.Mutex
-	tags      tags.List
-	envTags   []config.EnvTag
-	closers   []io.Closer
+	hostname   string
+	filter     uint8
+	elf        *binutils.Elf
+	exited     atomic.Bool
+	tlsOk      bool
+	startTime  time.Time
+	mu         sync.Mutex
+	scanMu     sync.Mutex
+	scanWg     sync.WaitGroup
+	scanCtx    context.Context
+	scanCancel context.CancelFunc
+	tags       tags.List
+	envTags    []config.EnvTag
+	closers    []io.Closer
 
 	// notifier is called when parts of the process change
 	// that are required to be updated by the eventer for
@@ -457,12 +460,44 @@ func (p *Process) Unlock() {
 	p.mu.Unlock()
 }
 
-func (p *Process) ScanLock() {
+// StartScan cancels any in-progress scan, waits for it to finish, then returns a new context for the current scan.
+// The caller MUST defer FinishScan() to signal completion.
+func (p *Process) StartScan(ctx context.Context) (context.Context, error) {
 	p.scanMu.Lock()
+	defer p.scanMu.Unlock()
+
+	// Cancel any existing scan
+	if p.scanCancel != nil {
+		p.scanCancel()
+	}
+
+	// Wait for the previous scan to fully exit
+	// Note: FinishScan() only calls Done(), which doesn't need the lock,
+	// so the cancelled goroutine can complete even though we hold the lock
+	p.scanWg.Wait()
+
+	// Now start the new scan
+	p.scanWg.Add(1)
+	p.scanCtx, p.scanCancel = context.WithCancel(ctx)
+	return p.scanCtx, nil
 }
 
-func (p *Process) ScanUnlock() {
-	p.scanMu.Unlock()
+// FinishScan signals that the current scan has completed.
+// Must be called (typically via defer) after StartScan.
+func (p *Process) FinishScan() {
+	p.scanWg.Done()
+}
+
+// CancelScan cancels any in-progress scan without waiting
+func (p *Process) CancelScan() {
+	p.scanMu.Lock()
+	defer p.scanMu.Unlock()
+
+	if p.scanCancel != nil {
+		p.scanCancel()
+		p.scanCancel = nil
+		p.scanCtx = nil
+	}
 }
 
 func (p *Process) Tags() tags.List {


### PR DESCRIPTION
Use a bidirectional readiness handshake to wait for processes to finish scanning for TLS and become ready to make HTTP requests. This allows us to remove the fixed startup delay and improves process detection reliability.

1. wait for the container to create the pid file `/tmp/readiness-signal.pid` containing the pid of the process that will be making requests
2. wait for the tls manager to finish scanning said process
3. create the file `/tmp/readiness-signal.ready` which indicates to the container that it may start executing http requests
