### PR TITLE
Allow operators to attach custom tags from various sources

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -80,8 +80,15 @@ type Config struct {
 	Stacks   map[string]Stack `yaml:"stacks" validate:"dive"`
 	Tap      *TapConfig       `yaml:"tap"`
 	Services Services         `yaml:"services"`
+	Tags     []Tag            `yaml:"tags" validate:"omitempty,dive"`
 	Control  *Control         `yaml:"control"`
 	Rulekit  *Rulekit         `yaml:"rulekit"`
+}
+
+type Tag struct {
+	Key      string `yaml:"key" validate:"required"`
+	Source   string `yaml:"source" validate:"required,oneof=env k8s.label k8s.annotation container.label"`
+	Location string `yaml:"location" validate:"required"`
 }
 
 type Control struct {

--- a/pkg/config/tap.go
+++ b/pkg/config/tap.go
@@ -23,11 +23,6 @@ type TapEndpointConfig struct {
 	Http   TapHttpConfig `yaml:"http"`
 }
 
-type EnvTag struct {
-	Env string `yaml:"env"`
-	Key string `yaml:"key"`
-}
-
 type TapConfig struct {
 	Direction       TrafficDirection    `yaml:"direction"`
 	IgnoreLoopback  bool                `yaml:"ignore_loopback"`
@@ -35,7 +30,6 @@ type TapConfig struct {
 	Http            TapHttpConfig       `yaml:"http"`
 	Filters         TapFilters          `yaml:"filters,omitempty"`
 	Endpoints       []TapEndpointConfig `yaml:"endpoints" validate:"dive"`
-	EnvTags         []EnvTag            `yaml:"env_tags,omitempty"`
 }
 
 func (c *TapConfig) HasAnyStack() bool {

--- a/pkg/connection/connection_test.go
+++ b/pkg/connection/connection_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/qpoint-io/qtap/pkg/tlsutils"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 )
 
@@ -274,7 +275,7 @@ func TestValidatePort(t *testing.T) {
 }
 
 func TestConnection_ControlValues(t *testing.T) {
-	proc := process.NewProcess(0, "")
+	proc := process.NewProcess(0, "", zap.NewNop())
 
 	proc.SetUser(1000, "testuser")
 	proc.SetHostname("testhost")

--- a/pkg/ebpf/process/reader.go
+++ b/pkg/ebpf/process/reader.go
@@ -65,7 +65,7 @@ func (m *Manager) handleExecStartEvent(r *bytes.Reader) error {
 
 	if m.reciever != nil {
 		// create process
-		p := process.NewProcess(int(e.Pid), exe)
+		p := process.NewProcess(int(e.Pid), exe, m.logger)
 
 		// set the notifier so the process can indicate when it's changed
 		// and when we should collect data for the ebpf meta map

--- a/pkg/ebpf/process/reader_test.go
+++ b/pkg/ebpf/process/reader_test.go
@@ -140,7 +140,7 @@ func TestHandleExecArgvEvent(t *testing.T) {
 
 			// Setup process in cache if needed
 			if tt.setupPid {
-				p := process.NewProcess(int(tt.pid), "/test/exe")
+				p := process.NewProcess(int(tt.pid), "/test/exe", zap.NewNop())
 				p.Args = make([]string, 0) // Initialize Args slice
 				m.cache.Add(tt.pid, p)
 			}
@@ -226,7 +226,7 @@ func TestHandleExecEndEvent(t *testing.T) {
 
 			// Setup process in cache if needed
 			if tt.setupPid {
-				m.cache.Add(tt.pid, process.NewProcess(int(tt.pid), "/test/exe"))
+				m.cache.Add(tt.pid, process.NewProcess(int(tt.pid), "/test/exe", zap.NewNop()))
 			}
 
 			// Test handler

--- a/pkg/process/manager.go
+++ b/pkg/process/manager.go
@@ -40,12 +40,11 @@ type Manager struct {
 	// observers
 	Observers []Observer
 
-	// env mask
+	// env variable mask
 	envMask *synq.Map[string, bool]
 
-	// env tags maps env var keys to tags for setting those tags
-	// with the value of the env var
-	envTags []config.EnvTag
+	// custom tags pulled from the environment (env, k8s.label, k8s.annotation, container.label)
+	envTags []config.Tag
 
 	// internal
 	mu    sync.Mutex
@@ -159,17 +158,22 @@ func (m *Manager) SetConfig(cfg *config.Config) {
 	defer m.mu.Unlock()
 
 	// remove the old env tags from the env mask
-	for _, old := range m.envTags {
-		m.envMask.Delete(old.Env)
+	for _, tag := range m.envTags {
+		m.envMask.Delete(tag.Key)
 	}
 
-	if cfg != nil && cfg.Tap != nil {
-		m.envTags = cfg.Tap.EnvTags
+	// add the new env tags to the env mask
+	if cfg != nil && cfg.Tags != nil {
+		for _, tag := range cfg.Tags {
+			if tag.Source == "env" {
+				m.envTags = append(m.envTags, tag)
+			}
+		}
 	}
 
 	// set the env tags in the env mask
-	for _, envTag := range m.envTags {
-		m.envMask.Store(envTag.Env, true)
+	for _, tag := range m.envTags {
+		m.envMask.Store(tag.Key, true)
 	}
 
 	// update the filters
@@ -183,7 +187,7 @@ func (m *Manager) Stop() error {
 
 func (m *Manager) preloadProcs() error {
 	// load all of the procs
-	snap, err := AllProcesses()
+	snap, err := AllProcesses(m.Logger)
 	if err != nil {
 		return fmt.Errorf("reading processes: %w", err)
 	}

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -77,6 +77,7 @@ type Process struct {
 	Pod       resolvable.V[*Pod]
 
 	// internal
+	logger     *zap.Logger
 	hostname   string
 	filter     uint8
 	elf        *binutils.Elf
@@ -89,7 +90,7 @@ type Process struct {
 	scanCtx    context.Context
 	scanCancel context.CancelFunc
 	tags       tags.List
-	envTags    []config.EnvTag
+	envTags    []config.Tag
 	closers    []io.Closer
 
 	// notifier is called when parts of the process change
@@ -101,15 +102,15 @@ type Process struct {
 	notifier func() error
 }
 
-func NewProcess(pid int, exeFilename string) *Process {
+func NewProcess(pid int, exeFilename string, logger *zap.Logger) *Process {
 	p := &Process{
 		Pid:         pid,
 		PidExe:      fmt.Sprintf("/proc/%d/exe", pid),
 		ExeFilename: exeFilename,
 		startTime:   time.Now(),
-		tags:        tags.New(),
 		Container:   resolvable.Static[*Container](nil).WithBackgroundContext(),
 		Pod:         resolvable.Static[*Pod](nil).WithBackgroundContext(),
+		logger:      logger,
 	}
 	p.User = resolvable.New(func(context.Context) (*ProcessUser, error) {
 		return GetProcessUser(p.Pid)
@@ -127,7 +128,7 @@ func NewProcess(pid int, exeFilename string) *Process {
 	return p
 }
 
-func AllProcesses() ([]*Process, error) {
+func AllProcesses(logger *zap.Logger) ([]*Process, error) {
 	ps, err := AllProcs("/proc")
 	if err != nil {
 		return nil, fmt.Errorf("reading /proc: %w", err)
@@ -147,7 +148,7 @@ func AllProcesses() ([]*Process, error) {
 			continue
 		}
 
-		procs = append(procs, NewProcess(int(p), ""))
+		procs = append(procs, NewProcess(int(p), "", logger))
 	}
 
 	return procs, nil
@@ -254,22 +255,6 @@ func (p *Process) Discover(mountPoint string, envMask *synq.Map[string, bool]) e
 		strategy = StrategyObserve
 	}
 	p.Strategy = strategy
-
-	if v, ok := p.Env[QpointTagsEnvVar]; ok {
-		ts := strings.Split(v, ",")
-		for _, t := range ts {
-			if err := p.tags.AddString(t); err != nil {
-				zap.L().Warn("failed to add tag", zap.String("tag", t), zap.Error(err))
-			}
-		}
-	}
-
-	// check for env tags
-	for _, t := range p.envTags {
-		if v, ok := p.Env[t.Env]; ok {
-			p.tags.Add(t.Key, v)
-		}
-	}
 
 	// notify the eventer that the process has changed
 	if p.notifier != nil {
@@ -500,7 +485,66 @@ func (p *Process) CancelScan() {
 }
 
 func (p *Process) Tags() tags.List {
+	if p.tags == nil {
+		// initialize the tag list
+		p.tags = tags.New()
+
+		// discover the tags
+		if err := p.discoverTags(); err != nil {
+			p.logger.Error("failed to discover tags", zap.Error(err))
+		}
+	}
+
+	// return a clone of the tag list
 	return p.tags.Clone()
+}
+
+func (p *Process) discoverTags() error {
+	// look for any custom tags in the QPOINT_TAGS environment variable
+	if v, ok := p.Env[QpointTagsEnvVar]; ok {
+		ts := strings.Split(v, ",")
+		for _, t := range ts {
+			if err := p.tags.AddString(t); err != nil {
+				return fmt.Errorf("adding tag from QPOINT_TAGS environment variable: %w", err)
+			}
+		}
+	}
+
+	// check the environment for tags
+	for _, t := range p.envTags {
+		switch t.Source {
+		case "env":
+			if v, ok := p.Env[t.Location]; ok {
+				p.tags.Add(t.Key, v)
+			}
+		case "k8s.label":
+			if pod, _ := p.Pod(); pod != nil {
+				for k, v := range pod.Labels {
+					if k == t.Location {
+						p.tags.Add(t.Key, v)
+					}
+				}
+			}
+		case "k8s.annotation":
+			if pod, _ := p.Pod(); pod != nil {
+				for k, v := range pod.Annotations {
+					if k == t.Location {
+						p.tags.Add(t.Key, v)
+					}
+				}
+			}
+		case "container.label":
+			if container, _ := p.Container(); container != nil {
+				for k, v := range container.Labels {
+					if k == t.Location {
+						p.tags.Add(t.Key, v)
+					}
+				}
+			}
+		}
+	}
+
+	return nil
 }
 
 // getRootID returns the unique identifier of the process' root filesystem


### PR DESCRIPTION
This PR enables operators to declare where Qtap can find their metadata from the running environment.

Supports:
- environment variables
- kubernetes labels
- kubernetes annotations
- container labels

```
tags:
  - key: app
    source: env
    location: APP
  - key: team
    source: k8s.label
    location: team
  ...
```
