### PR TITLE
eventstore: offload meta injection to the connection manager

### DIFF
--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -194,28 +194,48 @@ func NewConnection(ctx context.Context, logger *zap.Logger, openEvent *OpenEvent
 		opt(c)
 	}
 
-	if c.serviceRegistry != nil {
-		factory := c.serviceRegistry.Get(eventstore.TypeEventStore)
-		if factory != nil {
-			instance, err := factory.Create(ctx)
-			if err != nil {
-				c.logger.Error("failed to create event store", zap.Error(err))
-			}
-			if l, ok := instance.(servicespkg.LoggerAdapter); ok {
-				l.SetLogger(c.logger)
-			}
-			if ca, ok := instance.(ConnectionAdapter); ok {
-				ca.SetConnection(c)
-			}
-			if es, ok := instance.(eventstore.EventStore); ok {
-				c.eventStore = es
-			} else {
-				c.logger.DPanic("event store factory returned non-eventstore instance")
-			}
-		}
+	c.assignEventStore(ctx)
+	return c
+}
+
+func (c *Connection) assignEventStore(ctx context.Context) {
+	if c.serviceRegistry == nil {
+		return
 	}
 
-	return c
+	factory := c.serviceRegistry.Get(eventstore.TypeEventStore)
+	if factory == nil {
+		return
+	}
+
+	instance, err := factory.Create(ctx)
+	if err != nil {
+		c.logger.Error("failed to create event store", zap.Error(err))
+		return
+	}
+
+	es, ok := instance.(eventstore.EventStore)
+	if !ok {
+		c.logger.DPanic("event store factory returned non-eventstore instance")
+		return
+	}
+
+	// setup adapters
+	if l, ok := instance.(servicespkg.LoggerAdapter); ok {
+		l.SetLogger(c.logger)
+	}
+	if ca, ok := instance.(ConnectionAdapter); ok {
+		ca.SetConnection(c)
+	}
+
+	// setup meta injector
+	injector := &eventMetaInjector{
+		conn:       c,
+		eventStore: es,
+	}
+
+	// set event store
+	c.eventStore = injector
 }
 
 func (c *Connection) SetProcess(process *process.Process) {
@@ -689,4 +709,37 @@ func isAlphanumeric(ch rune) bool {
 
 type ConnectionAdapter interface {
 	SetConnection(*Connection)
+}
+
+// eventMetaInjector implements the event store interface and adds connection metadata to events
+// before they are submitted to the event store.
+type eventMetaInjector struct {
+	conn       *Connection
+	eventStore eventstore.EventStore
+}
+
+func (e *eventMetaInjector) Save(ctx context.Context, item any) {
+	if e.conn != nil {
+		if c, ok := item.(connidable); ok {
+			c.SetConnectionID(e.conn.ID())
+		}
+
+		if t, ok := item.(taggable); ok {
+			t.AddTags(e.conn.Tags().List()...)
+		}
+	}
+
+	e.eventStore.Save(ctx, item)
+}
+
+func (e *eventMetaInjector) ServiceType() servicespkg.ServiceType {
+	return eventstore.TypeEventStore
+}
+
+type connidable interface {
+	SetConnectionID(id string)
+}
+
+type taggable interface {
+	AddTags(tag ...string)
 }

--- a/pkg/e2e/eventstore.go
+++ b/pkg/e2e/eventstore.go
@@ -55,14 +55,6 @@ func (f *EventStoreFactory) save(conn *connection.Connection, item any) {
 	defer f.mu.Unlock()
 
 	if conn != nil {
-		if c, ok := item.(connidable); ok {
-			c.SetConnectionID(conn.ID())
-		}
-
-		if t, ok := item.(taggable); ok {
-			t.AddTags(conn.Tags().List()...)
-		}
-
 		if f.eventsByConn[conn.ID()] == nil {
 			f.eventsByConn[conn.ID()] = &Events{}
 		}
@@ -140,14 +132,6 @@ func (f *EventStoreFactory) AwaitByCtxID(id string, numConnections int, timeout 
 		time.Sleep(100 * time.Millisecond)
 		first = false
 	}
-}
-
-type connidable interface {
-	SetConnectionID(id string)
-}
-
-type taggable interface {
-	AddTags(tag ...string)
 }
 
 type EventStore struct {

--- a/pkg/services/eventstore/axiom/axiom.go
+++ b/pkg/services/eventstore/axiom/axiom.go
@@ -32,29 +32,11 @@ type EventStore struct {
 	objectStore objectstore.ObjectStore
 }
 
-type connidable interface {
-	SetConnectionID(id string)
-}
-
-type taggable interface {
-	AddTags(tag ...string)
-}
-
 // Save submits an event to Axiom
 func (s *EventStore) Save(_ context.Context, item any) {
 	ctx := context.Background()
 	ctx, span := tracer.Start(ctx, "Axiom.Save", trace.WithSpanKind(trace.SpanKindProducer))
 	defer span.End()
-
-	if s.conn != nil {
-		if c, ok := item.(connidable); ok {
-			c.SetConnectionID(s.conn.ID())
-		}
-
-		if t, ok := item.(taggable); ok {
-			t.AddTags(s.conn.Tags().List()...)
-		}
-	}
 
 	switch i := item.(type) {
 	case *eventstore.Request, *eventstore.PIIEntity, *eventstore.Issue, *eventstore.ArtifactRecord, *eventstore.Connection:

--- a/pkg/services/eventstore/console/console.go
+++ b/pkg/services/eventstore/console/console.go
@@ -16,14 +16,6 @@ const (
 	TypeConsoleEventStore services.ServiceType = "console"
 )
 
-type connidable interface {
-	SetConnectionID(id string)
-}
-
-type taggable interface {
-	AddTags(tag ...string)
-}
-
 type Factory struct {
 	eventstore.BaseEventStore
 }
@@ -71,16 +63,6 @@ func (s *EventStore) SetConnection(conn *connection.Connection) {
 func (s *EventStore) Save(ctx context.Context, item any) {
 	if l, ok := s.objectStore.(services.LoggerAdapter); ok {
 		l.SetLogger(s.Log())
-	}
-
-	if s.conn != nil {
-		if c, ok := item.(connidable); ok {
-			c.SetConnectionID(s.conn.ID())
-		}
-
-		if t, ok := item.(taggable); ok {
-			t.AddTags(s.conn.Tags().List()...)
-		}
 	}
 
 	switch i := item.(type) {

--- a/pkg/services/eventstore/otel/otel.go
+++ b/pkg/services/eventstore/otel/otel.go
@@ -30,26 +30,8 @@ type EventStore struct {
 	environment string
 }
 
-type connidable interface {
-	SetConnectionID(id string)
-}
-
-type taggable interface {
-	AddTags(tag ...string)
-}
-
 // Save submits an event to OpenTelemetry
 func (s *EventStore) Save(ctx context.Context, item any) {
-	// Add connection metadata if available
-	if s.conn != nil {
-		if c, ok := item.(connidable); ok {
-			c.SetConnectionID(s.conn.ID())
-		}
-		if t, ok := item.(taggable); ok {
-			t.AddTags(s.conn.Tags().List()...)
-		}
-	}
-
 	switch i := item.(type) {
 	case *eventstore.Request:
 		s.logEvent(ctx, i, log.SeverityInfo, fmt.Sprintf("HTTP %s (%d) %s", i.Method, i.Status, i.Url))


### PR DESCRIPTION
- offload the setting of connection id and tags on saved events to the connection manager instead of the event stores
- DRY up the code and allow multiple instances of event stores to work concurrently
    - previously both event stores would append the tags - duplicating them or running into a concurrency race