### PR TITLE
Update tap direction in default.yaml from 'egress' to 'all'

### DIFF
--- a/pkg/config/default.yaml
+++ b/pkg/config/default.yaml
@@ -14,7 +14,7 @@ stacks:
           format: console
       - type: report_usage
 tap:
-  direction: egress
+  direction: all
   ignore_loopback: true
   audit_include_dns: false
   http:


### PR DESCRIPTION
We support ingress, why not show it off by default! 😎 

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Contributing Guide: https://github.com/qpoint-io/qtap/docs/CONTRIBUTING.md
     - 📖 Read the Contributor License Agreement (CLA): https://github.com/qpoint-io/qtap/docs/CLA.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Qpoint Team member.
-->
