### PR TITLE
Override SSE Endpoint in dev mode only

### DIFF
--- a/pkg/devtools/app/src/composables/config.ts
+++ b/pkg/devtools/app/src/composables/config.ts
@@ -7,7 +7,8 @@
 export function useConfig() {
   const getSSEEndpoint = (): string => {
     // Use environment variable if set (dev mode override)
-    if (import.meta.env.VITE_SSE_ENDPOINT) {
+    // Only check in dev mode - production builds should use default
+    if (import.meta.env.DEV && import.meta.env.VITE_SSE_ENDPOINT) {
       return import.meta.env.VITE_SSE_ENDPOINT as string
     }
     


### PR DESCRIPTION
Vite automatically sets the DEV env var on `npm run dev` so this is the only change we need to make. If we run a `npm run build` any custom SSE endpoint configurations will be ignored.

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Contributing Guide: https://github.com/qpoint-io/qtap/docs/CONTRIBUTING.md
     - 📖 Read the Contributor License Agreement (CLA): https://github.com/qpoint-io/qtap/docs/CLA.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Qpoint Team member.
-->
