### PR TITLE
fix pprof endpoints

### DIFF
--- a/pkg/status/server.go
+++ b/pkg/status/server.go
@@ -35,7 +35,7 @@ func NewBaseStatusServer(listen string, logger *zap.Logger, readyCheck func() bo
 		listen:     listen,
 		logger:     logger,
 		readyCheck: readyCheck,
-		mux:        http.NewServeMux(),
+		mux:        http.DefaultServeMux,
 		ctx:        ctx,
 		cancel:     cancel,
 	}


### PR DESCRIPTION
importing `_ "net/http/pprof"` registers the pprof endpoints on the default mux