### PR TITLE
Refactor logging levels to reduce verbosity across multiple components

### DIFF
--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -82,7 +82,7 @@ func mainSetup() error {
 		// hit the google DNS to get the machines local IP
 		conn, err := net.Dial("udp", "8.8.8.8:80")
 		if err != nil {
-			logger.Info("⚠️ failed to get machine IP", zap.Error(err))
+			logger.Warn("⚠️ failed to get machine IP", zap.Error(err))
 		}
 		conn.Close()
 

--- a/pkg/config/local_provider.go
+++ b/pkg/config/local_provider.go
@@ -42,7 +42,7 @@ func NewLocalConfigProvider(logger *zap.Logger, configPath string) *LocalConfigP
 	if isURL {
 		// Create a temp file for caching downloaded configs
 		cacheFile = filepath.Join(os.TempDir(), fmt.Sprintf("qtap-config-%s.yaml", generateCacheKey(configPath)))
-		logger.Info("URL config detected, will cache to temp file",
+		logger.Debug("URL config detected, will cache to temp file",
 			zap.String("url", configPath),
 			zap.String("cache_file", cacheFile))
 	}

--- a/pkg/connection/manager.go
+++ b/pkg/connection/manager.go
@@ -126,7 +126,7 @@ func (m *Manager) HandleEvent(event Keyer) {
 		if conn.Process() == nil && conn.OpenEvent != nil {
 			proc := m.processManager.Get(int(conn.OpenEvent.PID))
 			if proc != nil {
-				m.logger.Info("discovered process", zap.Int("pid", proc.Pid))
+				m.logger.Debug("discovered process", zap.Int("pid", proc.Pid))
 				conn.SetProcess(proc)
 			}
 		}

--- a/pkg/container/containerd.go
+++ b/pkg/container/containerd.go
@@ -199,7 +199,7 @@ func (c *Containerd) buildContainerRecord(ctx context.Context, container contain
 	}
 	task, err := container.Task(ctx, nil)
 	if err != nil {
-		c.logger.Info("get task failed", zap.Error(err))
+		c.logger.Debug("get task failed", zap.Error(err))
 	}
 
 	name := getContainerName(info.Labels)
@@ -217,7 +217,7 @@ func (c *Containerd) buildContainerRecord(ctx context.Context, container contain
 	// set the rootfs path to the containerd runtime mount path
 	ns, err := namespaces.NamespaceRequired(ctx)
 	if err != nil {
-		c.logger.Info("failed to get namespace from context", zap.Error(err))
+		c.logger.Debug("failed to get namespace from context", zap.Error(err))
 	} else {
 		cr.RootFS = fmt.Sprintf("/run/containerd/io.containerd.runtime.v2.task/%s/%s/rootfs",
 			ns, container.ID())

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -142,7 +142,7 @@ func (c *Context) TestCtx(t *testing.T) *TestContext {
 		T:      t,
 		L:      c.L.With(zap.String("ctxid", id)),
 	}
-	ctx.L.Info("🔧 test context created")
+	ctx.L.Debug("🔧 test context created")
 	return ctx
 }
 
@@ -206,7 +206,7 @@ func (c *TestContext) Exec(name string, args ...string) ExecResult {
 	cmd.Env = []string{
 		fmt.Sprintf("QPOINT_TAGS=ctxid:%s,ctxid:%s", c.ID, id),
 	}
-	c.L.Info("🕹️ executing command", zap.String("cmd", strings.Join(append([]string{name}, args...), " ")))
+	c.L.Debug("🕹️ executing command", zap.String("cmd", strings.Join(append([]string{name}, args...), " ")))
 	out, err := cmd.CombinedOutput()
 	var code int
 	var exitErr *exec.ExitError
@@ -235,14 +235,14 @@ func (c *TestContext) Events(expectedConnections int) *Events {
 func (c *TestContext) WithConfig(t *testing.T, mut ConfigMutator, fn func(*testing.T)) {
 	t.Helper()
 	conf := c.e2ectx.TestConfig(mut)
-	c.L.Info("⚙️ setting test config")
+	c.L.Debug("⚙️ setting test config")
 	c.e2ectx.SetConfig(conf)
-	c.L.Info("✅ new config was propagated")
+	c.L.Debug("✅ new config was propagated")
 
 	defer func() {
-		c.L.Info("⚙️ restoring default config")
+		c.L.Debug("⚙️ restoring default config")
 		c.e2ectx.SetConfig(c.e2ectx.TestConfig(nil))
-		c.L.Info("✅ default config restored")
+		c.L.Debug("✅ default config restored")
 	}()
 
 	fn(t)

--- a/pkg/e2e/eventstore.go
+++ b/pkg/e2e/eventstore.go
@@ -120,13 +120,13 @@ func (f *EventStoreFactory) AwaitByCtxID(id string, numConnections int, timeout 
 
 		events := f.GetByCtxID(id)
 		if first {
-			ll.Info(fmt.Sprintf("waiting for %d connections", numConnections))
+			ll.Debug(fmt.Sprintf("waiting for %d connections", numConnections))
 		} else {
 			ll.Debug(fmt.Sprintf("waiting for %d connections (got %d)", numConnections, len(events.Connections)))
 		}
 
 		if len(events.Connections) >= numConnections {
-			ll.Info(fmt.Sprintf("found %d ≥ %d connections", len(events.Connections), numConnections))
+			ll.Debug(fmt.Sprintf("found %d ≥ %d connections", len(events.Connections), numConnections))
 			return events, nil
 		}
 		time.Sleep(100 * time.Millisecond)

--- a/pkg/e2e/runner.go
+++ b/pkg/e2e/runner.go
@@ -25,7 +25,7 @@ func (r *TestSuiteRunner) Run(t *testing.T, ctx *Context) {
 // run executes all tests in the suite
 func (r *TestSuiteRunner) run(t *testing.T, ctx *Context) {
 	r.Logger.Info("Running test suite", zap.String("suite", r.Suite.name))
-	r.Logger.Info("Total test cases", zap.Int("count", len(r.Suite.testCases)))
+	r.Logger.Debug("Total test cases", zap.Int("count", len(r.Suite.testCases)))
 
 	if len(r.Suite.skipped) > 0 {
 		for _, skip := range r.Suite.skipped {
@@ -138,7 +138,7 @@ func (r *TestSuiteRunner) runSingleTest(t *testing.T, tctx *TestContext, tc Test
 			containerID = containerID[:12]
 		}
 
-		r.Logger.Info("Waiting for process information", zap.String("container_id", containerID))
+		r.Logger.Debug("Waiting for process information", zap.String("container_id", containerID))
 		var pid int
 		select {
 		case pid = <-container.processPID:
@@ -147,11 +147,11 @@ func (r *TestSuiteRunner) runSingleTest(t *testing.T, tctx *TestContext, tc Test
 			return
 		}
 
-		r.Logger.Info("Waiting for process to be ready", zap.Int("pid", pid), zap.String("container_id", containerID))
+		r.Logger.Debug("Waiting for process to be ready", zap.Int("pid", pid), zap.String("container_id", containerID))
 		if err := tctx.WaitForProcess(NewProcessKey(containerID, pid), tc.Request.ReadinessTimeout); err != nil {
 			r.Logger.Warn("Failed to wait for process", zap.Error(err))
 		} else {
-			r.Logger.Info("🆕 creating readiness signal in container")
+			r.Logger.Debug("🆕 creating readiness signal in container")
 			if err := container.Container.CopyToContainer(ctx, []byte("Q"), tc.Request.ReadinessFile+".ready", 0644); err != nil {
 				r.Logger.Warn("Failed to create file in container", zap.Error(err))
 			}
@@ -160,7 +160,7 @@ func (r *TestSuiteRunner) runSingleTest(t *testing.T, tctx *TestContext, tc Test
 
 	var containerResult ContainerResult = <-container.resultCh
 
-	r.Logger.Info("⭕ Container result", zap.String("container_logs", containerResult.Combined()))
+	r.Logger.Debug("⭕ Container result", zap.String("container_logs", containerResult.Combined()))
 
 	// Check container exit code
 	if containerResult.ExitCode != 0 {

--- a/pkg/ebpf/tls/openssl/container.go
+++ b/pkg/ebpf/tls/openssl/container.go
@@ -83,7 +83,7 @@ func (c *Container) Init(p *process.Process) error {
 		c.hasOpenSSL = true
 
 		// debug
-		c.logger.Info("detected OpenSSL shared library",
+		c.logger.Debug("detected OpenSSL shared library",
 			zap.String("path", name),
 			zap.String("container_id", p.ContainerID),
 		)

--- a/pkg/ebpf/tls/openssl/manager.go
+++ b/pkg/ebpf/tls/openssl/manager.go
@@ -228,7 +228,7 @@ func (m *OpenSSLManager) ProcessStarted(p *process.Process) error {
 		p.AddDetectedTLSProbeType("openssl")
 
 		// debug
-		m.logger.Info("OpenSSL static symbols detected",
+		m.logger.Debug("OpenSSL static symbols detected",
 			zap.String("exe", p.Exe),
 			zap.String("container_id", p.ContainerID),
 			zap.Int("pid", p.Pid),

--- a/pkg/plugins/logger/logger.go
+++ b/pkg/plugins/logger/logger.go
@@ -31,7 +31,7 @@ func (f *Factory) Init(logger *zap.Logger, config yaml.Node) {
 
 func (f *Factory) NewInstance(ctx plugins.PluginContext, svcs *services.ServiceRegistry) plugins.HttpPluginInstance {
 	instances := f.instancesCreated.Add(1)
-	f.logger.Info(f.prefix+": new instance created.", zap.Uint64("instances created", instances))
+	f.logger.Debug(f.prefix+": new instance created.", zap.Uint64("instances created", instances))
 
 	return &filterInstance{
 		logger: f.logger,
@@ -46,7 +46,7 @@ func (f *Factory) Destroy() {
 	instances := f.instancesCreated.Load()
 	totalEgressReqBodySize := f.egressReqBodySize.Load()
 	totalEgressResBodySize := f.egressResBodySize.Load()
-	f.logger.Info(f.prefix+": plugin destroyed",
+	f.logger.Debug(f.prefix+": plugin destroyed",
 		zap.Uint64("instances created", instances),
 		zap.Uint64("total egress request body size", totalEgressReqBodySize),
 		zap.Uint64("total egress response body size", totalEgressResBodySize))
@@ -62,7 +62,7 @@ type filterInstance struct {
 
 func (h *filterInstance) RequestHeaders(headers plugins.Headers, endStream bool) plugins.HeadersStatus {
 	h.startTime = time.Now()
-	h.logger.Info(fmt.Sprintf("%s: request headers received. endstream: %v", h.prefix, endStream))
+	h.logger.Debug(fmt.Sprintf("%s: request headers received. endstream: %v", h.prefix, endStream))
 
 	return plugins.HeadersStatusContinue
 }
@@ -70,14 +70,14 @@ func (h *filterInstance) RequestHeaders(headers plugins.Headers, endStream bool)
 func (h *filterInstance) RequestBody(body plugins.BodyBuffer, endStream bool) plugins.BodyStatus {
 	totalSize := h.filter.egressReqBodySize.Add(uint64(body.Length()))
 
-	h.logger.Info(h.prefix+": request body received", zap.Int("body_size", body.Length()), zap.String("body", string(body.Copy())), zap.Bool("endstream", endStream))
-	h.logger.Info(h.prefix+": total egress request body size", zap.Uint64("size", totalSize))
+	h.logger.Debug(h.prefix+": request body received", zap.Int("body_size", body.Length()), zap.String("body", string(body.Copy())), zap.Bool("endstream", endStream))
+	h.logger.Debug(h.prefix+": total egress request body size", zap.Uint64("size", totalSize))
 
 	return plugins.BodyStatusContinue
 }
 
 func (h *filterInstance) ResponseHeaders(headers plugins.Headers, endStream bool) plugins.HeadersStatus {
-	h.logger.Info(h.prefix+": response headers received", zap.Bool("endstream", endStream))
+	h.logger.Debug(h.prefix+": response headers received", zap.Bool("endstream", endStream))
 
 	return plugins.HeadersStatusContinue
 }
@@ -85,14 +85,14 @@ func (h *filterInstance) ResponseHeaders(headers plugins.Headers, endStream bool
 func (h *filterInstance) ResponseBody(body plugins.BodyBuffer, endStream bool) plugins.BodyStatus {
 	totalSize := h.filter.egressResBodySize.Add(uint64(body.Length()))
 
-	h.logger.Info(h.prefix+": response body received", zap.Int("body_size", body.Length()), zap.String("body", string(body.Copy())), zap.Bool("endstream", endStream))
-	h.logger.Info(h.prefix+": total egress response body size", zap.Uint64("size", totalSize))
+	h.logger.Debug(h.prefix+": response body received", zap.Int("body_size", body.Length()), zap.String("body", string(body.Copy())), zap.Bool("endstream", endStream))
+	h.logger.Debug(h.prefix+": total egress response body size", zap.Uint64("size", totalSize))
 
 	return plugins.BodyStatusContinue
 }
 
 func (h *filterInstance) Destroy() {
-	h.logger.Info(h.prefix + ": plugin instance destroyed")
+	h.logger.Debug(h.prefix + ": plugin instance destroyed")
 }
 
 func (f *Factory) PluginType() plugins.PluginType {

--- a/pkg/services/eventstore/console/console.go
+++ b/pkg/services/eventstore/console/console.go
@@ -46,7 +46,7 @@ func (s *EventStore) Save(ctx context.Context, item any) {
 		ll.DPanic("event stores do not support artifacts", zap.Any("artifact", i))
 		return
 	default:
-		ll.Info("event store submission",
+		ll.Debug("event store submission",
 			zap.String("type", fmt.Sprintf("%T", item)),
 			zap.Any("item", item))
 	}

--- a/pkg/services/objectstore/console/console.go
+++ b/pkg/services/objectstore/console/console.go
@@ -43,5 +43,5 @@ func (s *ObjectStore) Put(ctx context.Context, artifact *eventstore.Artifact) {
 	fields := append(s.LogFields(artifact),
 		zap.String("data_base64", base64.StdEncoding.EncodeToString(artifact.Data)))
 
-	s.Log().Info("object store submission", fields...)
+	s.Log().Debug("object store submission", fields...)
 }

--- a/pkg/services/objectstore/s3/factory.go
+++ b/pkg/services/objectstore/s3/factory.go
@@ -109,9 +109,9 @@ func (f *Factory) Create(ctx context.Context, svcRegistry *services.ServiceRegis
 				url := templateURL(f.accessURL, m)
 				record := artifact.Record(url)
 				eventStore.Save(ctx, record)
-				logger.Info("artifact stored", zap.String("url", url))
+				logger.Debug("artifact stored", zap.String("url", url))
 			} else {
-				logger.Info("artifact stored")
+				logger.Debug("artifact stored")
 			}
 		},
 		eventStore: eventStore,


### PR DESCRIPTION
Changed log messages from Info to Debug level in various files, including e2e tests, connection manager, container management, and object store services. This adjustment aims to streamline log output and improve clarity during debugging.

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Contributing Guide: https://github.com/qpoint-io/qtap/docs/CONTRIBUTING.md
     - 📖 Read the Contributor License Agreement (CLA): https://github.com/qpoint-io/qtap/docs/CLA.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Qpoint Team member.
-->
