### PR TITLE
clean up `<nil>` strings

### DIFF
--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -169,7 +169,7 @@ func NewConnection(ctx context.Context, logger *zap.Logger, openEvent *OpenEvent
 	// } else {
 	// 	t.Add("ip", openEvent.Remote.IP.String())
 	// }
-	t.Add("ip", openEvent.Local.IP.String())
+	t.Add("ip", qnet.IPString(openEvent.Local.IP))
 
 	logger = logger.With(zap.String("conn_id", id), zap.Any("cookie", openEvent.Cookie))
 	c := &Connection{
@@ -292,8 +292,8 @@ func (c *Connection) Open() {
 		c.logger.Debug("opening connection")
 
 		// report metrics
-		connOpenTotal.WithLabelValues(c.OpenEvent.Remote.IP.String(), strconv.Itoa(int(c.OpenEvent.Remote.Port)), c.Direction()).Inc()
-		connActiveTotal.WithLabelValues(c.OpenEvent.Remote.IP.String(), strconv.Itoa(int(c.OpenEvent.Remote.Port)), c.Direction()).Inc()
+		connOpenTotal.WithLabelValues(qnet.IPString(c.OpenEvent.Remote.IP), strconv.Itoa(int(c.OpenEvent.Remote.Port)), c.Direction()).Inc()
+		connActiveTotal.WithLabelValues(qnet.IPString(c.OpenEvent.Remote.IP), strconv.Itoa(int(c.OpenEvent.Remote.Port)), c.Direction()).Inc()
 
 		// Check that the process was redirected if this processes connections
 		// are intended to be forwarded/proxied.
@@ -371,11 +371,11 @@ func (c *Connection) Close() {
 	defer c.cancel()
 
 	// report metrics
-	connCloseTotal.WithLabelValues(c.OpenEvent.Remote.IP.String(), strconv.Itoa(int(c.OpenEvent.Remote.Port)), c.Direction()).Inc()
-	connActiveTotal.WithLabelValues(c.OpenEvent.Remote.IP.String(), strconv.Itoa(int(c.OpenEvent.Remote.Port)), c.Direction()).Dec()
-	connDuration.WithLabelValues(c.OpenEvent.Remote.IP.String(), strconv.Itoa(int(c.OpenEvent.Remote.Port))).Observe(float64(c.report.closeTime.Sub(c.report.openTime).Milliseconds()))
-	connBytesSentTotal.WithLabelValues(c.OpenEvent.Remote.IP.String(), strconv.Itoa(int(c.OpenEvent.Remote.Port)), c.Direction()).Add(float64(c.CloseEvent.WrBytes))
-	connBytesRecvTotal.WithLabelValues(c.OpenEvent.Remote.IP.String(), strconv.Itoa(int(c.OpenEvent.Remote.Port)), c.Direction()).Add(float64(c.CloseEvent.RdBytes))
+	connCloseTotal.WithLabelValues(qnet.IPString(c.OpenEvent.Remote.IP), strconv.Itoa(int(c.OpenEvent.Remote.Port)), c.Direction()).Inc()
+	connActiveTotal.WithLabelValues(qnet.IPString(c.OpenEvent.Remote.IP), strconv.Itoa(int(c.OpenEvent.Remote.Port)), c.Direction()).Dec()
+	connDuration.WithLabelValues(qnet.IPString(c.OpenEvent.Remote.IP), strconv.Itoa(int(c.OpenEvent.Remote.Port))).Observe(float64(c.report.closeTime.Sub(c.report.openTime).Milliseconds()))
+	connBytesSentTotal.WithLabelValues(qnet.IPString(c.OpenEvent.Remote.IP), strconv.Itoa(int(c.OpenEvent.Remote.Port)), c.Direction()).Add(float64(c.CloseEvent.WrBytes))
+	connBytesRecvTotal.WithLabelValues(qnet.IPString(c.OpenEvent.Remote.IP), strconv.Itoa(int(c.OpenEvent.Remote.Port)), c.Direction()).Add(float64(c.CloseEvent.RdBytes))
 
 	span := trace.SpanFromContext(c.ctx)
 	defer span.End()
@@ -477,9 +477,9 @@ func (c *Connection) Domain() string {
 	if c.domain == "" {
 		// if we have an original destination, use that
 		if c.OriginalDestination != nil {
-			c.domain = c.OriginalDestination.IP.String()
+			c.domain = qnet.IPString(c.OriginalDestination.IP)
 		} else {
-			c.domain = dstAddr.IP.String()
+			c.domain = qnet.IPString(dstAddr.IP)
 		}
 		c.domainIsIP = true
 	}

--- a/pkg/connection/reader.go
+++ b/pkg/connection/reader.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/qpoint-io/qtap/pkg/dns"
+	"github.com/qpoint-io/qtap/pkg/qnet"
 	"go.uber.org/zap"
 )
 
@@ -129,7 +130,7 @@ func (c *Connection) processProtocolEvent(event ProtocolEvent) {
 	}
 
 	// report metrics
-	connProtocolTotal.WithLabelValues(c.OpenEvent.Remote.IP.String(), strconv.Itoa(int(c.OpenEvent.Remote.Port)), c.Direction(), c.Protocol.String()).Inc()
+	connProtocolTotal.WithLabelValues(qnet.IPString(c.OpenEvent.Remote.IP), strconv.Itoa(int(c.OpenEvent.Remote.Port)), c.Direction(), c.Protocol.String()).Inc()
 
 	// use the protocol event to create a stream processor
 	c.streamProcessor = c.services.createStreamer(c)
@@ -172,7 +173,7 @@ func (c *Connection) processOriginalDestinationEvent(event OriginalDestinationEv
 	c.OriginalDestination = &event.Destination
 
 	// set original destination as domain
-	c.SetDomain(event.Destination.IP.String())
+	c.SetDomain(qnet.IPString(event.Destination.IP))
 }
 
 func (c *Connection) processErrorEvent(event ErrorEvent) {
@@ -247,7 +248,7 @@ func (c *Connection) processTLSClientHelloEvent(event TLSClientHelloEvent) {
 	}
 
 	// report metrics
-	connTLSHandshakeTotal.WithLabelValues(c.OpenEvent.Remote.IP.String(), strconv.Itoa(int(c.OpenEvent.Remote.Port)), c.Direction(), event.Msg.SNI, event.Msg.Version.String()).Inc()
+	connTLSHandshakeTotal.WithLabelValues(qnet.IPString(c.OpenEvent.Remote.IP), strconv.Itoa(int(c.OpenEvent.Remote.Port)), c.Direction(), event.Msg.SNI, event.Msg.Version.String()).Inc()
 
 	c.TLSClientHello = event.Msg
 }

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -3,6 +3,8 @@ package dns
 import (
 	"net"
 	"syscall"
+
+	"github.com/qpoint-io/qtap/pkg/qnet"
 )
 
 // DNS record entry
@@ -36,5 +38,5 @@ func (r Record) IP() net.IP {
 }
 
 func (r Record) IpString() string {
-	return r.IP().String()
+	return qnet.IPString(r.IP())
 }

--- a/pkg/dns/manager.go
+++ b/pkg/dns/manager.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/qpoint-io/qtap/pkg/process"
+	"github.com/qpoint-io/qtap/pkg/qnet"
 	"github.com/qpoint-io/qtap/pkg/synq"
 	"github.com/qpoint-io/qtap/pkg/telemetry/metrics"
 	"go.uber.org/zap"
@@ -82,7 +83,7 @@ func (m *DNSManager) Lookup(addr [16]byte, containerID string) (*Record, error) 
 	ip := net.IP(addr[:])
 
 	// grab an IP string
-	ipString := ip.String()
+	ipString := qnet.IPString(ip)
 
 	// lookup domains
 	domains, err := net.LookupAddr(ipString)

--- a/pkg/ebpf/socket/socket.go
+++ b/pkg/ebpf/socket/socket.go
@@ -137,7 +137,7 @@ func (a netAddr) AddrString() string {
 	case a.Port == 0 && a.SaFamily == syscall.AF_INET6:
 		return "::"
 	default:
-		return net.IP(a.Addr[:a.AddrSize()]).String()
+		return qnet.IPString(net.IP(a.Addr[:a.AddrSize()]))
 	}
 }
 

--- a/pkg/ebpf/trace/reader.go
+++ b/pkg/ebpf/trace/reader.go
@@ -9,6 +9,7 @@ import (
 	"unsafe"
 
 	"github.com/cilium/ebpf/ringbuf"
+	"github.com/qpoint-io/qtap/pkg/qnet"
 	"go.uber.org/zap"
 )
 
@@ -182,7 +183,7 @@ func (m *TraceManager) readAttrEvent(r *bytes.Reader, event *TraceEventMeta) err
 
 		ip := make([]byte, 4)
 		binary.BigEndian.PutUint32(ip, ip4Value)
-		entry.AddField(zap.String(titleString, net.IP(ip).String()))
+		entry.AddField(zap.String(titleString, qnet.IPString(net.IP(ip))))
 	case TraceIP6:
 		var ip6Value [4]uint32
 		if err := binary.Read(r, binary.BigEndian, &ip6Value); err != nil {
@@ -194,7 +195,7 @@ func (m *TraceManager) readAttrEvent(r *bytes.Reader, event *TraceEventMeta) err
 		for i := range 4 {
 			binary.BigEndian.PutUint32(ip[i*4:], ip6Value[i])
 		}
-		entry.AddField(zap.String(titleString, net.IP(ip).String()))
+		entry.AddField(zap.String(titleString, qnet.IPString(net.IP(ip))))
 	}
 
 	return nil

--- a/pkg/qnet/addr.go
+++ b/pkg/qnet/addr.go
@@ -35,7 +35,7 @@ func (na NetAddr) Network() string {
 func (na NetAddr) String() string {
 	switch na.Family {
 	case NetFamily_IPv4, NetFamily_IPv6:
-		return net.JoinHostPort(na.IP.String(), strconv.Itoa(int(na.Port)))
+		return net.JoinHostPort(IPString(na.IP), strconv.Itoa(int(na.Port)))
 	default:
 		return "unknown"
 	}
@@ -81,4 +81,11 @@ func (na NetAddr) ControlValues() map[string]any {
 		"ip":   na.IP,
 		"port": int(na.Port),
 	}
+}
+
+func IPString(ip net.IP) string {
+	if len(ip) == 0 {
+		return ""
+	}
+	return ip.String()
 }


### PR DESCRIPTION
`net.IP`'s .`String()` returns `"<nil>"` if the IP is a zero value. Use a helper method to return `""` instead.