### PR TITLE
Access Log <-> HTTP Capture config compat adjustment

### DIFF
--- a/pkg/plugins/accesslogs/access_logs_http.go
+++ b/pkg/plugins/accesslogs/access_logs_http.go
@@ -16,6 +16,7 @@ const (
 	displayModeNone    displayMode = "none"
 	displayModeSummary displayMode = "summary"
 	displayModeDetails displayMode = "details"
+	displayModeHeaders displayMode = "headers" // Equivalent to details
 	displayModeFull    displayMode = "full"
 )
 

--- a/pkg/plugins/accesslogs/access_logs_plugin.go
+++ b/pkg/plugins/accesslogs/access_logs_plugin.go
@@ -90,6 +90,11 @@ func (f *factory) Init(logger *zap.Logger, config yaml.Node) {
 		cfg.Rules[i].rule = rule
 	}
 
+	// Adds cross support for headers -> details (from http_capture)
+	if cfg.Mode == displayModeHeaders {
+		cfg.Mode = displayModeDetails
+	}
+
 	f.config = &cfg
 }
 

--- a/pkg/plugins/httpcapture/httpcapture_plugin.go
+++ b/pkg/plugins/httpcapture/httpcapture_plugin.go
@@ -29,6 +29,7 @@ const (
 
 	// CaptureLevelHeaders captures everything in Summary, plus HTTP request and response headers.
 	CaptureLevelHeaders CaptureLevel = "headers"
+	CaptureLevelDetails CaptureLevel = "details" // Legacy from `access_logs`
 
 	// CaptureLevelFull captures everything in Headers, plus HTTP request and response bodies (i.e., the complete transaction).
 	CaptureLevelFull CaptureLevel = "full"
@@ -89,6 +90,12 @@ func (f *Factory) Init(logger *zap.Logger, config yaml.Node) {
 		if err != nil {
 			logger.Error("error parsing log rule", zap.Error(err), zap.String("rule", cfg.Rules[i].Name))
 		}
+	}
+
+	// Legacy support for `details` level
+	if cfg.Level == CaptureLevelDetails {
+		logger.Warn("`details` level is deprecated, using `headers` level instead")
+		cfg.Level = CaptureLevelHeaders
 	}
 
 	f.config = &cfg

--- a/pkg/services/eventstore/console/console.go
+++ b/pkg/services/eventstore/console/console.go
@@ -46,7 +46,7 @@ func (s *EventStore) Save(ctx context.Context, item any) {
 		ll.DPanic("event stores do not support artifacts", zap.Any("artifact", i))
 		return
 	default:
-		ll.Debug("event store submission",
+		ll.Info("event store submission",
 			zap.String("type", fmt.Sprintf("%T", item)),
 			zap.Any("item", item))
 	}

--- a/pkg/services/objectstore/console/console.go
+++ b/pkg/services/objectstore/console/console.go
@@ -43,5 +43,5 @@ func (s *ObjectStore) Put(ctx context.Context, artifact *eventstore.Artifact) {
 	fields := append(s.LogFields(artifact),
 		zap.String("data_base64", base64.StdEncoding.EncodeToString(artifact.Data)))
 
-	s.Log().Debug("object store submission", fields...)
+	s.Log().Info("object store submission", fields...)
 }


### PR DESCRIPTION
Previous the levels on Access Logs and and HTTP_Capture were slightly different. This change adds support between them since the levels are functionally the same.

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Contributing Guide: https://github.com/qpoint-io/qtap/docs/CONTRIBUTING.md
     - 📖 Read the Contributor License Agreement (CLA): https://github.com/qpoint-io/qtap/docs/CLA.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Qpoint Team member.
-->
