### PR TITLE
access logs: updated output styling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,14 @@ go 1.25.3
 require (
 	github.com/andybalholm/brotli v1.1.1
 	github.com/axiomhq/axiom-go v0.23.3
+	github.com/charmbracelet/glamour v0.8.0
+	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/cilium/ebpf v0.16.0
 	github.com/containerd/containerd/api v1.9.0
 	github.com/containerd/containerd/v2 v2.1.1
 	github.com/containerd/typeurl/v2 v2.2.3
 	github.com/docker/docker v28.4.0+incompatible
+	github.com/dustin/go-humanize v1.0.1
 	github.com/fatih/color v1.18.0
 	github.com/go-playground/validator/v10 v10.23.0
 	github.com/gopacket/gopacket v1.3.1
@@ -93,9 +96,7 @@ require (
 	github.com/charmbracelet/bubbles v0.20.0 // indirect
 	github.com/charmbracelet/bubbletea v1.3.4 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
-	github.com/charmbracelet/glamour v0.8.0 // indirect
 	github.com/charmbracelet/gum v0.16.0 // indirect
-	github.com/charmbracelet/lipgloss v1.1.0 // indirect
 	github.com/charmbracelet/log v0.4.0 // indirect
 	github.com/charmbracelet/x/ansi v0.8.0 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
@@ -127,7 +128,6 @@ require (
 	github.com/dnephin/pflag v1.0.7 // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
-	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/ebitengine/purego v0.8.4 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/ettle/strcase v0.2.0 // indirect

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -7,8 +7,10 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 	"unicode"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/qpoint-io/qtap/pkg/buildinfo"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
@@ -54,6 +56,9 @@ var (
 			runTapCmd(logger)
 		},
 	}
+
+	colorMuted = lipgloss.AdaptiveColor{Light: "#b0b0b0", Dark: "#737373"}
+	muteText   = lipgloss.NewStyle().Foreground(colorMuted).Render
 )
 
 func Execute() error {
@@ -138,7 +143,7 @@ func initLogger() *zap.Logger {
 
 	if strings.EqualFold(logEncoding, "console") {
 		cfg.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
-		cfg.EncoderConfig.EncodeTime = zapcore.TimeEncoderOfLayout("2006-01-02 15:04:05.000")
+		cfg.EncoderConfig.EncodeTime = consoleTimeEncoder
 	}
 
 	if cfg.Level.Level() == zapcore.DebugLevel {
@@ -155,6 +160,10 @@ func initLogger() *zap.Logger {
 	zap.ReplaceGlobals(l)
 
 	return l
+}
+
+func consoleTimeEncoder(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
+	enc.AppendString(muteText(t.Format("2006-01-02 15:04:05.000")))
 }
 
 func syncLogger(logger *zap.Logger) {

--- a/pkg/plugins/accesslogs/console.go
+++ b/pkg/plugins/accesslogs/console.go
@@ -27,7 +27,6 @@ var (
 	labelStyle      = lipgloss.NewStyle().Foreground(colorMuted)
 	valueStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("255"))
 	subsectionStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("117")).Bold(true)
-	boldStyle       = lipgloss.NewStyle().Bold(true)
 )
 
 // ConsolePrinter implements the Printer interface for console output
@@ -413,10 +412,6 @@ func bulletPoint(key, value string) string {
 		key += ": "
 	}
 	return labelStyle.Render("  • "+key) + valueStyle.Render(value) + "\n"
-}
-
-func joinPath(host, path string) string {
-	return strings.TrimSuffix(host, "/") + "/" + strings.TrimPrefix(path, "/")
 }
 
 func highlightCode(language, code string) (string, error) {

--- a/pkg/plugins/accesslogs/console.go
+++ b/pkg/plugins/accesslogs/console.go
@@ -3,13 +3,31 @@ package accesslogs
 import (
 	"fmt"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
+	"github.com/charmbracelet/glamour"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/dustin/go-humanize"
 	"github.com/fatih/color"
 	"github.com/qpoint-io/qtap/pkg/plugins"
 	"github.com/qpoint-io/qtap/pkg/plugins/tools"
 	"go.uber.org/zap"
+	"golang.org/x/term"
+)
+
+var (
+	borderWidthCap = 50
+
+	bodyStartToken  = "cc4f6a29-ba6d-488b-9cd4-a2656bc4d07f"
+	bodyEndToken    = "1afc4ffd-340c-4d7d-8972-fde4261b4569"
+	colorMuted      = lipgloss.AdaptiveColor{Light: "#b0b0b0", Dark: "#737373"}
+	labelStyle      = lipgloss.NewStyle().Foreground(colorMuted)
+	valueStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("255"))
+	subsectionStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("117")).Bold(true)
+	boldStyle       = lipgloss.NewStyle().Bold(true)
 )
 
 // ConsolePrinter implements the Printer interface for console output
@@ -54,7 +72,8 @@ func (c *ConsolePrinter) PrintSummary() {
 	resHeaders := tools.NewHeaderMap(c.resheaders)
 	status, _ := resHeaders.Status()
 
-	fmt.Fprintln(accessLogsWriter, summary(bin, direction, method, url, status))
+	summaryLine := " " + buildSummary(bin, direction, method, url, status)
+	fmt.Fprintln(accessLogsWriter, summaryLine)
 }
 
 // PrintDetails implements Printer.PrintDetails
@@ -69,162 +88,297 @@ func (c *ConsolePrinter) PrintFull() error {
 
 func (c *ConsolePrinter) printConsoleDetails(includeBody bool) error {
 	meta := c.ctx.Meta()
+
 	reqHeaders := tools.NewHeaderMap(c.reqheaders)
 	url, _ := reqHeaders.URL()
 	method, _ := reqHeaders.Method()
-	host, _ := reqHeaders.Authority()
-	protocol := meta.Protocol()
-	direction := meta.Direction()
-	var bin string
-
-	mp := map[string]string{
-		"direction": direction,
-		"wr_bytes":  strconv.FormatInt(meta.WriteBytes(), 10),
-		"rd_bytes":  strconv.FormatInt(meta.ReadBytes(), 10),
-	}
-
-	if p := meta.Process(); p != nil {
-		bin = p.Exe
-		mp["pid"] = strconv.Itoa(p.Pid)
-		mp["exe"] = p.Exe
-		if c, _ := p.Container(); c != nil {
-			mp["container_name"] = c.Name
-			mp["container_image"] = c.Image
-		}
-		if p, _ := p.Pod(); p != nil {
-			mp["pod_name"] = p.Name
-			mp["pod_namespace"] = p.Namespace
-		}
-	}
-
+	// host, _ := reqHeaders.Authority()
+	path, _ := reqHeaders.Path()
 	resHeaders := tools.NewHeaderMap(c.resheaders)
 	status, _ := resHeaders.Status()
 
-	var sb strings.Builder
+	protocol := meta.Protocol()
+	direction := meta.Direction()
 
-	sb.WriteString(header(summary(bin, direction, method, url, status)))
-	sb.WriteString(printMeta(mp))
-	sb.WriteString(printRequest(method, host, protocol, c.reqheaders.All()))
-	if includeBody {
-		sb.WriteString("\n------------------ REQUEST BODY ------------------\n")
-		if reqHeaders.BinaryContentType() {
-			sb.WriteString("Body is in binary format\n")
-		} else {
-			if c.ctx.GetRequestBodyBuffer().Length() > 0 {
-				sb.Write(c.ctx.GetRequestBodyBuffer().Copy())
-			} else {
-				sb.WriteString("(empty)\n")
-			}
-		}
-	}
-	var respHeaders map[string]string
-	if c.resheaders != nil {
-		respHeaders = c.resheaders.All()
-	}
-	sb.WriteString(printResponse(status, respHeaders))
-	if includeBody {
-		sb.WriteString("\n------------------ RESPONSE BODY ------------------\n")
-		if resHeaders.BinaryContentType() {
-			sb.WriteString("Body is in binary format\n")
-		} else {
-			if c.ctx.GetResponseBodyBuffer().Length() > 0 {
-				sb.Write(c.ctx.GetResponseBodyBuffer().Copy())
-			} else {
-				sb.WriteString("(empty)\n")
-			}
-		}
+	var bin string
+	if p := meta.Process(); p != nil {
+		bin = p.Exe
 	}
 
-	fmt.Fprintln(accessLogsWriter, sb.String())
+	// Build manual border at terminal width
+	termWidth := terminalWidth()
+	borderWidth := termWidth - 2 // Account for left/right border chars
+	if borderWidth < 0 {
+		borderWidth = 0
+	} else if borderWidth > borderWidthCap {
+		borderWidth = borderWidthCap
+	}
+	statusColor := getStatusColor(status)
+	borderStyle := lipgloss.NewStyle().Foreground(statusColor)
+	leftBorder := borderStyle.Render("│")
+	paddedLeftBorder := leftBorder + "  "
 
+	// Build sections
+	var output strings.Builder
+
+	/*
+		top border
+	*/
+	output.WriteString(borderStyle.Render("╭"+strings.Repeat("─", borderWidth)+"┄") + "\n")
+
+	/*
+		summary
+	*/
+	output.WriteString(prefixLines(buildSummary(bin, direction, method, url, status), paddedLeftBorder) + "\n")
+
+	/*
+		meta
+	*/
+	output.WriteString(buildSectionDivider(statusColor, "", borderWidth) + "\n")
+	output.WriteString(prefixLines(buildMetaContent(meta), paddedLeftBorder) + "\n")
+
+	/*
+		request
+	*/
+	output.WriteString(buildSectionDivider(statusColor, "REQUEST "+color.New(color.Reset).Sprint(protocol), borderWidth) + "\n")
+	writeReqResSections(&output, leftBorder, "  ", "\n"+subsectionStyle.Render(method)+" "+path)
+	writeReqResSections(&output, leftBorder, "  ", buildReqResContent(c.ctx.GetRequestBodyBuffer(), includeBody, reqHeaders))
+
+	/*
+		response
+	*/
+	responseTitle := "RESPONSE " + color.New(color.Reset).Sprint(fmt.Sprintf("%d %s", status, http.StatusText(status)))
+	output.WriteString(buildSectionDivider(statusColor, responseTitle, borderWidth) + "\n")
+	writeReqResSections(&output, leftBorder, "  ", buildReqResContent(c.ctx.GetResponseBodyBuffer(), includeBody, resHeaders))
+
+	/*
+		bottom border
+	*/
+	output.WriteString(borderStyle.Render("╰" + strings.Repeat("─", borderWidth) + "┄"))
+
+	fmt.Fprintln(accessLogsWriter, output.String())
 	return nil
 }
 
-func summary(cmd, direction, method, url string, status int) string {
+func writeReqResSections(output *strings.Builder, leftBorder, padding, content string) {
+	lines := strings.Split(content, "\n")
+	printBorder := true
+	for _, line := range lines {
+		if line == bodyStartToken {
+			printBorder = false
+			continue
+		}
+		if line == bodyEndToken {
+			printBorder = true
+			continue
+		}
+		if printBorder {
+			line = leftBorder + padding + line
+		}
+		output.WriteString(line + "\n")
+	}
+}
+
+// buildSummary creates the summary line with colored status
+func buildSummary(cmd, direction, method, url string, status int) string {
 	fn := getColorFn(status)
-	return fmt.Sprintf("%s %s %s %s %s %s %s", fn("■"), cmd, arrow(direction), method, url, fn(status), fn(http.StatusText(status)))
+	shortCmd := filepath.Base(cmd)
+
+	arrow := "→"
+	if !strings.Contains(direction, "egress") {
+		arrow = "←"
+	}
+	arrow = fn(arrow)
+
+	method = lipgloss.NewStyle().Bold(true).Render(method)
+	summary := fmt.Sprintf("%s %s %s %s %s %s %s",
+		fn("■"), shortCmd, arrow, method, url, fn(status), fn(http.StatusText(status)))
+
+	return summary
 }
 
-func header(summary string) string {
-	// generate a band
-	band := strings.Repeat("=", len(summary))
+// buildSectionDivider creates a horizontal divider with section title
+func buildSectionDivider(color lipgloss.Color, title string, width int) string {
+	titleStyle := lipgloss.NewStyle().Foreground(color).Bold(true)
 
-	// put them together
-	return fmt.Sprintf("\n%s\n%s\n%s\n", band, summary, band)
-}
-
-func arrow(direction string) string {
-	if strings.Contains(direction, "egress") {
-		return "→"
+	if width < 0 {
+		width = 0
 	}
 
-	return "←"
+	if title == "" {
+		return titleStyle.Render("├" + strings.Repeat("─", width) + "┄")
+	}
+
+	titleLeft := "├───╼ " + title
+	titleWidth := lipgloss.Width(titleLeft)
+
+	remainingWidth := width - titleWidth
+	if remainingWidth < 0 {
+		remainingWidth = 0
+	}
+	var titleRight string
+	switch {
+	case remainingWidth < 2:
+	case remainingWidth == 2:
+		titleRight = " ╾"
+	case remainingWidth > 2:
+		titleRight = " ╾" + strings.Repeat("─", remainingWidth-1) + "┄"
+	}
+
+	return titleStyle.Render(titleLeft) + titleStyle.Render(titleRight)
 }
 
-func printMeta(meta map[string]string) string {
+// buildMetaContent creates the META section content
+func buildMetaContent(meta plugins.Meta) string {
 	var sb strings.Builder
+	sb.WriteString("\n")
 
-	sb.WriteString("\n------------------ META ------------------\n")
-	fmt.Fprintf(&sb, "PID: %s\n", meta["pid"])
-	fmt.Fprintf(&sb, "Exe: %s\n", meta["exe"])
-	if cname := meta["container_name"]; cname != "" && cname != "<nil>" {
-		fmt.Fprintf(&sb, "Container Name: %s\n", cname)
-	}
-	if cimage := meta["container_image"]; cimage != "" && cimage != "<nil>" {
-		fmt.Fprintf(&sb, "Container Image: %s\n", cimage)
-	}
-	if pname := meta["pod_name"]; pname != "" && pname != "<nil>" {
-		fmt.Fprintf(&sb, "Pod Name: %s\n", pname)
-	}
-	if pnamespace := meta["pod_namespace"]; pnamespace != "" && pnamespace != "<nil>" {
-		fmt.Fprintf(&sb, "Pod Namespace: %s\n", pnamespace)
-	}
+	sb.WriteString(subsectionStyle.Render("Process") + "\n")
+	if p := meta.Process(); p != nil {
+		sb.WriteString(bulletPoint(
+			"",
+			labelStyle.Render("PID ")+valueStyle.Render(strconv.Itoa(p.Pid))+
+				labelStyle.Render(" @ ")+valueStyle.Render(p.Exe),
+		))
 
-	fmt.Fprintf(&sb, "Direction: %s\n", meta["direction"])
-	fmt.Fprintf(&sb, "Bytes Sent: %s\n", meta["wr_bytes"])
-	fmt.Fprintf(&sb, "Bytes Received: %s\n", meta["rd_bytes"])
-
-	return sb.String()
-}
-
-func printRequest(method, url, proto string, headers map[string]string) string {
-	var sb strings.Builder
-
-	sb.WriteString("\n------------------ REQUEST ------------------\n")
-	fmt.Fprintf(&sb, "%s %s %s\n", method, url, proto)
-	// print headers
-	if headers != nil {
-		for key, value := range headers {
-			sb.WriteString(key)
-			sb.WriteString(": ")
-			sb.WriteString(value)
-			sb.WriteString("\n")
+		if c, _ := p.Container(); c != nil {
+			sb.WriteString(bulletPoint("Container", c.Name))
+			sb.WriteString(bulletPoint("Image", c.Image))
 		}
-	} else {
-		sb.WriteString("(empty)\n")
+		if p, _ := p.Pod(); p != nil {
+			sb.WriteString(bulletPoint("Pod", p.Name))
+			sb.WriteString(bulletPoint("Namespace", p.Namespace))
+		}
+	}
+	sb.WriteString("\n")
+
+	sb.WriteString(subsectionStyle.Render("Network") + "\n")
+	var (
+		arrow     string
+		direction string
+	)
+	switch meta.Direction() {
+	case "ingress":
+		direction = "Ingress"
+		arrow = "←"
+	case "egress":
+		direction = "Egress"
+		arrow = "→"
+	case "egress-internal":
+		direction = "Egress (internal)"
+		arrow = "→"
+	case "egress-external":
+		direction = "Egress (external)"
+		arrow = "→"
+	}
+	sb.WriteString("  " + labelStyle.Render(arrow) + " " + valueStyle.Render(direction) + "\n")
+	wrBytes := humanize.Bytes(uint64(meta.WriteBytes()))
+	rdBytes := humanize.Bytes(uint64(meta.ReadBytes()))
+	sb.WriteString(
+		labelStyle.Render("  ↑ ") + valueStyle.Render(wrBytes) + labelStyle.Render(" sent") +
+			labelStyle.Render("   ↓ ") + valueStyle.Render(rdBytes) + labelStyle.Render(" received") +
+			"\n",
+	)
+
+	return sb.String()
+}
+
+// buildResponseContent creates the REQUEST or RESPONSE section contents
+func buildReqResContent(body plugins.BodyBuffer, includeBody bool, headers *tools.HeaderMap) string {
+	var sb strings.Builder
+	sb.WriteString("\n")
+
+	printHeaders(&sb, filterHeaders(headers.All()))
+
+	// Body
+	if includeBody {
+		sb.WriteString("\n")
+		sb.WriteString(subsectionStyle.Render("Body") + "\n")
+		contentType, _ := headers.ContentType()
+		if headers.BinaryContentType() {
+			body := "  Body is in binary format"
+			if contentType != "" {
+				body += " (" + contentType + ")"
+			}
+			sb.WriteString(labelStyle.Render(body) + "\n")
+		} else {
+			if body.Length() == 0 {
+				sb.WriteString(labelStyle.Render("  (empty)") + "\n")
+			} else {
+				printBody(&sb, contentType, body.Copy())
+			}
+		}
 	}
 
 	return sb.String()
 }
 
-func printResponse(status int, headers map[string]string) string {
-	var sb strings.Builder
-
-	sb.WriteString("\n------------------ RESPONSE ------------------\n")
-	fmt.Fprintf(&sb, "%d %s\n", status, http.StatusText(status))
-	// print headers
-	if headers != nil {
-		for key, value := range headers {
-			sb.WriteString(key)
-			sb.WriteString(": ")
-			sb.WriteString(value)
-			sb.WriteString("\n")
-		}
-	} else {
-		sb.WriteString("(empty)\n")
+func printHeaders(sb *strings.Builder, headers map[string]string) {
+	if len(headers) == 0 {
+		return
 	}
 
-	return sb.String()
+	sb.WriteString(subsectionStyle.Render("Headers") + "\n")
+	for key, value := range headers {
+		sb.WriteString(labelStyle.Render("  • "+key+": ") + valueStyle.Render(value) + "\n")
+	}
+}
+
+func printBody(sb *strings.Builder, contentType string, body []byte) {
+	sb.WriteString(bodyStartToken + "\n")
+
+	for prefix, language := range map[string]string{
+		"application/json":       "json",
+		"text/json":              "json",
+		"text/yaml":              "yaml",
+		"application/yaml":       "yaml",
+		"text/javascript":        "javascript",
+		"application/javascript": "javascript",
+		"text/html":              "html",
+		"text/css":               "css",
+		"application/css":        "css",
+	} {
+		if strings.HasPrefix(contentType, prefix) {
+			if res, err := highlightCode(language, string(body)); err == nil {
+				body = []byte(res)
+			}
+			break
+		}
+	}
+
+	sb.Write(body)
+	if !strings.HasSuffix(string(body), "\n") {
+		sb.WriteString("\n")
+	}
+
+	sb.WriteString(bodyEndToken)
+}
+
+func filterHeaders(headers map[string]string) map[string]string {
+	clean := make(map[string]string)
+	for k, v := range headers {
+		if strings.HasPrefix(k, ":") {
+			continue
+		}
+		clean[k] = v
+	}
+	return clean
+}
+
+// getStatusColor returns lipgloss color based on HTTP status
+func getStatusColor(status int) lipgloss.Color {
+	switch {
+	case status >= 200 && status < 300:
+		return lipgloss.Color("2") // Green
+	case status >= 300 && status < 400:
+		return lipgloss.Color("4") // Blue
+	case status >= 400 && status < 500:
+		return lipgloss.Color("3") // Yellow
+	case status >= 500:
+		return lipgloss.Color("1") // Red
+	default:
+		return lipgloss.Color("7") // White
+	}
 }
 
 func getColorFn(status int) func(a ...interface{}) string {
@@ -240,4 +394,43 @@ func getColorFn(status int) func(a ...interface{}) string {
 	default:
 		return color.New(color.FgWhite).SprintFunc()
 	}
+}
+
+func terminalWidth() int {
+	termWidth := 80 // Default width
+	if width, _, err := term.GetSize(int(os.Stdout.Fd())); err == nil {
+		termWidth = width
+	}
+	return termWidth
+}
+
+func prefixLines(text string, prefix string) string {
+	return prefix + strings.ReplaceAll(text, "\n", "\n"+prefix)
+}
+
+func bulletPoint(key, value string) string {
+	if key != "" {
+		key += ": "
+	}
+	return labelStyle.Render("  • "+key) + valueStyle.Render(value) + "\n"
+}
+
+func joinPath(host, path string) string {
+	return strings.TrimSuffix(host, "/") + "/" + strings.TrimPrefix(path, "/")
+}
+
+func highlightCode(language, code string) (string, error) {
+	renderer, err := glamour.NewTermRenderer(
+		glamour.WithAutoStyle(),
+		glamour.WithWordWrap(0),
+	)
+	if err != nil {
+		return "", fmt.Errorf("unable to create renderer: %w", err)
+	}
+	output, err := renderer.Render(fmt.Sprintf("```%s\n%s\n```", language, strings.TrimSpace(code)))
+	if err != nil {
+		return "", fmt.Errorf("unable to render: %w", err)
+	}
+	output = strings.TrimSpace(output)
+	return output, nil
 }

--- a/pkg/plugins/tools/txs.go
+++ b/pkg/plugins/tools/txs.go
@@ -121,6 +121,10 @@ func (h HeaderMap) URL() (string, bool) {
 	return buildAuthorityURL(s, a, p)
 }
 
+func (h HeaderMap) All() map[string]string {
+	return h.headers.All()
+}
+
 func (h HeaderMap) RulePairs() map[string]any {
 	if h.headers == nil {
 		return nil


### PR DESCRIPTION
<img width="1508" height="1335" alt="image" src="https://github.com/user-attachments/assets/0eb69be2-aecc-458f-8c9c-2b4f18d3cb69" />

more screenshots:
* <details>
    <summary>details log level</summary>
  <img width="1508" height="1335" alt="image" src="https://github.com/user-attachments/assets/779dced5-ffe5-410b-80fc-cb001cf179d2" />
  </details>

* <details>
    <summary>summary log level</summary>
  <img width="1000" height="566" alt="image" src="https://github.com/user-attachments/assets/e7c39377-574f-4e2f-9ab9-7a72072e6c4c" />
  </details>

global updates:
* timestamps are now muted (in color)

access_logs plugin updates:
* use unicode table chars to print a container for requests
* general cleanup + rearranging of things
* syntax highlighting for json, yaml, html, css, javascript based on the content-type header
* human-readable units for network traffic