### PR TITLE
eng-731:  refactor connection reports into a dedicated service

### DIFF
--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -207,8 +207,9 @@ func mainSetup() error {
 			return &config.ServiceConfig{
 				Type: reporter.Type.String(),
 				Config: &reporter.Config{
-					FirstReportDeadline: 500 * time.Millisecond,
-					ReportInterval:      0, // no recurring reports
+					// only report connections once they are closed
+					FirstReportDeadline: 0,
+					ReportInterval:      0,
 				},
 			}
 		},

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/qpoint-io/qtap/pkg/services"
 	"github.com/qpoint-io/qtap/pkg/services/connmeta"
 	objectstorenoop "github.com/qpoint-io/qtap/pkg/services/objectstore/noop"
+	"github.com/qpoint-io/qtap/pkg/services/reporter"
 	"github.com/qpoint-io/qtap/pkg/services/rulekitsvc"
 	"github.com/qpoint-io/qtap/pkg/stream"
 	"github.com/qpoint-io/qtap/pkg/tags"
@@ -98,6 +99,7 @@ func mainSetup() error {
 		// Add more services here...
 		func() services.ServiceFactory { return &rulekitsvc.Factory{} },
 		func() services.ServiceFactory { return &connmeta.Factory{} },
+		func() services.ServiceFactory { return &reporter.Factory{} },
 	}
 
 	pluginFactories = []plugins.HttpPlugin{
@@ -185,6 +187,32 @@ func mainSetup() error {
 	svcRegistry := services.NewFactoryRegistry()
 	svcManager := services.NewServiceManager(e2ectx, logger, svcRegistry)
 	svcManager.RegisterFactory(serviceFactories...)
+	// register core services that must always be included
+	svcManager.AddExtraServices(
+		// rulekit
+		func(cfg *config.Config) *config.ServiceConfig {
+			return &config.ServiceConfig{
+				Type:   rulekitsvc.TypeRulekit.String(),
+				Config: cfg.Rulekit,
+			}
+		},
+		// connmeta
+		func(cfg *config.Config) *config.ServiceConfig {
+			return &config.ServiceConfig{
+				Type: connmeta.Type.String(),
+			}
+		},
+		// report connections to the default event store
+		func(cfg *config.Config) *config.ServiceConfig {
+			return &config.ServiceConfig{
+				Type: reporter.Type.String(),
+				Config: &reporter.Config{
+					FirstReportDeadline: 500 * time.Millisecond,
+					ReportInterval:      0, // no recurring reports
+				},
+			}
+		},
+	)
 	confManager.SubscribeSetter(svcManager)
 
 	pluginRegistry := plugins.NewRegistry(pluginFactories...)

--- a/pkg/cmd/tap_linux.go
+++ b/pkg/cmd/tap_linux.go
@@ -339,7 +339,7 @@ func runTapCmd(logger *zap.Logger) {
 				Type: connmeta.Type.String(),
 			}
 		},
-		// report connections to the deafault event store
+		// report connections to the default event store
 		func(cfg *config.Config) *config.ServiceConfig {
 			return &config.ServiceConfig{
 				Type: reporter.Type.String(),

--- a/pkg/cmd/tap_linux.go
+++ b/pkg/cmd/tap_linux.go
@@ -9,6 +9,7 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/cilium/ebpf/ringbuf"
 	"github.com/moby/moby/pkg/parsers/kernel"
@@ -41,6 +42,7 @@ import (
 	objectstoreconsole "github.com/qpoint-io/qtap/pkg/services/objectstore/console"
 	objectstorenoop "github.com/qpoint-io/qtap/pkg/services/objectstore/noop"
 	objecstores3 "github.com/qpoint-io/qtap/pkg/services/objectstore/s3"
+	"github.com/qpoint-io/qtap/pkg/services/reporter"
 	"github.com/qpoint-io/qtap/pkg/services/rulekitsvc"
 	"github.com/qpoint-io/qtap/pkg/status"
 	"github.com/qpoint-io/qtap/pkg/stream"
@@ -79,6 +81,7 @@ var (
 		// Add more services here...
 		func() services.ServiceFactory { return &rulekitsvc.Factory{} },
 		func() services.ServiceFactory { return &connmeta.Factory{} },
+		func() services.ServiceFactory { return &reporter.Factory{} },
 	}
 
 	pluginFactories = []plugins.HttpPlugin{
@@ -321,6 +324,32 @@ func runTapCmd(logger *zap.Logger) {
 	svcFactoryRegistry := services.NewFactoryRegistry()
 	svcManager := services.NewServiceManager(ctx, logger, svcFactoryRegistry)
 	svcManager.RegisterFactory(serviceFactories...)
+	// register core services that must always be included
+	svcManager.AddExtraServices(
+		// rulekit
+		func(cfg *config.Config) *config.ServiceConfig {
+			return &config.ServiceConfig{
+				Type:   rulekitsvc.TypeRulekit.String(),
+				Config: cfg.Rulekit,
+			}
+		},
+		// connmeta
+		func(cfg *config.Config) *config.ServiceConfig {
+			return &config.ServiceConfig{
+				Type: connmeta.Type.String(),
+			}
+		},
+		// report connections to pulse
+		func(cfg *config.Config) *config.ServiceConfig {
+			return &config.ServiceConfig{
+				Type: reporter.Type.String(),
+				Config: &reporter.Config{
+					FirstReportDeadline: 500 * time.Millisecond,
+					ReportInterval:      10 * time.Second,
+				},
+			}
+		},
+	)
 	configManager.Subscribe(func(cfg *config.Config) {
 		svcManager.SetConfig(cfg)
 	})

--- a/pkg/cmd/tap_linux.go
+++ b/pkg/cmd/tap_linux.go
@@ -339,7 +339,7 @@ func runTapCmd(logger *zap.Logger) {
 				Type: connmeta.Type.String(),
 			}
 		},
-		// report connections to pulse
+		// report connections to the deafault event store
 		func(cfg *config.Config) *config.ServiceConfig {
 			return &config.ServiceConfig{
 				Type: reporter.Type.String(),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,16 +26,40 @@ type Services struct {
 	QscanClient  *ServiceQscan        `yaml:"qscan"`
 }
 
-func (s Services) ToMap() map[string]any {
-	m := make(map[string]any)
+func (s Services) AllConfigs() []*ServiceConfig {
+	es := s.FirstEventStore()
+	os := s.FirstObjectStore()
+	qc := s.Qscan()
 
-	m[s.FirstEventStore().ServiceType()] = s.FirstEventStore()
+	return []*ServiceConfig{
+		{
+			ID:      es.ID,
+			Type:    es.ServiceType(),
+			Config:  es,
+			Default: true,
+		},
+		{
+			ID:      os.ID,
+			Type:    os.ServiceType(),
+			Config:  os,
+			Default: true,
+		},
+		{
+			Type:    qc.ServiceType(),
+			Config:  qc,
+			Default: true,
+		},
+	}
+}
 
-	m[s.FirstObjectStore().ServiceType()] = s.FirstObjectStore()
+type ServiceConfig struct {
+	ID     string
+	Type   string
+	Config any
 
-	m[s.Qscan().ServiceType()] = s.Qscan()
-
-	return m
+	// Default indicates that this service should be used if its service type is requested
+	// without specifying an ID
+	Default bool
 }
 
 func (s Services) Qscan() ServiceQscan {

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -400,7 +400,7 @@ func (c *Connection) Close() {
 	}
 
 	// close all connection services
-	// this will also send a final report to the event store
+	// this will also close the reporter service, sending a final report to the event store
 	if err := c.svcRegistry.Close(); err != nil {
 		c.logger.Error("error closing service registry", zap.Error(err))
 	}

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -320,7 +320,7 @@ func (c *Connection) Open() {
 	})
 }
 
-func (c *Connection) SetupReporters() {
+func (c *Connection) setupReporters() {
 	// create reporter services
 	r, err := c.createService("reporter")
 	if err != nil {

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -194,11 +194,11 @@ func NewConnection(ctx context.Context, logger *zap.Logger, openEvent *OpenEvent
 		opt(c)
 	}
 
-	c.assignEventStore(ctx)
+	c.assignEventStore()
 	return c
 }
 
-func (c *Connection) assignEventStore(ctx context.Context) {
+func (c *Connection) assignEventStore() {
 	if c.svcFactoryRegistry == nil {
 		return
 	}
@@ -225,14 +225,14 @@ func (c *Connection) assignEventStore(ctx context.Context) {
 }
 
 func (c *Connection) createService(serviceType servicespkg.ServiceType) (servicespkg.Service, error) {
-	instance, err := c.svcFactoryRegistry.CreateService(c.ctx, serviceType)
+	instance, err := c.svcFactoryRegistry.CreateService(c.ctx, serviceType, "")
 	if err != nil {
 		return nil, fmt.Errorf("creating service %q: %w", serviceType, err)
 	}
 
 	// setup adapters
 	if l, ok := instance.(servicespkg.LoggerAdapter); ok {
-		l.SetLogger(c.logger)
+		l.SetLogger(c.logger.With(zap.Stringer("service", serviceType)))
 	}
 	if ca, ok := instance.(ConnectionAdapter); ok {
 		ca.SetConnection(c)

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -28,14 +28,9 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-const (
-	WarmupTimeout = 10 * time.Second
-)
-
 var tracer = telemetry.Tracer()
 
 type services interface {
-	generateAuditLog(conn *Connection)
 	finalizeConnection(conn *Connection)
 	createStreamer(conn *Connection) StreamProcessor
 }
@@ -60,10 +55,11 @@ type Connection struct {
 	// dependencies
 	services           services
 	svcFactoryRegistry *servicespkg.FactoryRegistry
-	eventStore         eventstore.EventStore
-	controlManager     ControlManager
-	streamProcessor    StreamProcessor
-	dnsRecord          *dns.Record
+	svcRegistry        *servicespkg.ServiceRegistry
+
+	controlManager  ControlManager
+	streamProcessor StreamProcessor
+	dnsRecord       *dns.Record
 
 	// connection properties
 	id string
@@ -102,9 +98,6 @@ type Connection struct {
 	// tags & labels
 	tags   tags.List
 	labels labels.Set
-
-	// auditCount is the number of times a connection audit log as been reported
-	auditCount uint32
 }
 
 type ConnOpt func(c *Connection)
@@ -169,6 +162,12 @@ func NewConnection(ctx context.Context, logger *zap.Logger, openEvent *OpenEvent
 	)
 
 	t := tags.New()
+	// TODO: is this what we actually want here?
+	// if openEvent.Source == Client {
+	// 	t.Add("ip", openEvent.Local.IP.String())
+	// } else {
+	// 	t.Add("ip", openEvent.Remote.IP.String())
+	// }
 	t.Add("ip", openEvent.Local.IP.String())
 
 	logger = logger.With(zap.String("conn_id", id), zap.Any("cookie", openEvent.Cookie))
@@ -187,6 +186,7 @@ func NewConnection(ctx context.Context, logger *zap.Logger, openEvent *OpenEvent
 		HandlerType: handlerType,
 		tags:        t,
 		labels:      labels.New(),
+		svcRegistry: servicespkg.NewServiceRegistry(),
 	}
 
 	// apply options
@@ -203,7 +203,7 @@ func (c *Connection) assignEventStore(ctx context.Context) {
 		return
 	}
 
-	instance, err := c.svcFactoryRegistry.CreateService(ctx, eventstore.TypeEventStore)
+	instance, err := c.createService(eventstore.TypeEventStore)
 	if err != nil {
 		c.logger.Error("failed to create event store", zap.Error(err))
 		return
@@ -215,6 +215,21 @@ func (c *Connection) assignEventStore(ctx context.Context) {
 		return
 	}
 
+	// setup meta injector
+	injector := &EventStoreMetaInjector{
+		Conn:       c,
+		EventStore: es,
+	}
+
+	c.svcRegistry.Register(injector)
+}
+
+func (c *Connection) createService(serviceType servicespkg.ServiceType) (servicespkg.Service, error) {
+	instance, err := c.svcFactoryRegistry.CreateService(c.ctx, serviceType)
+	if err != nil {
+		return nil, fmt.Errorf("creating service %q: %w", serviceType, err)
+	}
+
 	// setup adapters
 	if l, ok := instance.(servicespkg.LoggerAdapter); ok {
 		l.SetLogger(c.logger)
@@ -223,14 +238,7 @@ func (c *Connection) assignEventStore(ctx context.Context) {
 		ca.SetConnection(c)
 	}
 
-	// setup meta injector
-	injector := &EventStoreMetaInjector{
-		Conn:       c,
-		EventStore: es,
-	}
-
-	// set event store
-	c.eventStore = injector
+	return instance, nil
 }
 
 func (c *Connection) SetProcess(process *process.Process) {
@@ -309,22 +317,22 @@ func (c *Connection) Open() {
 
 		// Start monitoring
 		go c.watch()
-		go c.warmup()
 	})
+}
+
+func (c *Connection) SetupReporters() {
+	// create reporter services
+	r, err := c.createService("reporter")
+	if err != nil {
+		c.logger.Error("failed to create reporter service", zap.Error(err))
+		return
+	}
+
+	c.svcRegistry.Register(r)
 }
 
 func (c *Connection) ID() string {
 	return c.id
-}
-
-func (c *Connection) warmup() {
-	// Start goroutine to wait for timeout
-	select {
-	case <-c.ctx.Done():
-		return
-	case <-time.After(WarmupTimeout):
-		c.services.generateAuditLog(c)
-	}
 }
 
 func (c *Connection) watch() {
@@ -391,12 +399,13 @@ func (c *Connection) Close() {
 		}
 	}
 
-	// generate an audit log
-	c.services.generateAuditLog(c)
+	// close all connection services
+	// this will also send a final report to the event store
+	if err := c.svcRegistry.Close(); err != nil {
+		c.logger.Error("error closing service registry", zap.Error(err))
+	}
 
-	// log connection report
-	// if the connection is expected this will be a debug level log
-	// otherwise it will be a warning or an error
+	// print a debug log line with the report
 	c.logConnectionReport()
 }
 
@@ -524,6 +533,10 @@ func (c *Connection) Tags() tags.List {
 	return c.tags
 }
 
+func (c *Connection) Labels() labels.Set {
+	return c.labels
+}
+
 func (c *Connection) Context() context.Context {
 	if c.ctx == nil {
 		return context.Background()
@@ -589,7 +602,7 @@ func (c *Connection) ControlValues() map[string]any {
 		maps.Copy(dst, d.ControlValues())
 	}
 
-	if h := c.Domain(); h != "" && h != "<nil>" && !c.domainIsIP {
+	if h := c.Domain(); h != "" && !c.domainIsIP {
 		dst["domain"] = h
 	}
 

--- a/pkg/connection/reader.go
+++ b/pkg/connection/reader.go
@@ -73,6 +73,29 @@ func (m *Manager) processOpenEvent(event OpenEvent) {
 
 	// start watching the connection
 	conn.Open()
+
+	// setup reporters
+	if m.shouldReport(conn) {
+		conn.SetupReporters()
+	}
+}
+
+func (m *Manager) shouldReport(conn *Connection) bool {
+	if conn.HandlerType == HandlerType_FORWARDING {
+		conn.logger.Debug("generateAuditLog: forwarding connection detected, ignoring audit")
+		return false
+	}
+
+	// if this is DNS, ensure we're wanted
+	if m.config != nil && conn.Protocol == Protocol_DNS && !m.config.Tap.AuditIncludeDNS {
+		m.logger.Debug("generateAuditLog: DNS audit log disabled",
+			zap.String("conn_pid_id", conn.connPIDKey.String()),
+			zap.String("local_addr", conn.OpenEvent.Local.String()),
+			zap.String("remote_addr", conn.OpenEvent.Remote.String()))
+		return false
+	}
+
+	return true
 }
 
 func (c *Connection) processEvent(event any) {

--- a/pkg/connection/reader.go
+++ b/pkg/connection/reader.go
@@ -76,7 +76,7 @@ func (m *Manager) processOpenEvent(event OpenEvent) {
 
 	// setup reporters
 	if m.shouldReport(conn) {
-		conn.SetupReporters()
+		conn.setupReporters()
 	}
 }
 

--- a/pkg/connection/report.go
+++ b/pkg/connection/report.go
@@ -88,3 +88,7 @@ func (r *report) reportFields() []zap.Field {
 		zap.Uint64("dataEventCount", r.dataEventCount),
 	}
 }
+
+func (r *report) DataEventCount() uint64 {
+	return r.dataEventCount
+}

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -9,7 +9,7 @@ import (
 type Set set.Set[string]
 
 func New(items ...string) Set {
-	s := make(Set)
+	s := make(Set, len(items))
 	s.Add(items...)
 	return s
 }

--- a/pkg/plugins/manager.go
+++ b/pkg/plugins/manager.go
@@ -247,7 +247,7 @@ func (m *Manager) NewConnection(ctx context.Context, connectionType ConnectionTy
 
 	svcs := services.NewServiceRegistry()
 	for _, s := range requiredSvcs.Items() {
-		factory := m.serviceFactoryRegistry.Get(s)
+		factory := m.serviceFactoryRegistry.Get(s, "")
 		if factory == nil {
 			return nil, fmt.Errorf("service %s not found", s)
 		}

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -608,7 +608,7 @@ func (p *Process) ControlValues() map[string]any {
 
 	// user
 	user := map[string]any{}
-	if u, err := p.User(); err == nil {
+	if u, _ := p.User(); u != nil {
 		user["id"] = u.UID
 		user["name"] = u.Username
 	}

--- a/pkg/services/eventstore/axiom/axiom.go
+++ b/pkg/services/eventstore/axiom/axiom.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	"github.com/axiomhq/axiom-go/axiom"
-	"github.com/qpoint-io/qtap/pkg/connection"
 	"github.com/qpoint-io/qtap/pkg/services"
 	"github.com/qpoint-io/qtap/pkg/services/eventstore"
 	"github.com/qpoint-io/qtap/pkg/services/objectstore"
@@ -25,7 +24,6 @@ var (
 type EventStore struct {
 	services.LogHelper
 	eventstore.BaseEventStore
-	conn        *connection.Connection
 	axiomClient *axiom.Client
 	dataset     string
 
@@ -116,11 +114,6 @@ func (s *EventStore) convertToAxiomEvent(item any) (axiom.Event, error) {
 	}
 
 	return event, nil
-}
-
-// SetConnection sets the connection context for events
-func (s *EventStore) SetConnection(conn *connection.Connection) {
-	s.conn = conn
 }
 
 func toMap(v any) (map[string]any, error) {

--- a/pkg/services/eventstore/axiom/axiom_test.go
+++ b/pkg/services/eventstore/axiom/axiom_test.go
@@ -51,15 +51,6 @@ func TestEventStore_Save_UnsupportedType(t *testing.T) {
 	es.Save(t.Context(), "unsupported type")
 	// Since we can't easily test the log output, we just ensure it doesn't panic
 }
-
-func TestEventStore_SetConnection(t *testing.T) {
-	es := &EventStore{}
-
-	// Test that SetConnection doesn't panic
-	es.SetConnection(nil)
-	assert.Nil(t, es.conn)
-}
-
 func TestEventStore_ServiceType(t *testing.T) {
 	es := &EventStore{}
 	assert.Equal(t, eventstore.TypeEventStore, es.ServiceType())

--- a/pkg/services/eventstore/axiom/factory.go
+++ b/pkg/services/eventstore/axiom/factory.go
@@ -67,7 +67,7 @@ func (f *Factory) Init(ctx context.Context, cfg any) error {
 
 // Create creates a new Axiom EventStore service instance
 func (f *Factory) Create(ctx context.Context) (services.Service, error) {
-	svc, err := f.FactoryRegistry.CreateService(ctx, objectstore.TypeObjectStore)
+	svc, err := f.FactoryRegistry.CreateService(ctx, objectstore.TypeObjectStore, "")
 	if err != nil {
 		return nil, fmt.Errorf("creating object store: %w", err)
 	}

--- a/pkg/services/eventstore/console/console.go
+++ b/pkg/services/eventstore/console/console.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/qpoint-io/qtap/pkg/connection"
 	"github.com/qpoint-io/qtap/pkg/services"
 	"github.com/qpoint-io/qtap/pkg/services/eventstore"
 	"github.com/qpoint-io/qtap/pkg/services/objectstore"
@@ -49,12 +48,7 @@ type EventStore struct {
 	services.LogHelper
 	eventstore.BaseEventStore
 
-	conn        *connection.Connection
 	objectStore objectstore.ObjectStore
-}
-
-func (s *EventStore) SetConnection(conn *connection.Connection) {
-	s.conn = conn
 }
 
 // Save stores an event

--- a/pkg/services/eventstore/console/console.go
+++ b/pkg/services/eventstore/console/console.go
@@ -25,7 +25,7 @@ func (f *Factory) Init(ctx context.Context, cfg any) error {
 }
 
 func (f *Factory) Create(ctx context.Context) (services.Service, error) {
-	svc, err := f.FactoryRegistry.CreateService(ctx, objectstore.TypeObjectStore)
+	svc, err := f.FactoryRegistry.CreateService(ctx, objectstore.TypeObjectStore, "")
 	if err != nil {
 		return nil, fmt.Errorf("creating object store: %w", err)
 	}

--- a/pkg/services/eventstore/eventstore.go
+++ b/pkg/services/eventstore/eventstore.go
@@ -28,7 +28,7 @@ type EventStore interface {
 
 // BaseEventStore provides common functionality for EventStore implementations
 type BaseEventStore struct {
-	FactoryRegistry services.FactoryRegistryAccessor
+	FactoryRegistry *services.FactoryRegistry
 }
 
 // ServiceType returns the service type
@@ -36,7 +36,7 @@ func (b *BaseEventStore) ServiceType() services.ServiceType {
 	return TypeEventStore
 }
 
-func (b *BaseEventStore) SetFactoryRegistry(registry services.FactoryRegistryAccessor) {
+func (b *BaseEventStore) SetFactoryRegistry(registry *services.FactoryRegistry) {
 	b.FactoryRegistry = registry
 }
 

--- a/pkg/services/eventstore/otel/factory.go
+++ b/pkg/services/eventstore/otel/factory.go
@@ -153,7 +153,7 @@ func (f *Factory) Init(ctx context.Context, cfg any) error {
 }
 
 func (f *Factory) Create(ctx context.Context) (services.Service, error) {
-	svc, err := f.FactoryRegistry.CreateService(ctx, objectstore.TypeObjectStore)
+	svc, err := f.FactoryRegistry.CreateService(ctx, objectstore.TypeObjectStore, "")
 	if err != nil {
 		return nil, fmt.Errorf("creating object store: %w", err)
 	}

--- a/pkg/services/eventstore/otel/otel.go
+++ b/pkg/services/eventstore/otel/otel.go
@@ -8,7 +8,6 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/qpoint-io/qtap/pkg/connection"
 	"github.com/qpoint-io/qtap/pkg/services"
 	"github.com/qpoint-io/qtap/pkg/services/eventstore"
 	"github.com/qpoint-io/qtap/pkg/services/objectstore"
@@ -23,7 +22,6 @@ type EventStore struct {
 	services.LogHelper
 	eventstore.BaseEventStore
 
-	conn        *connection.Connection
 	logger      log.Logger
 	objectStore objectstore.ObjectStore
 	serviceName string
@@ -227,9 +225,4 @@ func (s *EventStore) extractTimestamp(item any) time.Time {
 	default:
 		return time.Now()
 	}
-}
-
-// SetConnection sets the connection context for events
-func (s *EventStore) SetConnection(conn *connection.Connection) {
-	s.conn = conn
 }

--- a/pkg/services/manager.go
+++ b/pkg/services/manager.go
@@ -10,10 +10,11 @@ import (
 
 // ServiceManager handles service creation and lifecycle
 type ServiceManager struct {
-	ctx       context.Context
-	logger    *zap.Logger
-	registry  *FactoryRegistry
-	factories *Registry[ServiceType, FactoryFactory]
+	ctx           context.Context
+	logger        *zap.Logger
+	registry      *FactoryRegistry
+	factories     *Registry[ServiceType, FactoryFactory]
+	extraServices []func(*config.Config) *config.ServiceConfig
 }
 
 // NewServiceManager creates a new service manager
@@ -24,6 +25,10 @@ func NewServiceManager(ctx context.Context, logger *zap.Logger, registry *Factor
 		registry:  registry,
 		factories: NewRegistry[ServiceType, FactoryFactory](),
 	}
+}
+
+func (sm *ServiceManager) AddExtraServices(services ...func(*config.Config) *config.ServiceConfig) {
+	sm.extraServices = append(sm.extraServices, services...)
 }
 
 // RegisterFactory registers a service factory
@@ -38,20 +43,21 @@ func (sm *ServiceManager) RegisterFactory(fns ...FactoryFactory) {
 }
 
 // SetConfig processes a config update and creates/updates services
-func (sm *ServiceManager) SetConfig(config *config.Config) {
-	if config == nil {
+func (sm *ServiceManager) SetConfig(cfg *config.Config) {
+	if cfg == nil {
 		return
 	}
 
 	// get services from config
-	svcs := config.Services.ToMap()
-	// add core services
-	svcs["rulekit"] = config.Rulekit
-	svcs["connmeta"] = nil
-	for key, svcConfig := range svcs {
-		fn := sm.factories.Get(ServiceType(key))
+	svcs := cfg.Services.AllConfigs()
+	for _, fn := range sm.extraServices {
+		svcs = append(svcs, fn(cfg))
+	}
+
+	for _, svcConfig := range svcs {
+		fn := sm.factories.Get(ServiceType(svcConfig.Type))
 		if fn == nil {
-			sm.logger.Debug("no factory registered for service type", zap.String("service_type", key))
+			sm.logger.Debug("no factory registered for service type", zap.String("service_type", svcConfig.Type))
 			continue
 		}
 
@@ -79,12 +85,22 @@ func (sm *ServiceManager) SetConfig(config *config.Config) {
 			sr.SetFactoryRegistry(sm.registry)
 		}
 
-		sm.logger.Info("initializing service factory", zap.String("factory_type", key))
-		if err := factory.Init(sm.ctx, svcConfig); err != nil {
-			sm.logger.Error("failed to initialize service factory", zap.String("factory_type", key), zap.Error(err))
+		sm.logger.Info(
+			"initializing service factory",
+			zap.String("factory_type", svcConfig.Type),
+			zap.Stringer("service_type", factory.ServiceType()),
+		)
+		if err := factory.Init(sm.ctx, svcConfig.Config); err != nil {
+			sm.logger.Error("failed to initialize service factory", zap.String("factory_type", svcConfig.Type), zap.Error(err))
 			continue
 		}
 
-		sm.registry.Register(factory)
+		if svcConfig.ID != "" {
+			sm.registry.Register(factory, svcConfig.ID)
+		}
+		// register it as the default if explicitly specified or no ID was provided
+		if svcConfig.Default || svcConfig.ID == "" {
+			sm.registry.Register(factory, "")
+		}
 	}
 }

--- a/pkg/services/manager.go
+++ b/pkg/services/manager.go
@@ -64,7 +64,7 @@ func (sm *ServiceManager) SetConfig(cfg *config.Config) {
 		factory := fn()
 
 		// Close old service if it exists and implements Closer
-		if old := sm.registry.Get(factory.ServiceType()); old != nil {
+		if old := sm.registry.Get(factory.ServiceType(), ""); old != nil {
 			// closes factories that are closeable
 			if closer, ok := old.(io.Closer); ok {
 				defer func() {

--- a/pkg/services/registry.go
+++ b/pkg/services/registry.go
@@ -13,31 +13,10 @@ import (
 	Convenience types
 */
 
-// ServiceRegistry is a convenience type for a registry of services
-type ServiceRegistry struct {
-	*Registry[ServiceType, Service]
-}
-
-func NewServiceRegistry(services ...Service) *ServiceRegistry {
-	sr := NewRegistrySize[ServiceType, Service](len(services))
-	for _, service := range services {
-		sr.Register(service.ServiceType(), service)
-	}
-	return &ServiceRegistry{sr}
-}
-
-func (sr *ServiceRegistry) Register(value Service) {
-	sr.Registry.Register(value.ServiceType(), value)
-}
-
-func (sr *ServiceRegistry) Copy() *ServiceRegistry {
-	return &ServiceRegistry{sr.Registry.Copy()}
-}
-
 // FactoryRegistry is a convenience type for a registry of service factories.
 // Factory registries are keyed by ServiceType() and not FactoryType() so this wrapper exists to avoid any confusion by users.
 type FactoryRegistry struct {
-	*Registry[ServiceType, ServiceFactory]
+	r *Registry[ServiceType, ServiceFactory]
 }
 
 func NewFactoryRegistry(factories ...ServiceFactory) *FactoryRegistry {
@@ -55,7 +34,7 @@ func (fr *FactoryRegistry) Register(value ServiceFactory, id string) {
 	if id != "" {
 		key = ServiceType(fmt.Sprintf("%s:%s", key.String(), id))
 	}
-	fr.Registry.Register(key, value)
+	fr.r.Register(key, value)
 }
 
 // Load retrieves a service factory by type and optional ID.
@@ -65,20 +44,63 @@ func (fr *FactoryRegistry) Load(serviceType ServiceType, id string) (ServiceFact
 	if id != "" {
 		key = ServiceType(fmt.Sprintf("%s:%s", serviceType.String(), id))
 	}
-	return fr.Registry.Load(key)
+	return fr.r.Load(key)
+}
+
+// Get retrieves a service factory by type and optional ID.
+// If the ID is empty, the default factory for the type is returned.
+func (fr *FactoryRegistry) Get(serviceType ServiceType, id string) ServiceFactory {
+	f, ok := fr.Load(serviceType, id)
+	if !ok {
+		return nil
+	}
+	return f
 }
 
 func (fr *FactoryRegistry) Copy() *FactoryRegistry {
-	return &FactoryRegistry{fr.Registry.Copy()}
+	return &FactoryRegistry{fr.r.Copy()}
 }
 
 // CreateService creates a new service instance from the default factory for the given type.
-func (fr *FactoryRegistry) CreateService(ctx context.Context, serviceType ServiceType) (Service, error) {
-	factory := fr.Get(serviceType)
-	if factory == nil {
-		return nil, fmt.Errorf("factory not found for service %s", serviceType)
+func (fr *FactoryRegistry) CreateService(ctx context.Context, serviceType ServiceType, id string) (Service, error) {
+	factory, ok := fr.Load(serviceType, id)
+	if !ok {
+		key := serviceType.String()
+		if id != "" {
+			key = fmt.Sprintf("%s:%s", key, id)
+		}
+		return nil, fmt.Errorf("factory not found for service %s", key)
 	}
 	return factory.Create(ctx)
+}
+
+// ServiceRegistry is a convenience type for a registry of services
+type ServiceRegistry struct {
+	r *Registry[ServiceType, Service]
+}
+
+func NewServiceRegistry(services ...Service) *ServiceRegistry {
+	sr := NewRegistrySize[ServiceType, Service](len(services))
+	for _, service := range services {
+		sr.Register(service.ServiceType(), service)
+	}
+	return &ServiceRegistry{sr}
+}
+
+func (sr *ServiceRegistry) Register(value Service) {
+	sr.r.Register(value.ServiceType(), value)
+}
+
+func (sr *ServiceRegistry) Get(serviceType ServiceType) Service {
+	return sr.r.Get(serviceType)
+}
+
+func (sr *ServiceRegistry) Copy() *ServiceRegistry {
+	return &ServiceRegistry{sr.r.Copy()}
+}
+
+func (sr *ServiceRegistry) Close() error {
+	return sr.r.Close()
 }
 
 /*

--- a/pkg/services/registry.go
+++ b/pkg/services/registry.go
@@ -48,14 +48,31 @@ func NewFactoryRegistry(factories ...ServiceFactory) *FactoryRegistry {
 	return &FactoryRegistry{fr}
 }
 
-func (fr *FactoryRegistry) Register(value ServiceFactory) {
-	fr.Registry.Register(value.ServiceType(), value)
+// Register registers a default service factory by type and optional ID.
+// If the ID is empty, the factory is registered as the default for the type.
+func (fr *FactoryRegistry) Register(value ServiceFactory, id string) {
+	key := value.ServiceType()
+	if id != "" {
+		key = ServiceType(fmt.Sprintf("%s:%s", key.String(), id))
+	}
+	fr.Registry.Register(key, value)
+}
+
+// Load retrieves a service factory by type and optional ID.
+// If the ID is empty, the default factory for the type is returned.
+func (fr *FactoryRegistry) Load(serviceType ServiceType, id string) (ServiceFactory, bool) {
+	key := serviceType
+	if id != "" {
+		key = ServiceType(fmt.Sprintf("%s:%s", serviceType.String(), id))
+	}
+	return fr.Registry.Load(key)
 }
 
 func (fr *FactoryRegistry) Copy() *FactoryRegistry {
 	return &FactoryRegistry{fr.Registry.Copy()}
 }
 
+// CreateService creates a new service instance from the default factory for the given type.
 func (fr *FactoryRegistry) CreateService(ctx context.Context, serviceType ServiceType) (Service, error) {
 	factory := fr.Get(serviceType)
 	if factory == nil {

--- a/pkg/services/reporter/factory.go
+++ b/pkg/services/reporter/factory.go
@@ -54,26 +54,16 @@ func (f *Factory) Init(ctx context.Context, cfg any) error {
 }
 
 func (f *Factory) Create(ctx context.Context) (services.Service, error) {
-	var factory services.ServiceFactory
-	if f.config.EventStoreID == "" {
-		// get default event store factory
-		factory = f.factoryRegistry.Get(eventstore.TypeEventStore)
-	} else {
-		// get named event store factory
-		factory, _ = f.factoryRegistry.Load(eventstore.TypeEventStore, f.config.EventStoreID)
-	}
-
-	if factory == nil {
-		return nil, errors.New("event store factory not found")
-	}
-
-	svc, err := factory.Create(ctx)
+	svc, err := f.factoryRegistry.CreateService(ctx, eventstore.TypeEventStore, f.config.EventStoreID)
 	if err != nil {
 		return nil, fmt.Errorf("creating event store: %w", err)
 	}
 	es, ok := svc.(eventstore.EventStore)
 	if !ok {
 		return nil, errors.New("service is not an eventstore.EventStore")
+	}
+	if l, ok := es.(services.LoggerAdapter); ok {
+		l.SetLogger(f.logger)
 	}
 
 	ctx, cancel := context.WithCancel(ctx)
@@ -83,6 +73,6 @@ func (f *Factory) Create(ctx context.Context) (services.Service, error) {
 		firstReportDeadline: f.config.FirstReportDeadline,
 		reportInterval:      f.config.ReportInterval,
 		eventStore:          es,
-		// logToConsole:        f.config.EventStoreID == "", // log to the console only if this is the default reporter
+		logToConsole:        f.config.EventStoreID == "", // log to the console only if this is the default reporter
 	}, nil
 }

--- a/pkg/services/reporter/factory.go
+++ b/pkg/services/reporter/factory.go
@@ -25,7 +25,7 @@ type Config struct {
 	// FirstReportDeadline ensures that a report is sent after a connection has been open for at least this duration.
 	FirstReportDeadline time.Duration
 
-	// ReportInterval sets an optional reporting interval meant for long-running connections.
+	// ReportInterval sets an optional interval for recurring reports following the first report.
 	ReportInterval time.Duration
 }
 

--- a/pkg/services/reporter/factory.go
+++ b/pkg/services/reporter/factory.go
@@ -1,0 +1,88 @@
+package reporter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/qpoint-io/qtap/pkg/services"
+	"github.com/qpoint-io/qtap/pkg/services/eventstore"
+	"go.uber.org/zap"
+)
+
+const Type services.ServiceType = "reporter"
+
+type Factory struct {
+	factoryRegistry *services.FactoryRegistry
+	logger          *zap.Logger
+	config          *Config
+}
+
+type Config struct {
+	EventStoreID string
+
+	// FirstReportDeadline ensures that a report is sent after a connection has been open for at least this duration.
+	FirstReportDeadline time.Duration
+
+	// ReportInterval sets an optional reporting interval meant for long-running connections.
+	ReportInterval time.Duration
+}
+
+func (f *Factory) FactoryType() services.ServiceType {
+	return Type
+}
+
+func (f *Factory) ServiceType() services.ServiceType {
+	return Type
+}
+
+// SetFactoryRegistry implements the SetFactoryRegistry interface.
+func (f *Factory) SetFactoryRegistry(registry *services.FactoryRegistry) {
+	f.factoryRegistry = registry
+}
+
+func (f *Factory) Init(ctx context.Context, cfg any) error {
+	c, ok := cfg.(*Config)
+	if !ok {
+		return fmt.Errorf("invalid config type: %T wanted Config", cfg)
+	}
+	f.config = c
+	f.logger = zap.L().With(zap.String("service_factory", f.FactoryType().String()))
+
+	return nil
+}
+
+func (f *Factory) Create(ctx context.Context) (services.Service, error) {
+	var factory services.ServiceFactory
+	if f.config.EventStoreID == "" {
+		// get default event store factory
+		factory = f.factoryRegistry.Get(eventstore.TypeEventStore)
+	} else {
+		// get named event store factory
+		factory, _ = f.factoryRegistry.Load(eventstore.TypeEventStore, f.config.EventStoreID)
+	}
+
+	if factory == nil {
+		return nil, errors.New("event store factory not found")
+	}
+
+	svc, err := factory.Create(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("creating event store: %w", err)
+	}
+	es, ok := svc.(eventstore.EventStore)
+	if !ok {
+		return nil, errors.New("service is not an eventstore.EventStore")
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	return &service{
+		ctx:                 ctx,
+		cancel:              cancel,
+		firstReportDeadline: f.config.FirstReportDeadline,
+		reportInterval:      f.config.ReportInterval,
+		eventStore:          es,
+		// logToConsole:        f.config.EventStoreID == "", // log to the console only if this is the default reporter
+	}, nil
+}

--- a/pkg/services/reporter/reporter.go
+++ b/pkg/services/reporter/reporter.go
@@ -92,7 +92,7 @@ func (s *service) report() {
 
 	// debug log
 	if s.logToConsole {
-		s.logger.Debug("audit log", zap.Any("connection", connection))
+		s.logger.Debug("connection report", zap.Any("connection", connection))
 	}
 
 	// increment report count for next report

--- a/pkg/services/reporter/reporter.go
+++ b/pkg/services/reporter/reporter.go
@@ -34,7 +34,7 @@ func (s *service) SetConnection(conn *connection.Connection) {
 	s.conn = conn
 
 	// now that we have the connection, we can kick off the loop
-	s.start()
+	go s.start()
 }
 
 // SetLogger implements the LoggerAdapter interface.
@@ -43,29 +43,34 @@ func (s *service) SetLogger(logger *zap.Logger) {
 }
 
 func (s *service) start() {
-	if s.firstReportDeadline > 0 && s.firstReportDeadline < s.reportInterval {
-		go func() {
-			select {
-			case <-s.ctx.Done():
-				return
-			case <-time.After(s.firstReportDeadline):
-				s.report()
-			}
-		}()
+	// kick off the first report
+	if s.firstReportDeadline > 0 {
+		select {
+		case <-s.ctx.Done():
+			return
+		case <-time.After(s.firstReportDeadline):
+			// send the first report
+			s.report()
+		}
 	}
 
-	if s.reportInterval > 0 {
-		go func() {
-			tick := time.Tick(s.reportInterval)
-			for {
-				select {
-				case <-s.ctx.Done():
-					return
-				case <-tick:
-					s.report()
-				}
-			}
-		}()
+	// start the recurring reports
+	s.startRecurringReports()
+}
+
+func (s *service) startRecurringReports() {
+	if s.reportInterval == 0 || s.ctx.Err() != nil {
+		return
+	}
+
+	tick := time.Tick(s.reportInterval)
+	for {
+		select {
+		case <-s.ctx.Done():
+			return
+		case <-tick:
+			s.report()
+		}
 	}
 }
 

--- a/pkg/services/reporter/reporter.go
+++ b/pkg/services/reporter/reporter.go
@@ -1,85 +1,127 @@
-package connection
+package reporter
 
 import (
-	"strings"
+	"context"
+	"sync"
 	"time"
 
+	"github.com/qpoint-io/qtap/pkg/connection"
 	"github.com/qpoint-io/qtap/pkg/process"
+	"github.com/qpoint-io/qtap/pkg/services"
 	"github.com/qpoint-io/qtap/pkg/services/eventstore"
 	"github.com/qpoint-io/qtap/pkg/telemetry"
 	"go.uber.org/zap"
 )
 
-func (m *Manager) generateAuditLog(conn *Connection) {
-	if conn.eventStore == nil {
-		conn.logger.Debug("generateAuditLog: no event store, skipping")
-		return
+// service runs for the duration of the connection and sends reports to the event store.
+type service struct {
+	conn                *connection.Connection
+	eventStore          eventstore.EventStore
+	logToConsole        bool
+	firstReportDeadline time.Duration
+	reportInterval      time.Duration
+	logger              *zap.Logger
+
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	reportCount uint32
+	mu          sync.Mutex
+}
+
+// SetConnection implements the ConnectionAdapter interface.
+func (s *service) SetConnection(conn *connection.Connection) {
+	s.conn = conn
+
+	// now that we have the connection, we can kick off the loop
+	s.start()
+}
+
+// SetLogger implements the LoggerAdapter interface.
+func (s *service) SetLogger(logger *zap.Logger) {
+	s.logger = logger
+}
+
+func (s *service) start() {
+	if s.firstReportDeadline > 0 && s.firstReportDeadline < s.reportInterval {
+		go func() {
+			select {
+			case <-s.ctx.Done():
+				return
+			case <-time.After(s.firstReportDeadline):
+				s.report()
+			}
+		}()
 	}
 
-	if conn.HandlerType == HandlerType_FORWARDING {
-		conn.logger.Debug("generateAuditLog: forwarding connection detected, ignoring audit")
+	if s.reportInterval > 0 {
+		go func() {
+			tick := time.Tick(s.reportInterval)
+			for {
+				select {
+				case <-s.ctx.Done():
+					return
+				case <-tick:
+					s.report()
+				}
+			}
+		}()
+	}
+}
+
+func (s *service) report() {
+	ok := s.mu.TryLock()
+	if !ok {
+		// if the mutex is locked, another report is already in progress
 		return
 	}
+	defer s.mu.Unlock()
 
-	// if this is DNS, ensure we're wanted
-	if m.config != nil && conn.Protocol == Protocol_DNS && !m.config.Tap.AuditIncludeDNS {
-		m.logger.Debug("generateAuditLog: DNS audit log disabled",
-			zap.String("conn_pid_id", conn.connPIDKey.String()),
-			zap.String("local_addr", conn.OpenEvent.Local.String()),
-			zap.String("remote_addr", conn.OpenEvent.Remote.String()))
-		return
-	}
-
-	// if the domain is '<nil>' it means the destination IP had a 0 length and something was
+	// if the domain is empty it means the destination IP had a 0 length and something was
 	// interupted in the socket layer. The connection is invalid and we can safely ignore it.
-	if strings.EqualFold(conn.Domain(), "<nil>") {
-		m.logger.Debug("generateAuditLog: domain is <nil>, ignoring",
-			zap.String("conn_pid_id", conn.connPIDKey.String()),
-			zap.String("local_addr", conn.OpenEvent.Local.String()),
-			zap.String("remote_addr", conn.OpenEvent.Remote.String()))
+	if s.conn.Domain() == "" {
 		return
 	}
 
-	// audit logs are disabled, nothing to do
-	if m.config != nil {
-		if !m.config.Services.HasAnyEventStores() {
-			m.logger.Debug("generateAuditLog: audit logs disabled",
-				zap.String("conn_pid_id", conn.connPIDKey.String()),
-				zap.String("local_addr", conn.OpenEvent.Local.String()),
-				zap.String("remote_addr", conn.OpenEvent.Remote.String()))
-			return
-		}
-	}
-
-	// set original destination if available
-	if od := conn.OriginalDestination; od != nil {
-		conn.OpenEvent.Remote = *od
-	}
-
-	connection := toEventStoreConnection(conn)
+	connection := toEventStoreConnection(s.conn)
+	connection.Part = s.reportCount // set event store specific part number
 	connection.Timestamp = time.Now()
 
 	// generate the log
-	conn.eventStore.Save(conn.ctx, connection)
+	s.eventStore.Save(s.conn.Context(), connection)
 
 	// debug log
-	conn.logger.Debug("audit log", zap.Any("connection", connection))
+	if s.logToConsole {
+		s.logger.Debug("audit log", zap.Any("connection", connection))
+	}
 
 	// increment report count for next report
-	conn.auditCount++
+	s.reportCount++
 }
 
-func toEventStoreConnection(conn *Connection) *eventstore.Connection {
+func (s *service) Close() error {
+	// cancel the tickers
+	s.cancel()
+
+	// send a final report
+	s.report()
+	return nil
+}
+
+func (s *service) ServiceType() services.ServiceType {
+	return Type
+}
+
+func toEventStoreConnection(conn *connection.Connection) *eventstore.Connection {
 	c := &eventstore.Connection{
 		Finalized: conn.CloseEvent != nil,
-		Part:      conn.auditCount,
 		System: &eventstore.ConnectionSystem{
 			Hostname:      telemetry.Hostname(),
 			Agent:         "tap",
 			AgentInstance: telemetry.InstanceID(),
 		},
 		L7Protocol: toEventStoreL7Protocol(conn.Protocol),
-		Labels:     conn.labels.Items(),
+		Labels:     conn.Labels().Items(),
 	}
 	c.SetConnectionID(conn.ID())
 	c.SetEndpointID(conn.Domain())
@@ -99,7 +141,7 @@ func toEventStoreConnection(conn *Connection) *eventstore.Connection {
 
 	// For TLS connections that have data events we can resolve
 	// that the connection was introspected by one of the probes
-	if conn.IsTLS && conn.dataEventCount > 0 {
+	if conn.IsTLS && conn.DataEventCount() > 0 {
 		c.TLSIntrospected = true
 	}
 
@@ -108,7 +150,7 @@ func toEventStoreConnection(conn *Connection) *eventstore.Connection {
 		localEndpoint := &eventstore.ConnectionEndpointLocal{
 			Address: conn.OpenEvent.Local,
 		}
-		if proc := conn.process; proc != nil {
+		if proc := conn.Process(); proc != nil {
 			localEndpoint.Exe = proc.Exe
 
 			if hostname, _ := proc.Hostname(); hostname != "" {
@@ -133,7 +175,7 @@ func toEventStoreConnection(conn *Connection) *eventstore.Connection {
 
 		// client vs server
 		switch conn.OpenEvent.Source {
-		case Client:
+		case connection.Client:
 			if conn.OpenEvent.Remote.IP.IsPrivate() {
 				c.Direction = eventstore.Direction_EgressInternal
 			} else {
@@ -142,7 +184,7 @@ func toEventStoreConnection(conn *Connection) *eventstore.Connection {
 			c.Source = localEndpoint
 			c.Destination = remoteEndpoint
 
-		case Server:
+		case connection.Server:
 			c.Direction = eventstore.Direction_Ingress
 			c.Source = remoteEndpoint
 			c.Destination = localEndpoint
@@ -152,30 +194,30 @@ func toEventStoreConnection(conn *Connection) *eventstore.Connection {
 	return c
 }
 
-func toEventStoreSocketType(socketType SocketType) eventstore.SocketProtocol {
+func toEventStoreSocketType(socketType connection.SocketType) eventstore.SocketProtocol {
 	switch socketType {
-	case SocketType_TCP:
+	case connection.SocketType_TCP:
 		return eventstore.SocketProtocol_TCP
-	case SocketType_UDP:
+	case connection.SocketType_UDP:
 		return eventstore.SocketProtocol_UDP
-	case SocketType_RAW:
+	case connection.SocketType_RAW:
 		return eventstore.SocketProtocol_RAW
-	case SocketType_ICMP:
+	case connection.SocketType_ICMP:
 		return eventstore.SocketProtocol_ICMP
 	default:
 		return ""
 	}
 }
 
-func toEventStoreL7Protocol(protocol Protocol) eventstore.L7Protocol {
+func toEventStoreL7Protocol(protocol connection.Protocol) eventstore.L7Protocol {
 	switch protocol {
-	case Protocol_HTTP1:
+	case connection.Protocol_HTTP1:
 		return eventstore.L7Protocol_HTTP1
-	case Protocol_HTTP2:
+	case connection.Protocol_HTTP2:
 		return eventstore.L7Protocol_HTTP2
-	case Protocol_DNS:
+	case connection.Protocol_DNS:
 		return eventstore.L7Protocol_DNS
-	case Protocol_GRPC:
+	case connection.Protocol_GRPC:
 		return eventstore.L7Protocol_GRPC
 	default:
 		return eventstore.L7Protocol_OTHER

--- a/pkg/services/reporter/reporter.go
+++ b/pkg/services/reporter/reporter.go
@@ -32,6 +32,9 @@ type service struct {
 // SetConnection implements the ConnectionAdapter interface.
 func (s *service) SetConnection(conn *connection.Connection) {
 	s.conn = conn
+	if es, ok := s.eventStore.(connection.ConnectionAdapter); ok {
+		es.SetConnection(conn)
+	}
 
 	// now that we have the connection, we can kick off the loop
 	go s.start()

--- a/pkg/services/reporter/reporter_test.go
+++ b/pkg/services/reporter/reporter_test.go
@@ -1,4 +1,4 @@
-package connection
+package reporter
 
 import (
 	"crypto/tls"
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/kamaln7/resolvable"
+	"github.com/qpoint-io/qtap/pkg/connection"
 	"github.com/qpoint-io/qtap/pkg/process"
 	"github.com/qpoint-io/qtap/pkg/qnet"
 	"github.com/qpoint-io/qtap/pkg/services/eventstore"
@@ -28,6 +29,7 @@ func Test_toEventStoreConnection(t *testing.T) {
 			Name:      "pod-name",
 			Namespace: "pod-namespace",
 		}).WithBackgroundContext(),
+		UserShell: resolvable.Static(true).WithBackgroundContext(),
 	}
 	process.SetHostname("local-hostname")
 	process.SetUser(1000, "test-user")
@@ -35,7 +37,7 @@ func Test_toEventStoreConnection(t *testing.T) {
 	t.Run("ingress connection", func(t *testing.T) {
 		conn := &eventstore.Connection{
 			Direction: eventstore.Direction_Ingress,
-			Part:      1,
+			Part:      0,
 			Finalized: true,
 			System: &eventstore.ConnectionSystem{
 				Hostname:      telemetry.Hostname(),
@@ -43,8 +45,14 @@ func Test_toEventStoreConnection(t *testing.T) {
 				AgentInstance: telemetry.InstanceID(),
 			},
 			Tags: map[string][]string{
-				"tag1": {"value1", "value2"},
-				"tag2": {"value"},
+				"tag1":     {"value1", "value2"},
+				"tag2":     {"value"},
+				"strategy": {"observe"},
+				"host":     {"local-hostname"},
+				"ip":       {"5.6.7.8"},
+			},
+			Labels: []string{
+				"user-shell",
 			},
 			Source: &eventstore.ConnectionEndpointRemote{
 				Address: qnet.NetAddr{
@@ -77,50 +85,46 @@ func Test_toEventStoreConnection(t *testing.T) {
 			SocketProtocol: eventstore.SocketProtocol_TCP,
 			L7Protocol:     eventstore.L7Protocol_HTTP1,
 		}
-		conn.SetConnectionID("test-conn-id")
 		conn.SetEndpointID("example.com")
 
-		assert.Equal(t,
-			conn,
-			toEventStoreConnection(&Connection{
-				logger:     zaptest.NewLogger(t),
-				id:         "test-conn-id",
-				domain:     "example.com",
-				auditCount: 1,
-				tags: tags.FromMultiValues(map[string][]string{
-					"tag1": {"value1", "value2"},
-					"tag2": {"value"},
-				}),
-				TLSClientHello: &tlsutils.ClientHello{
-					Version: tls.VersionTLS13,
+		origConn := connection.NewConnection(
+			t.Context(),
+			zaptest.NewLogger(t),
+			&connection.OpenEvent{
+				Local: qnet.NetAddr{
+					IP:   net.ParseIP("5.6.7.8"),
+					Port: 5678,
 				},
-				Protocol: Protocol_HTTP1,
-				OpenEvent: &OpenEvent{
-					Local: qnet.NetAddr{
-						IP:   net.ParseIP("5.6.7.8"),
-						Port: 5678,
-					},
-					Remote: qnet.NetAddr{
-						IP:   net.ParseIP("1.2.3.4"),
-						Port: 1234,
-					},
-					Source:       Server,
-					SocketType:   SocketType_TCP,
-					IsRedirected: false,
+				Remote: qnet.NetAddr{
+					IP:   net.ParseIP("1.2.3.4"),
+					Port: 1234,
 				},
-				CloseEvent: &CloseEvent{
-					WrBytes: 2000,
-					RdBytes: 1000,
-				},
-				process: process,
-			}),
+				Source:       connection.Server,
+				SocketType:   connection.SocketType_TCP,
+				IsRedirected: false,
+			},
+			connection.WithProcess(process),
+			connection.WithTags(tags.FromMultiValues(map[string][]string{
+				"tag1": {"value1", "value2"},
+				"tag2": {"value"},
+			})),
 		)
+		origConn.SetDomain("example.com")
+		origConn.TLSClientHello = &tlsutils.ClientHello{
+			Version: tls.VersionTLS13,
+		}
+		origConn.Protocol = connection.Protocol_HTTP1
+		origConn.CloseEvent = &connection.CloseEvent{WrBytes: 2000, RdBytes: 1000}
+
+		// sync up the randomly generated connection ID
+		conn.SetConnectionID(origConn.ID())
+		assert.Equal(t, conn, toEventStoreConnection(origConn))
 	})
 
 	t.Run("egress connection", func(t *testing.T) {
 		conn := &eventstore.Connection{
 			Direction: eventstore.Direction_EgressExternal,
-			Part:      1,
+			Part:      0,
 			Finalized: true,
 			System: &eventstore.ConnectionSystem{
 				Hostname:      telemetry.Hostname(),
@@ -128,8 +132,14 @@ func Test_toEventStoreConnection(t *testing.T) {
 				AgentInstance: telemetry.InstanceID(),
 			},
 			Tags: map[string][]string{
-				"tag1": {"value1", "value2"},
-				"tag2": {"value"},
+				"tag1":     {"value1", "value2"},
+				"tag2":     {"value"},
+				"strategy": {"observe"},
+				"host":     {"local-hostname"},
+				"ip":       {"5.6.7.8"},
+			},
+			Labels: []string{
+				"user-shell",
 			},
 			Source: &eventstore.ConnectionEndpointLocal{
 				Address: qnet.NetAddr{
@@ -162,43 +172,39 @@ func Test_toEventStoreConnection(t *testing.T) {
 			SocketProtocol: eventstore.SocketProtocol_UDP,
 			L7Protocol:     eventstore.L7Protocol_HTTP2,
 		}
-		conn.SetConnectionID("test-conn-id")
 		conn.SetEndpointID("example.com")
 
-		assert.Equal(t,
-			conn,
-			toEventStoreConnection(&Connection{
-				logger:     zaptest.NewLogger(t),
-				id:         "test-conn-id",
-				domain:     "example.com",
-				auditCount: 1,
-				tags: tags.FromMultiValues(map[string][]string{
-					"tag1": {"value1", "value2"},
-					"tag2": {"value"},
-				}),
-				TLSClientHello: &tlsutils.ClientHello{
-					Version: tls.VersionTLS13,
+		origConn := connection.NewConnection(
+			t.Context(),
+			zaptest.NewLogger(t),
+			&connection.OpenEvent{
+				Local: qnet.NetAddr{
+					IP:   net.ParseIP("5.6.7.8"),
+					Port: 5678,
 				},
-				OpenEvent: &OpenEvent{
-					Local: qnet.NetAddr{
-						IP:   net.ParseIP("5.6.7.8"),
-						Port: 5678,
-					},
-					Remote: qnet.NetAddr{
-						IP:   net.ParseIP("1.2.3.4"),
-						Port: 1234,
-					},
-					Source:       Client,
-					SocketType:   SocketType_UDP,
-					IsRedirected: false,
+				Remote: qnet.NetAddr{
+					IP:   net.ParseIP("1.2.3.4"),
+					Port: 1234,
 				},
-				CloseEvent: &CloseEvent{
-					WrBytes: 2000,
-					RdBytes: 1000,
-				},
-				process:  process,
-				Protocol: Protocol_HTTP2,
-			}),
+				Source:       connection.Client,
+				SocketType:   connection.SocketType_UDP,
+				IsRedirected: false,
+			},
+			connection.WithProcess(process),
+			connection.WithTags(tags.FromMultiValues(map[string][]string{
+				"tag1": {"value1", "value2"},
+				"tag2": {"value"},
+			})),
 		)
+		origConn.SetDomain("example.com")
+		origConn.TLSClientHello = &tlsutils.ClientHello{
+			Version: tls.VersionTLS13,
+		}
+		origConn.CloseEvent = &connection.CloseEvent{WrBytes: 2000, RdBytes: 1000}
+		origConn.Protocol = connection.Protocol_HTTP2
+
+		// sync up the randomly generated connection ID
+		conn.SetConnectionID(origConn.ID())
+		assert.Equal(t, conn, toEventStoreConnection(origConn))
 	})
 }

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -36,13 +36,7 @@ type ServiceFactory interface {
 
 // SetFactoryRegistry sets the factory registry for the service
 type SetFactoryRegistry interface {
-	SetFactoryRegistry(registry FactoryRegistryAccessor)
-}
-
-// FactoryRegistryAccessor is a type that can access the service registry
-type FactoryRegistryAccessor interface {
-	// CreateService creates a service by type
-	CreateService(ctx context.Context, serviceType ServiceType) (Service, error)
+	SetFactoryRegistry(registry *FactoryRegistry)
 }
 
 // NextFactory indicates that a factory will handle graceful replacements


### PR DESCRIPTION
- replace the `generateAuditLog` system built into the connection manager with a `reporter` service dedicated to creating reports.
- the new service is configurable:
    ```go
	// FirstReportDeadline ensures that a report is sent after a connection has been open for at least this duration.
	FirstReportDeadline time.Duration

	// ReportInterval sets an optional interval for recurring reports following the first report.
	ReportInterval time.Duration
    ```
- we can create multiple instances of the service with different configs for a single connection
- lay the foundation for per-plugin event/object stores