### PR TITLE
Fix tags <-> env mask mapping and container verification

### DIFF
--- a/pkg/container/containerd.go
+++ b/pkg/container/containerd.go
@@ -40,8 +40,12 @@ func NewContainerdAccessor(logger *zap.Logger, endpoint string) (*Containerd, er
 	}
 
 	// check if the endpoint exists and is a socket
-	if _, err := os.Stat(endpoint); err != nil {
-		return nil, fmt.Errorf("endpoint %s does not exist or is not a socket: %w", endpoint, err)
+	info, err := os.Stat(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("endpoint %s does not exist: %w", endpoint, err)
+	}
+	if info.Mode()&os.ModeSocket == 0 {
+		return nil, fmt.Errorf("endpoint %s is not a socket", endpoint)
 	}
 
 	// create global client

--- a/pkg/container/docker.go
+++ b/pkg/container/docker.go
@@ -49,9 +49,16 @@ func NewDockerAccessor(logger *zap.Logger, endpoint string) (*docker, error) {
 		client.WithAPIVersionNegotiation(),
 	}
 
-	// check if the endpoint exists and is a socket
-	if _, err := os.Stat(endpoint); err != nil {
-		return nil, fmt.Errorf("endpoint %s does not exist or is not a socket: %w", endpoint, err)
+	// if a unix socket is provided, check if the endpoint exists and is a socket
+	if strings.HasPrefix(endpoint, "unix://") {
+		filepath := strings.TrimPrefix(endpoint, "unix://")
+		info, err := os.Stat(filepath)
+		if err != nil {
+			return nil, fmt.Errorf("endpoint %s does not exist: %w", filepath, err)
+		}
+		if info.Mode()&os.ModeSocket == 0 {
+			return nil, fmt.Errorf("endpoint %s is not a socket", filepath)
+		}
 	}
 
 	if endpoint != "" {

--- a/pkg/container/kubernetes.go
+++ b/pkg/container/kubernetes.go
@@ -38,14 +38,21 @@ type KubernetesAccessor struct {
 }
 
 func NewKubernetesAccessor(logger *zap.Logger, criRuntimeEndpoint string) (*KubernetesAccessor, string, []error) {
+	// if a unix socket is provided, check if the endpoint exists and is a socket
+	if strings.HasPrefix(criRuntimeEndpoint, "unix://") {
+		filepath := strings.TrimPrefix(criRuntimeEndpoint, "unix://")
+		info, err := os.Stat(filepath)
+		if err != nil {
+			return nil, "", []error{fmt.Errorf("endpoint %s does not exist: %w", filepath, err)}
+		}
+		if info.Mode()&os.ModeSocket == 0 {
+			return nil, "", []error{fmt.Errorf("endpoint %s is not a socket", filepath)}
+		}
+	}
+
 	rs, endpoint, errs := getRuntimeService(logger, criRuntimeEndpoint)
 	if len(errs) > 0 {
 		return nil, "", errs
-	}
-
-	// verify the endpoint exists and is a socket
-	if _, err := os.Stat(endpoint); err != nil {
-		return nil, "", []error{fmt.Errorf("endpoint %s does not exist or is not a socket: %w", endpoint, err)}
 	}
 
 	podCache := expirable.NewLRU[string, *podCacheEntry](podCacheSize, nil, podCacheTTL)

--- a/pkg/process/manager.go
+++ b/pkg/process/manager.go
@@ -60,6 +60,7 @@ func NewProcessManager(logger *zap.Logger, procEventer Eventer) *Manager {
 		procs:          synq.NewMap[int, *Process](),
 		envMask:        synq.NewMap[string, bool](),
 		processWaiters: make(map[int][]chan *Process),
+		envTags:        make([]config.Tag, 0),
 	}
 
 	if procEventer != nil {
@@ -162,19 +163,21 @@ func (m *Manager) SetConfig(cfg *config.Config) {
 		m.envMask.Delete(tag.Key)
 	}
 
+	// nothing to do if we don't have any tag configs
+	if cfg == nil || cfg.Tags == nil {
+		m.envTags = make([]config.Tag, 0)
+		return
+	}
+
 	// add the new env tags to the env mask
-	if cfg != nil && cfg.Tags != nil {
-		for _, tag := range cfg.Tags {
-			if tag.Source == "env" {
-				m.envTags = append(m.envTags, tag)
-			}
+	for _, tag := range cfg.Tags {
+		if tag.Source == "env" {
+			m.envMask.Store(tag.Location, true)
 		}
 	}
 
-	// set the env tags in the env mask
-	for _, tag := range m.envTags {
-		m.envMask.Store(tag.Key, true)
-	}
+	// set the new env tags
+	m.envTags = cfg.Tags
 
 	// update the filters
 	m.updateFilters(cfg)


### PR DESCRIPTION
This PR does a few things:

1 - Cleans up the env mask process to clarify the logic
2 - Uses the correct field to access environment variables as custom tags
3 - Fixes an unrelated issue with the container manager socket verification process
