### PR TITLE
Enable filtering events from devtools event SSE endpoint

### DIFF
--- a/pkg/devtools/cache.go
+++ b/pkg/devtools/cache.go
@@ -1,0 +1,62 @@
+package devtools
+
+import (
+	lru "github.com/hashicorp/golang-lru/v2"
+)
+
+const (
+	// DefaultCacheMaxSize is the default maximum number of connections to cache
+	DefaultCacheMaxSize = 10000
+)
+
+// ConnectionCache stores connection data for cross-entity filtering lookups.
+// It allows request/issue/pii events to be filtered by connection or process attributes.
+type ConnectionCache struct {
+	cache *lru.Cache[string, map[string]any]
+}
+
+// NewConnectionCache creates a new connection cache with the specified max size
+func NewConnectionCache(maxSize int) *ConnectionCache {
+	if maxSize <= 0 {
+		maxSize = DefaultCacheMaxSize
+	}
+	cache, err := lru.New[string, map[string]any](maxSize)
+	if err != nil {
+		panic(err)
+	}
+	return &ConnectionCache{
+		cache: cache,
+	}
+}
+
+// Set adds or updates a connection in the cache
+func (c *ConnectionCache) Set(connId string, data map[string]any) {
+	if connId == "" {
+		return
+	}
+	c.cache.Add(connId, data)
+}
+
+// Get retrieves connection data from the cache
+func (c *ConnectionCache) Get(connId string) map[string]any {
+	if connId == "" {
+		return nil
+	}
+	if data, ok := c.cache.Get(connId); ok {
+		return data
+	}
+	return nil
+}
+
+// Delete removes a connection from the cache
+func (c *ConnectionCache) Delete(connId string) {
+	if connId == "" {
+		return
+	}
+	c.cache.Remove(connId)
+}
+
+// Len returns the current number of cached connections
+func (c *ConnectionCache) Len() int {
+	return c.cache.Len()
+}

--- a/pkg/devtools/filter.go
+++ b/pkg/devtools/filter.go
@@ -102,16 +102,14 @@ func (f *EventFilter) IsEmpty() bool {
 // This enables cross-entity filtering (e.g., process.* filters apply to connection events).
 // Note: "http" filter entity applies to "request" topic events (request.created, request.http_transaction)
 var entityAppliesTo = map[string]map[string]bool{
-	"process":    {"process": true, "connection": true, "request": true, "issue": true, "pii": true},
-	"connection": {"connection": true, "request": true, "issue": true, "pii": true},
+	"process":    {"process": true, "connection": true, "request": true},
+	"connection": {"connection": true, "request": true},
 	"http":       {"request": true},
-	"issue":      {"issue": true},
-	"pii":        {"pii": true},
 }
 
 // Matches checks if an event matches the filter conditions.
 // The cache parameter enables cross-entity filtering by looking up connection data
-// for request/issue/pii events.
+// for request events.
 // Returns true if:
 // - No applicable conditions exist for this event's entity type (pass through)
 // - All applicable conditions match (AND logic)
@@ -174,11 +172,11 @@ func extractAttributeWithCache(filterEntity, eventEntity string, data map[string
 		// Connection events have process data embedded in source
 		return extractProcessFromConnection(data, attr)
 
-	case filterEntity == "process" && (eventEntity == "request" || eventEntity == "issue" || eventEntity == "pii"):
+	case filterEntity == "process" && eventEntity == "request":
 		// Need to lookup connection, then extract process data
 		return extractProcessFromRequest(data, cache, attr)
 
-	case filterEntity == "connection" && (eventEntity == "request" || eventEntity == "issue" || eventEntity == "pii"):
+	case filterEntity == "connection" && eventEntity == "request":
 		// Need to lookup connection data from cache
 		return extractConnectionFromRequest(data, cache, attr)
 	}
@@ -320,10 +318,6 @@ func extractAttribute(entity string, data map[string]any, attr string) any {
 		return extractHttpAttribute(data, attr)
 	case "connection":
 		return extractConnectionAttribute(data, attr)
-	case "issue":
-		return extractIssueAttribute(data, attr)
-	case "pii":
-		return extractPIIAttribute(data, attr)
 	default:
 		return nil
 	}
@@ -552,54 +546,6 @@ func extractEndpointPort(data map[string]any, endpoint string) any {
 		}
 	}
 	return nil
-}
-
-// extractIssueAttribute extracts attributes from issue event data
-func extractIssueAttribute(data map[string]any, attr string) any {
-	issueData := toMapAny(data["data"])
-	if issueData == nil {
-		issueData = data
-	}
-
-	switch attr {
-	case "method":
-		return issueData["method"]
-	case "status":
-		return issueData["status"]
-	case "path":
-		return issueData["path"]
-	case "url":
-		return issueData["url"]
-	case "direction":
-		return issueData["direction"]
-	case "error":
-		return issueData["error"]
-	default:
-		return nil
-	}
-}
-
-// extractPIIAttribute extracts attributes from PII event data
-func extractPIIAttribute(data map[string]any, attr string) any {
-	piiData := toMapAny(data["data"])
-	if piiData == nil {
-		piiData = data
-	}
-
-	switch attr {
-	case "entityType":
-		return piiData["entityType"]
-	case "entitySource":
-		return piiData["entitySource"]
-	case "fieldPath":
-		return piiData["fieldPath"]
-	case "requestMethod":
-		return piiData["requestMethod"]
-	case "requestPath":
-		return piiData["requestPath"]
-	default:
-		return nil
-	}
 }
 
 // matchCondition checks if a value matches a filter condition

--- a/pkg/devtools/filter.go
+++ b/pkg/devtools/filter.go
@@ -1,0 +1,796 @@
+package devtools
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// FilterOperator defines comparison operations for event filtering
+type FilterOperator string
+
+const (
+	OpEq       FilterOperator = "eq"
+	OpNeq      FilterOperator = "neq"
+	OpIn       FilterOperator = "in"
+	OpGt       FilterOperator = "gt"
+	OpGte      FilterOperator = "gte"
+	OpLt       FilterOperator = "lt"
+	OpLte      FilterOperator = "lte"
+	OpPrefix   FilterOperator = "prefix"
+	OpContains FilterOperator = "contains"
+)
+
+// validOperators is the set of recognized operators
+var validOperators = map[FilterOperator]struct{}{
+	OpEq:       {},
+	OpNeq:      {},
+	OpIn:       {},
+	OpGt:       {},
+	OpGte:      {},
+	OpLt:       {},
+	OpLte:      {},
+	OpPrefix:   {},
+	OpContains: {},
+}
+
+// FilterCondition represents a single filter condition
+type FilterCondition struct {
+	Entity    string         // e.g., "process", "request", "connection"
+	Attribute string         // e.g., "pid", "method", "container"
+	Operator  FilterOperator // e.g., "eq", "gte", "prefix"
+	Value     string         // raw value from query param
+}
+
+// EventFilter holds parsed filter conditions grouped by entity
+type EventFilter struct {
+	Conditions map[string][]FilterCondition // entity -> conditions
+}
+
+// ParseFilters parses query parameters into an EventFilter.
+// Query params should be in the format: entity.attribute.operator=value
+// Example: process.pid.eq=1234, request.status.gte=400
+func ParseFilters(query url.Values) (*EventFilter, error) {
+	filter := &EventFilter{
+		Conditions: make(map[string][]FilterCondition),
+	}
+
+	for key, values := range query {
+		// Skip empty values
+		if len(values) == 0 || values[0] == "" {
+			continue
+		}
+
+		// Parse the key: entity.attribute.operator
+		parts := strings.Split(key, ".")
+		if len(parts) != 3 {
+			// Not a filter param, skip (could be other query params)
+			continue
+		}
+
+		entity := parts[0]
+		attribute := parts[1]
+		operator := FilterOperator(parts[2])
+
+		// Validate operator
+		if _, ok := validOperators[operator]; !ok {
+			return nil, fmt.Errorf("invalid operator %q in filter %q", operator, key)
+		}
+
+		// Create condition (use first value if multiple provided)
+		condition := FilterCondition{
+			Entity:    entity,
+			Attribute: attribute,
+			Operator:  operator,
+			Value:     values[0],
+		}
+
+		filter.Conditions[entity] = append(filter.Conditions[entity], condition)
+	}
+
+	return filter, nil
+}
+
+// IsEmpty returns true if no filter conditions are defined
+func (f *EventFilter) IsEmpty() bool {
+	return f == nil || len(f.Conditions) == 0
+}
+
+// entityAppliesTo defines which event types each filter entity applies to.
+// This enables cross-entity filtering (e.g., process.* filters apply to connection events).
+// Note: "http" filter entity applies to "request" topic events (request.created, request.http_transaction)
+var entityAppliesTo = map[string]map[string]bool{
+	"process":    {"process": true, "connection": true, "request": true, "issue": true, "pii": true},
+	"connection": {"connection": true, "request": true, "issue": true, "pii": true},
+	"http":       {"request": true},
+	"issue":      {"issue": true},
+	"pii":        {"pii": true},
+}
+
+// Matches checks if an event matches the filter conditions.
+// The cache parameter enables cross-entity filtering by looking up connection data
+// for request/issue/pii events.
+// Returns true if:
+// - No applicable conditions exist for this event's entity type (pass through)
+// - All applicable conditions match (AND logic)
+func (f *EventFilter) Matches(event *Event, cache *ConnectionCache) bool {
+	if f.IsEmpty() {
+		return true
+	}
+
+	// Extract entity from topic (e.g., "request.created" -> "request")
+	eventEntity := event.TopLevelTopic()
+
+	// System events always pass through
+	if eventEntity == "system" {
+		return true
+	}
+
+	// Extract the data from the event
+	data, ok := event.Data.(map[string]any)
+	if !ok {
+		// Can't extract data, pass through
+		return true
+	}
+
+	// Check each filter entity's conditions
+	for filterEntity, conditions := range f.Conditions {
+		// Check if this filter entity applies to the event's entity type
+		appliesTo, exists := entityAppliesTo[filterEntity]
+		if !exists || !appliesTo[eventEntity] {
+			// This filter entity doesn't apply to this event type, skip
+			continue
+		}
+
+		// All conditions for this filter entity must match
+		for _, cond := range conditions {
+			attrValue := extractAttributeWithCache(filterEntity, eventEntity, data, cond.Attribute, cache)
+			if !matchCondition(attrValue, cond) {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+// extractAttributeWithCache extracts an attribute value, using cache for cross-entity lookups
+func extractAttributeWithCache(filterEntity, eventEntity string, data map[string]any, attr string, cache *ConnectionCache) any {
+	// Same entity - direct extraction
+	if filterEntity == eventEntity {
+		return extractAttribute(filterEntity, data, attr)
+	}
+
+	// "http" filter entity maps to "request" event entity
+	if filterEntity == "http" && eventEntity == "request" {
+		return extractAttribute("http", data, attr)
+	}
+
+	// Cross-entity extraction
+	switch {
+	case filterEntity == "process" && eventEntity == "connection":
+		// Connection events have process data embedded in source
+		return extractProcessFromConnection(data, attr)
+
+	case filterEntity == "process" && (eventEntity == "request" || eventEntity == "issue" || eventEntity == "pii"):
+		// Need to lookup connection, then extract process data
+		return extractProcessFromRequest(data, cache, attr)
+
+	case filterEntity == "connection" && (eventEntity == "request" || eventEntity == "issue" || eventEntity == "pii"):
+		// Need to lookup connection data from cache
+		return extractConnectionFromRequest(data, cache, attr)
+	}
+
+	return nil
+}
+
+// extractProcessFromConnection extracts process attributes from connection event data
+// Connection events have process info embedded in the source endpoint
+func extractProcessFromConnection(data map[string]any, attr string) any {
+	// Connection data is nested under "data" key
+	connData := toMapAny(data["data"])
+	if connData == nil {
+		connData = data
+	}
+
+	// Get source endpoint (local process info)
+	source := toMapAny(connData["source"])
+	if source == nil {
+		return nil
+	}
+
+	switch attr {
+	case "pid":
+		return source["pid"]
+	case "hostname":
+		return source["hostname"]
+	case "user":
+		return source["user"]
+	case "userId":
+		return source["userId"]
+	case "path":
+		return source["exe"]
+	case "binary":
+		// Extract basename from exe path
+		if exe, ok := source["exe"].(string); ok {
+			parts := strings.Split(exe, "/")
+			if len(parts) > 0 {
+				return parts[len(parts)-1]
+			}
+		}
+		return nil
+	case "container":
+		if container := toMapAny(source["container"]); container != nil {
+			return container["name"]
+		}
+		return nil
+	case "containerId":
+		if container := toMapAny(source["container"]); container != nil {
+			return container["id"]
+		}
+		return nil
+	case "containerImage":
+		if container := toMapAny(source["container"]); container != nil {
+			return container["image"]
+		}
+		return nil
+	case "pod":
+		if container := toMapAny(source["container"]); container != nil {
+			if pod := toMapAny(container["pod"]); pod != nil {
+				return pod["name"]
+			}
+		}
+		return nil
+	case "podNamespace":
+		if container := toMapAny(source["container"]); container != nil {
+			if pod := toMapAny(container["pod"]); pod != nil {
+				return pod["namespace"]
+			}
+		}
+		return nil
+	}
+
+	return nil
+}
+
+// extractConnectionFromRequest extracts connection attributes from request data via cache lookup
+func extractConnectionFromRequest(data map[string]any, cache *ConnectionCache, attr string) any {
+	if cache == nil {
+		return nil
+	}
+
+	// Request data is nested under "data" key
+	reqData := toMapAny(data["data"])
+	if reqData == nil {
+		reqData = data
+	}
+
+	// Get connectionId from request
+	connId, ok := reqData["connectionId"].(string)
+	if !ok {
+		return nil
+	}
+
+	// Lookup connection from cache
+	connData := cache.Get(connId)
+	if connData == nil {
+		return nil
+	}
+
+	// Extract the attribute from connection data
+	return extractConnectionAttribute(map[string]any{"data": connData}, attr)
+}
+
+// extractProcessFromRequest extracts process attributes from request data via cache lookup
+func extractProcessFromRequest(data map[string]any, cache *ConnectionCache, attr string) any {
+	if cache == nil {
+		return nil
+	}
+
+	// Request data is nested under "data" key
+	reqData := toMapAny(data["data"])
+	if reqData == nil {
+		reqData = data
+	}
+
+	// Get connectionId from request
+	connId, ok := reqData["connectionId"].(string)
+	if !ok {
+		return nil
+	}
+
+	// Lookup connection from cache
+	connData := cache.Get(connId)
+	if connData == nil {
+		return nil
+	}
+
+	// Extract process data from connection's source
+	return extractProcessFromConnection(map[string]any{"data": connData}, attr)
+}
+
+// extractAttribute extracts an attribute value from event data based on entity type and attribute name
+func extractAttribute(entity string, data map[string]any, attr string) any {
+	switch entity {
+	case "process":
+		return extractProcessAttribute(data, attr)
+	case "http":
+		return extractHttpAttribute(data, attr)
+	case "connection":
+		return extractConnectionAttribute(data, attr)
+	case "issue":
+		return extractIssueAttribute(data, attr)
+	case "pii":
+		return extractPIIAttribute(data, attr)
+	default:
+		return nil
+	}
+}
+
+// extractProcessAttribute extracts attributes from process event data
+func extractProcessAttribute(data map[string]any, attr string) any {
+	switch attr {
+	case "pid":
+		return data["pid"]
+	case "binary":
+		return data["binary"]
+	case "path":
+		return data["path"]
+	case "hostname":
+		return data["hostname"]
+	case "user":
+		if user, ok := data["user"].(map[string]any); ok {
+			return user["name"]
+		}
+		return nil
+	case "userId":
+		if user, ok := data["user"].(map[string]any); ok {
+			return user["id"]
+		}
+		return nil
+	case "container":
+		if container, ok := data["container"].(map[string]any); ok {
+			return container["name"]
+		}
+		return nil
+	case "containerId":
+		if container, ok := data["container"].(map[string]any); ok {
+			return container["id"]
+		}
+		return nil
+	case "containerImage":
+		if container, ok := data["container"].(map[string]any); ok {
+			return container["image"]
+		}
+		return nil
+	case "pod":
+		if pod, ok := data["pod"].(map[string]any); ok {
+			return pod["name"]
+		}
+		return nil
+	case "podNamespace":
+		if pod, ok := data["pod"].(map[string]any); ok {
+			return pod["namespace"]
+		}
+		return nil
+	default:
+		return nil
+	}
+}
+
+// extractHttpAttribute extracts attributes from HTTP event data.
+// Handles both request.created events (from EventStore) and request.http_transaction
+// events (from ObjectStore/Artifact) which have different data structures.
+func extractHttpAttribute(data map[string]any, attr string) any {
+	// HTTP data is nested under "data" key from eventstore
+	httpData := toMapAny(data["data"])
+	if httpData == nil {
+		// Try direct access (in case structure varies)
+		httpData = data
+	}
+
+	// Check if this is an http_transaction artifact (has "summary" field)
+	// These come from ObjectStore and have a different structure
+	if summary := toMapAny(httpData["summary"]); summary != nil {
+		return extractFromHttpSummary(summary, attr)
+	}
+
+	// Standard request.created event structure
+	switch attr {
+	case "method":
+		return httpData["method"]
+	case "status":
+		return httpData["status"]
+	case "path":
+		return httpData["path"]
+	case "url":
+		return httpData["url"]
+	case "domain":
+		// Extract domain from URL
+		if urlStr, ok := httpData["url"].(string); ok {
+			if parsed, err := url.Parse(urlStr); err == nil {
+				return parsed.Hostname()
+			}
+		}
+		return nil
+	case "direction":
+		return httpData["direction"]
+	case "category":
+		return httpData["category"]
+	case "contentType":
+		return httpData["contentType"]
+	case "agent":
+		return httpData["agent"]
+	case "duration":
+		return httpData["duration"]
+	case "bytesSent":
+		return httpData["bytesSent"]
+	case "bytesReceived":
+		return httpData["bytesReceived"]
+	case "connectionId":
+		return httpData["connectionId"]
+	case "requestId":
+		return httpData["requestId"]
+	default:
+		return nil
+	}
+}
+
+// extractFromHttpSummary extracts attributes from http_transaction summary data.
+// Summary fields use snake_case naming like request_host, request_method, etc.
+func extractFromHttpSummary(summary map[string]any, attr string) any {
+	switch attr {
+	case "method":
+		return summary["request_method"]
+	case "status":
+		return summary["response_status"]
+	case "path":
+		return summary["request_path"]
+	case "domain":
+		return summary["request_host"]
+	case "direction":
+		return summary["direction"]
+	case "protocol":
+		return summary["request_protocol"]
+	case "scheme":
+		return summary["request_scheme"]
+	case "requestContentType":
+		return summary["request_content_type"]
+	case "responseContentType":
+		return summary["response_content_type"]
+	case "duration":
+		return summary["duration_ms"]
+	case "connectionId":
+		return summary["connection_id"]
+	case "requestId":
+		return summary["request_id"]
+	case "container":
+		return summary["container_name"]
+	case "containerImage":
+		return summary["container_image"]
+	case "pod":
+		return summary["pod_name"]
+	case "podNamespace":
+		return summary["pod_namespace"]
+	case "binary":
+		return summary["process_exe"]
+	default:
+		return nil
+	}
+}
+
+// extractConnectionAttribute extracts attributes from connection event data
+func extractConnectionAttribute(data map[string]any, attr string) any {
+	// Connection data is nested under "data" key from eventstore
+	connData := toMapAny(data["data"])
+	if connData == nil {
+		connData = data
+	}
+
+	switch attr {
+	case "direction":
+		return connData["direction"]
+	case "protocol":
+		return connData["l7Protocol"]
+	case "socketProtocol":
+		return connData["socketProtocol"]
+	case "vendorId":
+		return connData["vendorId"]
+	case "tlsVersion":
+		return connData["tlsVersion"]
+	case "pid":
+		return extractEndpointField(connData, "source", "pid")
+	case "container":
+		if src := toMapAny(connData["source"]); src != nil {
+			if container := toMapAny(src["container"]); container != nil {
+				return container["name"]
+			}
+		}
+		return nil
+	case "hostname":
+		return extractEndpointField(connData, "source", "hostname")
+	case "exe":
+		return extractEndpointField(connData, "source", "exe")
+	case "srcIp":
+		return extractEndpointIP(connData, "source")
+	case "srcPort":
+		return extractEndpointPort(connData, "source")
+	case "dstIp":
+		return extractEndpointIP(connData, "destination")
+	case "dstPort":
+		return extractEndpointPort(connData, "destination")
+	default:
+		return nil
+	}
+}
+
+// extractEndpointField extracts a field from a connection endpoint
+func extractEndpointField(data map[string]any, endpoint, field string) any {
+	if ep := toMapAny(data[endpoint]); ep != nil {
+		return ep[field]
+	}
+	return nil
+}
+
+// extractEndpointIP extracts the IP address from a connection endpoint
+func extractEndpointIP(data map[string]any, endpoint string) any {
+	if ep := toMapAny(data[endpoint]); ep != nil {
+		if addr := toMapAny(ep["address"]); addr != nil {
+			return addr["ip"]
+		}
+	}
+	return nil
+}
+
+// extractEndpointPort extracts the port from a connection endpoint
+func extractEndpointPort(data map[string]any, endpoint string) any {
+	if ep := toMapAny(data[endpoint]); ep != nil {
+		if addr := toMapAny(ep["address"]); addr != nil {
+			return addr["port"]
+		}
+	}
+	return nil
+}
+
+// extractIssueAttribute extracts attributes from issue event data
+func extractIssueAttribute(data map[string]any, attr string) any {
+	issueData := toMapAny(data["data"])
+	if issueData == nil {
+		issueData = data
+	}
+
+	switch attr {
+	case "method":
+		return issueData["method"]
+	case "status":
+		return issueData["status"]
+	case "path":
+		return issueData["path"]
+	case "url":
+		return issueData["url"]
+	case "direction":
+		return issueData["direction"]
+	case "error":
+		return issueData["error"]
+	default:
+		return nil
+	}
+}
+
+// extractPIIAttribute extracts attributes from PII event data
+func extractPIIAttribute(data map[string]any, attr string) any {
+	piiData := toMapAny(data["data"])
+	if piiData == nil {
+		piiData = data
+	}
+
+	switch attr {
+	case "entityType":
+		return piiData["entityType"]
+	case "entitySource":
+		return piiData["entitySource"]
+	case "fieldPath":
+		return piiData["fieldPath"]
+	case "requestMethod":
+		return piiData["requestMethod"]
+	case "requestPath":
+		return piiData["requestPath"]
+	default:
+		return nil
+	}
+}
+
+// matchCondition checks if a value matches a filter condition
+func matchCondition(value any, cond FilterCondition) bool {
+	if value == nil {
+		// If the attribute doesn't exist, the condition doesn't match
+		// unless we're using neq (not equals)
+		return cond.Operator == OpNeq
+	}
+
+	switch cond.Operator {
+	case OpEq:
+		return compareEqual(value, cond.Value)
+	case OpNeq:
+		return !compareEqual(value, cond.Value)
+	case OpIn:
+		return compareIn(value, cond.Value)
+	case OpGt:
+		return compareNumeric(value, cond.Value, func(a, b int64) bool { return a > b })
+	case OpGte:
+		return compareNumeric(value, cond.Value, func(a, b int64) bool { return a >= b })
+	case OpLt:
+		return compareNumeric(value, cond.Value, func(a, b int64) bool { return a < b })
+	case OpLte:
+		return compareNumeric(value, cond.Value, func(a, b int64) bool { return a <= b })
+	case OpPrefix:
+		return comparePrefix(value, cond.Value)
+	case OpContains:
+		return compareContains(value, cond.Value)
+	default:
+		return false
+	}
+}
+
+// compareEqual compares a value for equality with a filter value
+func compareEqual(value any, filterValue string) bool {
+	switch v := value.(type) {
+	case string:
+		return v == filterValue
+	case int:
+		if fv, err := strconv.Atoi(filterValue); err == nil {
+			return v == fv
+		}
+	case int64:
+		if fv, err := strconv.ParseInt(filterValue, 10, 64); err == nil {
+			return v == fv
+		}
+	case float64:
+		// JSON numbers are often float64
+		if fv, err := strconv.ParseFloat(filterValue, 64); err == nil {
+			return v == fv
+		}
+		// Also try int comparison for integer values
+		if fv, err := strconv.ParseInt(filterValue, 10, 64); err == nil {
+			return int64(v) == fv
+		}
+	case uint32:
+		if fv, err := strconv.ParseUint(filterValue, 10, 32); err == nil {
+			return v == uint32(fv)
+		}
+	case uint16:
+		if fv, err := strconv.ParseUint(filterValue, 10, 16); err == nil {
+			return v == uint16(fv)
+		}
+	}
+	// Fallback: convert both to string
+	return fmt.Sprintf("%v", value) == filterValue
+}
+
+// compareIn checks if a value is in a comma-separated list
+func compareIn(value any, filterValue string) bool {
+	parts := strings.Split(filterValue, ",")
+	for _, part := range parts {
+		if compareEqual(value, strings.TrimSpace(part)) {
+			return true
+		}
+	}
+	return false
+}
+
+// compareNumeric performs a numeric comparison
+func compareNumeric(value any, filterValue string, cmp func(a, b int64) bool) bool {
+	fv, err := strconv.ParseInt(filterValue, 10, 64)
+	if err != nil {
+		return false
+	}
+
+	var v int64
+	switch val := value.(type) {
+	case int:
+		v = int64(val)
+	case int64:
+		v = val
+	case float64:
+		v = int64(val)
+	case uint32:
+		v = int64(val)
+	case uint16:
+		v = int64(val)
+	default:
+		return false
+	}
+
+	return cmp(v, fv)
+}
+
+// comparePrefix checks if a string value starts with the filter value
+func comparePrefix(value any, filterValue string) bool {
+	if s, ok := value.(string); ok {
+		return strings.HasPrefix(s, filterValue)
+	}
+	return false
+}
+
+// compareContains checks if a string value contains the filter value
+func compareContains(value any, filterValue string) bool {
+	if s, ok := value.(string); ok {
+		return strings.Contains(s, filterValue)
+	}
+	return false
+}
+
+// ParseFiltersFromBody parses filters from a map (from JSON body).
+// The map keys should be in the format: entity.attribute.operator
+// Example: {"process.pid.eq": "1234", "request.status.gte": "400"}
+func ParseFiltersFromBody(filters map[string]string) (*EventFilter, error) {
+	if len(filters) == 0 {
+		return nil, nil
+	}
+
+	// Convert map to url.Values format and reuse ParseFilters
+	values := make(url.Values)
+	for key, val := range filters {
+		values.Set(key, val)
+	}
+	return ParseFilters(values)
+}
+
+// MergeFilters combines two filters, with override taking precedence.
+// Returns override if base is nil, base if override is nil/empty.
+// When both have conditions for the same entity, override's conditions replace base's.
+func MergeFilters(base, override *EventFilter) *EventFilter {
+	if override == nil || override.IsEmpty() {
+		return base
+	}
+	if base == nil || base.IsEmpty() {
+		return override
+	}
+
+	// Merge conditions: override replaces base for same entity
+	merged := &EventFilter{
+		Conditions: make(map[string][]FilterCondition),
+	}
+
+	// Copy base conditions
+	for entity, conds := range base.Conditions {
+		merged.Conditions[entity] = conds
+	}
+
+	// Override with override's conditions
+	for entity, conds := range override.Conditions {
+		merged.Conditions[entity] = conds
+	}
+
+	return merged
+}
+
+// toMapAny converts a value to map[string]any.
+// If the value is already a map[string]any, it returns it directly.
+// If the value is a struct or pointer to struct, it JSON marshals/unmarshals to convert.
+// Returns nil if conversion fails.
+func toMapAny(v any) map[string]any {
+	if v == nil {
+		return nil
+	}
+
+	// Already a map
+	if m, ok := v.(map[string]any); ok {
+		return m
+	}
+
+	// Convert struct via JSON marshal/unmarshal
+	jsonBytes, err := json.Marshal(v)
+	if err != nil {
+		return nil
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(jsonBytes, &result); err != nil {
+		return nil
+	}
+
+	return result
+}

--- a/pkg/devtools/filter_test.go
+++ b/pkg/devtools/filter_test.go
@@ -1,0 +1,1018 @@
+package devtools
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestParseFilters(t *testing.T) {
+	tests := []struct {
+		name       string
+		query      string
+		wantErr    bool
+		wantEmpty  bool
+		wantEntity string
+		wantCount  int
+	}{
+		{
+			name:      "empty query",
+			query:     "",
+			wantEmpty: true,
+		},
+		{
+			name:       "single filter",
+			query:      "process.pid.eq=1234",
+			wantEntity: "process",
+			wantCount:  1,
+		},
+		{
+			name:       "multiple filters same entity",
+			query:      "process.pid.eq=1234&process.container.eq=nginx",
+			wantEntity: "process",
+			wantCount:  2,
+		},
+		{
+			name:      "multiple filters different entities",
+			query:     "process.pid.eq=1234&http.method.eq=POST",
+			wantCount: 2, // 1 per entity
+		},
+		{
+			name:    "invalid operator",
+			query:   "process.pid.invalid=1234",
+			wantErr: true,
+		},
+		{
+			name:      "non-filter query params ignored",
+			query:     "foo=bar&baz=qux",
+			wantEmpty: true,
+		},
+		{
+			name:       "mixed filter and non-filter params",
+			query:      "foo=bar&process.pid.eq=1234",
+			wantEntity: "process",
+			wantCount:  1,
+		},
+		{
+			name:       "all operators",
+			query:      "http.status.eq=200&http.status.neq=404&http.status.gt=100&http.status.gte=200&http.status.lt=500&http.status.lte=299&http.path.prefix=/api&http.path.contains=users&http.method.in=GET,POST",
+			wantEntity: "http",
+			wantCount:  9,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, err := url.ParseQuery(tt.query)
+			if err != nil {
+				t.Fatalf("failed to parse query: %v", err)
+			}
+
+			filter, err := ParseFilters(values)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if tt.wantEmpty {
+				if !filter.IsEmpty() {
+					t.Errorf("expected empty filter, got %+v", filter.Conditions)
+				}
+				return
+			}
+
+			if tt.wantEntity != "" {
+				conditions, ok := filter.Conditions[tt.wantEntity]
+				if !ok {
+					t.Errorf("expected conditions for entity %q", tt.wantEntity)
+					return
+				}
+				if len(conditions) != tt.wantCount {
+					t.Errorf("expected %d conditions, got %d", tt.wantCount, len(conditions))
+				}
+			} else if tt.wantCount > 0 {
+				// Count total conditions across all entities
+				total := 0
+				for _, conds := range filter.Conditions {
+					total += len(conds)
+				}
+				if total != tt.wantCount {
+					t.Errorf("expected %d total conditions, got %d", tt.wantCount, total)
+				}
+			}
+		})
+	}
+}
+
+func TestEventFilter_Matches(t *testing.T) {
+	tests := []struct {
+		name   string
+		filter *EventFilter
+		event  *Event
+		want   bool
+	}{
+		{
+			name:   "nil filter matches everything",
+			filter: nil,
+			event:  NewEvent("request.created", map[string]any{"data": map[string]any{"method": "GET"}}),
+			want:   true,
+		},
+		{
+			name:   "empty filter matches everything",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{}},
+			event:  NewEvent("request.created", map[string]any{"data": map[string]any{"method": "GET"}}),
+			want:   true,
+		},
+		{
+			name: "system events always pass",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"http": {{Entity: "http", Attribute: "method", Operator: OpEq, Value: "POST"}},
+			}},
+			event: NewEvent("system.connected", map[string]any{"topics": []string{}}),
+			want:  true,
+		},
+		{
+			name: "unfiltered entity passes through",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"http": {{Entity: "http", Attribute: "method", Operator: OpEq, Value: "POST"}},
+			}},
+			event: NewEvent("process.started", map[string]any{"pid": 1234}),
+			want:  true,
+		},
+		{
+			name: "matching eq filter",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"http": {{Entity: "http", Attribute: "method", Operator: OpEq, Value: "GET"}},
+			}},
+			event: NewEvent("request.created", map[string]any{"data": map[string]any{"method": "GET"}}),
+			want:  true,
+		},
+		{
+			name: "non-matching eq filter",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"http": {{Entity: "http", Attribute: "method", Operator: OpEq, Value: "POST"}},
+			}},
+			event: NewEvent("request.created", map[string]any{"data": map[string]any{"method": "GET"}}),
+			want:  false,
+		},
+		{
+			name: "matching neq filter",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"http": {{Entity: "http", Attribute: "method", Operator: OpNeq, Value: "POST"}},
+			}},
+			event: NewEvent("request.created", map[string]any{"data": map[string]any{"method": "GET"}}),
+			want:  true,
+		},
+		{
+			name: "matching in filter",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"http": {{Entity: "http", Attribute: "method", Operator: OpIn, Value: "GET,POST,PUT"}},
+			}},
+			event: NewEvent("request.created", map[string]any{"data": map[string]any{"method": "POST"}}),
+			want:  true,
+		},
+		{
+			name: "non-matching in filter",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"http": {{Entity: "http", Attribute: "method", Operator: OpIn, Value: "GET,POST,PUT"}},
+			}},
+			event: NewEvent("request.created", map[string]any{"data": map[string]any{"method": "DELETE"}}),
+			want:  false,
+		},
+		{
+			name: "matching gte filter",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"http": {{Entity: "http", Attribute: "status", Operator: OpGte, Value: "400"}},
+			}},
+			event: NewEvent("request.created", map[string]any{"data": map[string]any{"status": 500}}),
+			want:  true,
+		},
+		{
+			name: "non-matching gte filter",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"http": {{Entity: "http", Attribute: "status", Operator: OpGte, Value: "400"}},
+			}},
+			event: NewEvent("request.created", map[string]any{"data": map[string]any{"status": 200}}),
+			want:  false,
+		},
+		{
+			name: "matching prefix filter",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"http": {{Entity: "http", Attribute: "path", Operator: OpPrefix, Value: "/api/"}},
+			}},
+			event: NewEvent("request.created", map[string]any{"data": map[string]any{"path": "/api/users/123"}}),
+			want:  true,
+		},
+		{
+			name: "matching contains filter",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"http": {{Entity: "http", Attribute: "path", Operator: OpContains, Value: "users"}},
+			}},
+			event: NewEvent("request.created", map[string]any{"data": map[string]any{"path": "/api/users/123"}}),
+			want:  true,
+		},
+		{
+			name: "multiple conditions AND logic - all match",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"http": {
+					{Entity: "http", Attribute: "method", Operator: OpEq, Value: "POST"},
+					{Entity: "http", Attribute: "status", Operator: OpGte, Value: "400"},
+				},
+			}},
+			event: NewEvent("request.created", map[string]any{"data": map[string]any{"method": "POST", "status": 500}}),
+			want:  true,
+		},
+		{
+			name: "multiple conditions AND logic - one fails",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"http": {
+					{Entity: "http", Attribute: "method", Operator: OpEq, Value: "POST"},
+					{Entity: "http", Attribute: "status", Operator: OpGte, Value: "400"},
+				},
+			}},
+			event: NewEvent("request.created", map[string]any{"data": map[string]any{"method": "POST", "status": 200}}),
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.filter.Matches(tt.event, nil)
+			if got != tt.want {
+				t.Errorf("Matches() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCrossEntityFiltering(t *testing.T) {
+	tests := []struct {
+		name   string
+		filter *EventFilter
+		event  *Event
+		cache  *ConnectionCache
+		want   bool
+	}{
+		{
+			name: "process filter on connection event - matching pid",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"process": {{Entity: "process", Attribute: "pid", Operator: OpEq, Value: "1234"}},
+			}},
+			event: NewEvent("connection.opened", map[string]any{
+				"data": map[string]any{
+					"source": map[string]any{
+						"pid": uint32(1234),
+					},
+				},
+			}),
+			want: true,
+		},
+		{
+			name: "process filter on connection event - non-matching pid",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"process": {{Entity: "process", Attribute: "pid", Operator: OpEq, Value: "1234"}},
+			}},
+			event: NewEvent("connection.opened", map[string]any{
+				"data": map[string]any{
+					"source": map[string]any{
+						"pid": uint32(5678),
+					},
+				},
+			}),
+			want: false,
+		},
+		{
+			name: "process filter on connection event - matching container",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"process": {{Entity: "process", Attribute: "container", Operator: OpEq, Value: "nginx"}},
+			}},
+			event: NewEvent("connection.opened", map[string]any{
+				"data": map[string]any{
+					"source": map[string]any{
+						"container": map[string]any{"name": "nginx", "id": "abc123"},
+					},
+				},
+			}),
+			want: true,
+		},
+		{
+			name: "process filter on process event - still works directly",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"process": {{Entity: "process", Attribute: "pid", Operator: OpEq, Value: "1234"}},
+			}},
+			event: NewEvent("process.started", map[string]any{"pid": 1234}),
+			want:  true,
+		},
+		{
+			name: "http filter does not apply to connection",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"http": {{Entity: "http", Attribute: "method", Operator: OpEq, Value: "POST"}},
+			}},
+			event: NewEvent("connection.opened", map[string]any{
+				"data": map[string]any{"direction": "egress"},
+			}),
+			want: true, // passes through - http filter doesn't apply to connection
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.filter.Matches(tt.event, tt.cache)
+			if got != tt.want {
+				t.Errorf("Matches() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCrossEntityFilteringWithCache(t *testing.T) {
+	// Create a cache with a connection
+	cache := NewConnectionCache(100)
+	cache.Set("conn-123", map[string]any{
+		"connectionId": "conn-123",
+		"direction":    "egress",
+		"source": map[string]any{
+			"pid":      uint32(1234),
+			"hostname": "web-server",
+			"container": map[string]any{
+				"name": "nginx",
+				"id":   "abc123",
+			},
+		},
+		"destination": map[string]any{
+			"address": map[string]any{
+				"ip":   "10.0.0.1",
+				"port": 443,
+			},
+		},
+	})
+
+	tests := []struct {
+		name   string
+		filter *EventFilter
+		event  *Event
+		want   bool
+	}{
+		{
+			name: "process filter on request - matching via cache lookup",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"process": {{Entity: "process", Attribute: "pid", Operator: OpEq, Value: "1234"}},
+			}},
+			event: NewEvent("request.created", map[string]any{
+				"data": map[string]any{
+					"connectionId": "conn-123",
+					"method":       "GET",
+					"status":       200,
+				},
+			}),
+			want: true,
+		},
+		{
+			name: "process filter on request - non-matching via cache lookup",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"process": {{Entity: "process", Attribute: "pid", Operator: OpEq, Value: "9999"}},
+			}},
+			event: NewEvent("request.created", map[string]any{
+				"data": map[string]any{
+					"connectionId": "conn-123",
+					"method":       "GET",
+					"status":       200,
+				},
+			}),
+			want: false,
+		},
+		{
+			name: "process container filter on request via cache",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"process": {{Entity: "process", Attribute: "container", Operator: OpEq, Value: "nginx"}},
+			}},
+			event: NewEvent("request.created", map[string]any{
+				"data": map[string]any{
+					"connectionId": "conn-123",
+					"method":       "POST",
+				},
+			}),
+			want: true,
+		},
+		{
+			name: "connection filter on request - matching dstPort via cache",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"connection": {{Entity: "connection", Attribute: "dstPort", Operator: OpEq, Value: "443"}},
+			}},
+			event: NewEvent("request.created", map[string]any{
+				"data": map[string]any{
+					"connectionId": "conn-123",
+					"method":       "GET",
+				},
+			}),
+			want: true,
+		},
+		{
+			name: "request with unknown connectionId - cache miss, filter fails",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"process": {{Entity: "process", Attribute: "pid", Operator: OpEq, Value: "1234"}},
+			}},
+			event: NewEvent("request.created", map[string]any{
+				"data": map[string]any{
+					"connectionId": "unknown-conn",
+					"method":       "GET",
+				},
+			}),
+			want: false, // Can't verify process.pid without connection data
+		},
+		{
+			name: "combined cross-entity and direct filter",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"process": {{Entity: "process", Attribute: "pid", Operator: OpEq, Value: "1234"}},
+				"http":    {{Entity: "http", Attribute: "status", Operator: OpGte, Value: "400"}},
+			}},
+			event: NewEvent("request.created", map[string]any{
+				"data": map[string]any{
+					"connectionId": "conn-123",
+					"method":       "GET",
+					"status":       500,
+				},
+			}),
+			want: true,
+		},
+		{
+			name: "combined filter - process matches but http fails",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"process": {{Entity: "process", Attribute: "pid", Operator: OpEq, Value: "1234"}},
+				"http":    {{Entity: "http", Attribute: "status", Operator: OpGte, Value: "400"}},
+			}},
+			event: NewEvent("request.created", map[string]any{
+				"data": map[string]any{
+					"connectionId": "conn-123",
+					"method":       "GET",
+					"status":       200,
+				},
+			}),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.filter.Matches(tt.event, cache)
+			if got != tt.want {
+				t.Errorf("Matches() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConnectionCache(t *testing.T) {
+	t.Run("basic set and get", func(t *testing.T) {
+		cache := NewConnectionCache(100)
+		data := map[string]any{"direction": "egress"}
+		cache.Set("conn-1", data)
+
+		got := cache.Get("conn-1")
+		if got == nil {
+			t.Error("expected to get cached data, got nil")
+		}
+		if got["direction"] != "egress" {
+			t.Errorf("expected direction=egress, got %v", got["direction"])
+		}
+	})
+
+	t.Run("get non-existent", func(t *testing.T) {
+		cache := NewConnectionCache(100)
+		got := cache.Get("non-existent")
+		if got != nil {
+			t.Errorf("expected nil for non-existent key, got %v", got)
+		}
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		cache := NewConnectionCache(100)
+		cache.Set("conn-1", map[string]any{"direction": "egress"})
+		cache.Delete("conn-1")
+
+		got := cache.Get("conn-1")
+		if got != nil {
+			t.Errorf("expected nil after delete, got %v", got)
+		}
+	})
+
+	t.Run("LRU eviction", func(t *testing.T) {
+		cache := NewConnectionCache(3) // Small cache
+
+		cache.Set("conn-1", map[string]any{"id": 1})
+		cache.Set("conn-2", map[string]any{"id": 2})
+		cache.Set("conn-3", map[string]any{"id": 3})
+
+		// Cache is full, adding conn-4 should evict conn-1
+		cache.Set("conn-4", map[string]any{"id": 4})
+
+		if cache.Get("conn-1") != nil {
+			t.Error("expected conn-1 to be evicted")
+		}
+		if cache.Get("conn-2") == nil {
+			t.Error("expected conn-2 to still exist")
+		}
+		if cache.Get("conn-4") == nil {
+			t.Error("expected conn-4 to exist")
+		}
+	})
+
+	t.Run("update existing", func(t *testing.T) {
+		cache := NewConnectionCache(100)
+		cache.Set("conn-1", map[string]any{"version": 1})
+		cache.Set("conn-1", map[string]any{"version": 2})
+
+		got := cache.Get("conn-1")
+		if got["version"] != 2 {
+			t.Errorf("expected version=2, got %v", got["version"])
+		}
+		if cache.Len() != 1 {
+			t.Errorf("expected cache len=1, got %d", cache.Len())
+		}
+	})
+}
+
+func TestExtractProcessAttribute(t *testing.T) {
+	tests := []struct {
+		name string
+		data map[string]any
+		attr string
+		want any
+	}{
+		{
+			name: "pid",
+			data: map[string]any{"pid": 1234},
+			attr: "pid",
+			want: 1234,
+		},
+		{
+			name: "binary",
+			data: map[string]any{"binary": "nginx"},
+			attr: "binary",
+			want: "nginx",
+		},
+		{
+			name: "container name",
+			data: map[string]any{"container": map[string]any{"name": "web-container", "id": "abc123"}},
+			attr: "container",
+			want: "web-container",
+		},
+		{
+			name: "container id",
+			data: map[string]any{"container": map[string]any{"name": "web-container", "id": "abc123"}},
+			attr: "containerId",
+			want: "abc123",
+		},
+		{
+			name: "pod name",
+			data: map[string]any{"pod": map[string]any{"name": "web-pod", "namespace": "default"}},
+			attr: "pod",
+			want: "web-pod",
+		},
+		{
+			name: "pod namespace",
+			data: map[string]any{"pod": map[string]any{"name": "web-pod", "namespace": "default"}},
+			attr: "podNamespace",
+			want: "default",
+		},
+		{
+			name: "user name",
+			data: map[string]any{"user": map[string]any{"name": "root", "id": uint(0)}},
+			attr: "user",
+			want: "root",
+		},
+		{
+			name: "missing attribute",
+			data: map[string]any{"pid": 1234},
+			attr: "nonexistent",
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractProcessAttribute(tt.data, tt.attr)
+			if got != tt.want {
+				t.Errorf("extractProcessAttribute() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractConnectionAttribute(t *testing.T) {
+	tests := []struct {
+		name string
+		data map[string]any
+		attr string
+		want any
+	}{
+		{
+			name: "direction",
+			data: map[string]any{"data": map[string]any{"direction": "egress"}},
+			attr: "direction",
+			want: "egress",
+		},
+		{
+			name: "protocol",
+			data: map[string]any{"data": map[string]any{"l7Protocol": "http2"}},
+			attr: "protocol",
+			want: "http2",
+		},
+		{
+			name: "srcIp",
+			data: map[string]any{"data": map[string]any{
+				"source": map[string]any{
+					"address": map[string]any{"ip": "192.168.1.1", "port": 8080},
+				},
+			}},
+			attr: "srcIp",
+			want: "192.168.1.1",
+		},
+		{
+			name: "dstPort",
+			data: map[string]any{"data": map[string]any{
+				"destination": map[string]any{
+					"address": map[string]any{"ip": "10.0.0.1", "port": 443},
+				},
+			}},
+			attr: "dstPort",
+			want: 443,
+		},
+		{
+			name: "container from source",
+			data: map[string]any{"data": map[string]any{
+				"source": map[string]any{
+					"container": map[string]any{"name": "web-app"},
+				},
+			}},
+			attr: "container",
+			want: "web-app",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractConnectionAttribute(tt.data, tt.attr)
+			if got != tt.want {
+				t.Errorf("extractConnectionAttribute() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompareEqual(t *testing.T) {
+	tests := []struct {
+		name        string
+		value       any
+		filterValue string
+		want        bool
+	}{
+		{"string match", "hello", "hello", true},
+		{"string no match", "hello", "world", false},
+		{"int match", 42, "42", true},
+		{"int no match", 42, "43", false},
+		{"int64 match", int64(1234567890), "1234567890", true},
+		{"float64 match", float64(200), "200", true},
+		{"float64 decimal", float64(3.14), "3.14", true},
+		{"uint32 match", uint32(443), "443", true},
+		{"uint16 match", uint16(8080), "8080", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := compareEqual(tt.value, tt.filterValue)
+			if got != tt.want {
+				t.Errorf("compareEqual(%v, %q) = %v, want %v", tt.value, tt.filterValue, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompareNumeric(t *testing.T) {
+	tests := []struct {
+		name        string
+		value       any
+		filterValue string
+		op          func(a, b int64) bool
+		want        bool
+	}{
+		{"int gt true", 100, "50", func(a, b int64) bool { return a > b }, true},
+		{"int gt false", 50, "100", func(a, b int64) bool { return a > b }, false},
+		{"int gte equal", 100, "100", func(a, b int64) bool { return a >= b }, true},
+		{"float64 lt", float64(50), "100", func(a, b int64) bool { return a < b }, true},
+		{"uint32 lte", uint32(100), "100", func(a, b int64) bool { return a <= b }, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := compareNumeric(tt.value, tt.filterValue, tt.op)
+			if got != tt.want {
+				t.Errorf("compareNumeric(%v, %q) = %v, want %v", tt.value, tt.filterValue, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractHttpDomain(t *testing.T) {
+	tests := []struct {
+		name string
+		data map[string]any
+		want any
+	}{
+		{
+			name: "extract domain from url",
+			data: map[string]any{"data": map[string]any{"url": "https://api.example.com/v1/users"}},
+			want: "api.example.com",
+		},
+		{
+			name: "extract domain with port",
+			data: map[string]any{"data": map[string]any{"url": "http://localhost:8080/api"}},
+			want: "localhost",
+		},
+		{
+			name: "missing url",
+			data: map[string]any{"data": map[string]any{"method": "GET"}},
+			want: nil,
+		},
+		{
+			name: "invalid url",
+			data: map[string]any{"data": map[string]any{"url": "not-a-url"}},
+			want: "",
+		},
+		{
+			name: "http_transaction summary - domain from request_host",
+			data: map[string]any{"data": map[string]any{
+				"summary": map[string]any{
+					"request_host":   "api.slack.com",
+					"request_method": "POST",
+				},
+			}},
+			want: "api.slack.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractHttpAttribute(tt.data, "domain")
+			if got != tt.want {
+				t.Errorf("extractHttpAttribute(domain) = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractFromHttpTransactionSummary(t *testing.T) {
+	// Simulates the structure of request.http_transaction events from ObjectStore
+	data := map[string]any{
+		"data": map[string]any{
+			"connectionId": "abc123",
+			"type":         "http_transaction",
+			"summary": map[string]any{
+				"request_host":     "api.slack.com",
+				"request_method":   "POST",
+				"response_status":  float64(200), // JSON numbers are float64
+				"request_path":     "/api/chat.postMessage",
+				"direction":        "egress-external",
+				"request_protocol": "http2",
+				"request_scheme":   "https",
+				"connection_id":    "abc123",
+				"container_name":   "myapp",
+				"container_image":  "myapp:latest",
+				"process_exe":      "/usr/bin/node",
+			},
+		},
+	}
+
+	tests := []struct {
+		attr string
+		want any
+	}{
+		{"domain", "api.slack.com"},
+		{"method", "POST"},
+		{"status", float64(200)},
+		{"path", "/api/chat.postMessage"},
+		{"direction", "egress-external"},
+		{"protocol", "http2"},
+		{"scheme", "https"},
+		{"connectionId", "abc123"},
+		{"container", "myapp"},
+		{"containerImage", "myapp:latest"},
+		{"binary", "/usr/bin/node"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.attr, func(t *testing.T) {
+			got := extractHttpAttribute(data, tt.attr)
+			if got != tt.want {
+				t.Errorf("extractHttpAttribute(%q) = %v, want %v", tt.attr, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseFiltersFromBody(t *testing.T) {
+	tests := []struct {
+		name       string
+		filters    map[string]string
+		wantErr    bool
+		wantNil    bool
+		wantEntity string
+		wantCount  int
+	}{
+		{
+			name:    "nil map",
+			filters: nil,
+			wantNil: true,
+		},
+		{
+			name:    "empty map",
+			filters: map[string]string{},
+			wantNil: true,
+		},
+		{
+			name:       "single filter",
+			filters:    map[string]string{"process.pid.eq": "1234"},
+			wantEntity: "process",
+			wantCount:  1,
+		},
+		{
+			name: "multiple filters same entity",
+			filters: map[string]string{
+				"process.pid.eq":       "1234",
+				"process.container.eq": "nginx",
+			},
+			wantEntity: "process",
+			wantCount:  2,
+		},
+		{
+			name: "multiple filters different entities",
+			filters: map[string]string{
+				"process.pid.eq": "1234",
+				"http.method.eq": "POST",
+			},
+			wantCount: 2, // 1 per entity
+		},
+		{
+			name:    "invalid operator",
+			filters: map[string]string{"process.pid.invalid": "1234"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filter, err := ParseFiltersFromBody(tt.filters)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if tt.wantNil {
+				if filter != nil {
+					t.Errorf("expected nil filter, got %+v", filter)
+				}
+				return
+			}
+
+			if tt.wantEntity != "" {
+				conditions, ok := filter.Conditions[tt.wantEntity]
+				if !ok {
+					t.Errorf("expected conditions for entity %q", tt.wantEntity)
+					return
+				}
+				if len(conditions) != tt.wantCount {
+					t.Errorf("expected %d conditions, got %d", tt.wantCount, len(conditions))
+				}
+			} else if tt.wantCount > 0 {
+				// Count total conditions across all entities
+				total := 0
+				for _, conds := range filter.Conditions {
+					total += len(conds)
+				}
+				if total != tt.wantCount {
+					t.Errorf("expected %d total conditions, got %d", tt.wantCount, total)
+				}
+			}
+		})
+	}
+}
+
+func TestMergeFilters(t *testing.T) {
+	tests := []struct {
+		name     string
+		base     *EventFilter
+		override *EventFilter
+		wantNil  bool
+		check    func(*EventFilter) bool
+	}{
+		{
+			name:     "both nil",
+			base:     nil,
+			override: nil,
+			wantNil:  true,
+		},
+		{
+			name: "nil base, non-nil override",
+			base: nil,
+			override: &EventFilter{Conditions: map[string][]FilterCondition{
+				"process": {{Entity: "process", Attribute: "pid", Operator: OpEq, Value: "1234"}},
+			}},
+			check: func(f *EventFilter) bool {
+				return len(f.Conditions["process"]) == 1 && f.Conditions["process"][0].Value == "1234"
+			},
+		},
+		{
+			name: "non-nil base, nil override",
+			base: &EventFilter{Conditions: map[string][]FilterCondition{
+				"process": {{Entity: "process", Attribute: "pid", Operator: OpEq, Value: "1234"}},
+			}},
+			override: nil,
+			check: func(f *EventFilter) bool {
+				return len(f.Conditions["process"]) == 1 && f.Conditions["process"][0].Value == "1234"
+			},
+		},
+		{
+			name: "non-nil base, empty override",
+			base: &EventFilter{Conditions: map[string][]FilterCondition{
+				"process": {{Entity: "process", Attribute: "pid", Operator: OpEq, Value: "1234"}},
+			}},
+			override: &EventFilter{Conditions: map[string][]FilterCondition{}},
+			check: func(f *EventFilter) bool {
+				return len(f.Conditions["process"]) == 1 && f.Conditions["process"][0].Value == "1234"
+			},
+		},
+		{
+			name: "override replaces same entity",
+			base: &EventFilter{Conditions: map[string][]FilterCondition{
+				"process": {{Entity: "process", Attribute: "pid", Operator: OpEq, Value: "1234"}},
+			}},
+			override: &EventFilter{Conditions: map[string][]FilterCondition{
+				"process": {{Entity: "process", Attribute: "pid", Operator: OpEq, Value: "5678"}},
+			}},
+			check: func(f *EventFilter) bool {
+				return len(f.Conditions["process"]) == 1 && f.Conditions["process"][0].Value == "5678"
+			},
+		},
+		{
+			name: "merge different entities",
+			base: &EventFilter{Conditions: map[string][]FilterCondition{
+				"process": {{Entity: "process", Attribute: "pid", Operator: OpEq, Value: "1234"}},
+			}},
+			override: &EventFilter{Conditions: map[string][]FilterCondition{
+				"http": {{Entity: "http", Attribute: "method", Operator: OpEq, Value: "POST"}},
+			}},
+			check: func(f *EventFilter) bool {
+				return len(f.Conditions["process"]) == 1 &&
+					f.Conditions["process"][0].Value == "1234" &&
+					len(f.Conditions["http"]) == 1 &&
+					f.Conditions["http"][0].Value == "POST"
+			},
+		},
+		{
+			name: "override one entity, keep another",
+			base: &EventFilter{Conditions: map[string][]FilterCondition{
+				"process": {{Entity: "process", Attribute: "pid", Operator: OpEq, Value: "1234"}},
+				"http":    {{Entity: "http", Attribute: "method", Operator: OpEq, Value: "GET"}},
+			}},
+			override: &EventFilter{Conditions: map[string][]FilterCondition{
+				"http": {{Entity: "http", Attribute: "method", Operator: OpEq, Value: "POST"}},
+			}},
+			check: func(f *EventFilter) bool {
+				return len(f.Conditions["process"]) == 1 &&
+					f.Conditions["process"][0].Value == "1234" &&
+					len(f.Conditions["http"]) == 1 &&
+					f.Conditions["http"][0].Value == "POST"
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := MergeFilters(tt.base, tt.override)
+			if tt.wantNil {
+				if result != nil {
+					t.Errorf("expected nil, got %+v", result)
+				}
+				return
+			}
+			if result == nil {
+				t.Error("expected non-nil result")
+				return
+			}
+			if tt.check != nil && !tt.check(result) {
+				t.Errorf("check failed for result: %+v", result.Conditions)
+			}
+		})
+	}
+}

--- a/pkg/devtools/manager.go
+++ b/pkg/devtools/manager.go
@@ -27,14 +27,28 @@ type Manager struct {
 	eventStore         *EventStoreFactory
 	objectStore        *ObjectStoreFactory
 	processSnapshotter ProcessSnapshotter
+	connectionCache    *ConnectionCache
 	mu                 sync.RWMutex
-	clients            map[chan<- *Event]map[string]struct{}
+	clients            map[chan<- *Event]*ClientSubscription
+}
+
+// topicAliases maps topic aliases to their canonical names.
+// This allows users to use "http" as a topic which maps to "request" events.
+var topicAliases = map[string]string{
+	"http": "request",
+}
+
+// ClientSubscription holds subscription information for a connected client
+type ClientSubscription struct {
+	Topics map[string]struct{} // legacy topic filtering (for backward compat)
+	Filter *EventFilter        // structured filtering via query params
 }
 
 func NewManager(opts ...ManagerOpt) *Manager {
 	m := &Manager{
-		logger:  zap.L(),
-		clients: make(map[chan<- *Event]map[string]struct{}),
+		logger:          zap.L(),
+		clients:         make(map[chan<- *Event]*ClientSubscription),
+		connectionCache: NewConnectionCache(DefaultCacheMaxSize),
 	}
 	m.eventStore = &EventStoreFactory{broadcast: m.broadcast}
 	m.objectStore = &ObjectStoreFactory{broadcast: m.broadcast}
@@ -80,8 +94,9 @@ func (m *Manager) RegisterRoutes(mux *http.ServeMux, prefix string) error {
 }
 
 type APIEventsRequest struct {
-	FilterTopics        []string `json:"filter_topics,omitempty"`
-	SkipProcessSnapshot bool     `json:"skip_process_snapshot,omitempty"`
+	FilterTopics        []string          `json:"filter_topics,omitempty"`
+	Filters             map[string]string `json:"filters,omitempty"`
+	SkipProcessSnapshot bool              `json:"skip_process_snapshot,omitempty"`
 }
 
 func (m *Manager) routeAPIEvents(w http.ResponseWriter, r *http.Request) {
@@ -111,21 +126,54 @@ func (m *Manager) routeAPIEvents(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Parse topics: query params override body
+	topics := req.FilterTopics
+	if topicsParam := r.URL.Query().Get("topics"); topicsParam != "" {
+		topics = strings.Split(topicsParam, ",")
+		// Trim whitespace from each topic
+		for i, t := range topics {
+			topics[i] = strings.TrimSpace(t)
+		}
+	}
+
+	// Parse filters: start with body, then merge/override with query params
+	var filter *EventFilter
+	var err error
+
+	// First, parse from body if present
+	if len(req.Filters) > 0 {
+		filter, err = ParseFiltersFromBody(req.Filters)
+		if err != nil {
+			httpError(ll, w, fmt.Errorf("parsing body filters: %w", err), http.StatusBadRequest)
+			return
+		}
+	}
+
+	// Then, parse from query params (overrides body)
+	queryFilter, err := ParseFilters(r.URL.Query())
+	if err != nil {
+		httpError(ll, w, fmt.Errorf("parsing query filters: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	// Merge: query params override body
+	filter = MergeFilters(filter, queryFilter)
+
 	// init SSE
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
 	w.WriteHeader(http.StatusOK)
 	writeEvent(ll, w, NewEvent("system.connected", map[string]any{
-		"topics": req.FilterTopics,
+		"topics": topics,
 	}))
 	ll.Debug("client connected",
-		zap.Any("topics", req.FilterTopics),
+		zap.Any("topics", topics),
 		zap.Int("total_connected_clients", m.clientCount()+1),
 	)
 
 	// subscribe to events
-	events := m.SubscribeClient(r.Context(), req.FilterTopics, !req.SkipProcessSnapshot)
+	events := m.SubscribeClient(r.Context(), topics, filter, !req.SkipProcessSnapshot)
 	for {
 		select {
 		case <-r.Context().Done():
@@ -205,6 +253,9 @@ func writeEvent(ll *zap.Logger, w http.ResponseWriter, event *Event) {
 }
 
 func (m *Manager) broadcast(event *Event) {
+	// Update connection cache for cross-entity filtering
+	m.updateConnectionCache(event)
+
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
@@ -213,13 +264,18 @@ func (m *Manager) broadcast(event *Event) {
 	}
 
 	topLevelTopic := event.TopLevelTopic()
-	for client, topics := range m.clients {
-		// skip if client is not subscribed to the topic
+	for client, sub := range m.clients {
+		// skip if client is not subscribed to the topic (legacy topic filtering)
 		// `system` topic events will be broadcast to all clients regardless of filtering
-		if topLevelTopic != "" && topLevelTopic != "system" && len(topics) > 0 {
-			if _, ok := topics[topLevelTopic]; !ok {
+		if topLevelTopic != "" && topLevelTopic != "system" && len(sub.Topics) > 0 {
+			if _, ok := sub.Topics[topLevelTopic]; !ok {
 				continue
 			}
+		}
+
+		// Apply structured filter if present (with cache for cross-entity lookups)
+		if sub.Filter != nil && !sub.Filter.Matches(event, m.connectionCache) {
+			continue
 		}
 
 		select {
@@ -231,16 +287,83 @@ func (m *Manager) broadcast(event *Event) {
 	}
 }
 
-func (m *Manager) sendProcessSnapshot(ctx context.Context, ch chan<- *Event) {
+// updateConnectionCache maintains the connection cache for cross-entity filtering
+func (m *Manager) updateConnectionCache(event *Event) {
+	// Only process connection events
+	if !strings.HasPrefix(event.Topic, "connection.") {
+		return
+	}
+
+	data, ok := event.Data.(map[string]any)
+	if !ok {
+		return
+	}
+
+	// Connection data is nested under "data" key
+	innerData, ok := data["data"]
+	if !ok {
+		return
+	}
+
+	// Handle both struct and map types
+	var connId string
+	var connData map[string]any
+
+	switch d := innerData.(type) {
+	case map[string]any:
+		connData = d
+		if meta, ok := d["meta"].(map[string]any); ok {
+			connId, _ = meta["connectionId"].(string)
+		} else {
+			connId, _ = d["connectionId"].(string)
+		}
+	default:
+		// For struct types, we need to extract via JSON marshaling
+		// This handles *eventstore.Connection
+		jsonBytes, err := json.Marshal(innerData)
+		if err != nil {
+			return
+		}
+		if err := json.Unmarshal(jsonBytes, &connData); err != nil {
+			return
+		}
+		if meta, ok := connData["meta"].(map[string]any); ok {
+			connId, _ = meta["connectionId"].(string)
+		} else {
+			connId, _ = connData["connectionId"].(string)
+		}
+	}
+
+	if connId == "" {
+		return
+	}
+
+	switch event.Topic {
+	case "connection.opened", "connection.updated":
+		m.connectionCache.Set(connId, connData)
+	case "connection.closed":
+		// Remove from cache - connection is done, no more requests expected
+		m.connectionCache.Delete(connId)
+	}
+}
+
+func (m *Manager) sendProcessSnapshot(ctx context.Context, ch chan<- *Event, filter *EventFilter) {
 	if m.processSnapshotter == nil {
 		return
 	}
 
 	m.processSnapshotter.SnapshotProcesses(func(pid int, p *process.Process) bool {
+		event := NewEvent("process.started", marshalProcess(p))
+
+		// Apply filter if present (no cache needed for process events)
+		if filter != nil && !filter.Matches(event, nil) {
+			return true // continue to next process
+		}
+
 		select {
 		case <-ctx.Done():
 			return false
-		case ch <- NewEvent("process.started", marshalProcess(p)):
+		case ch <- event:
 		default:
 			m.logger.Warn("client buffer is full, stopping process snapshot")
 			return false
@@ -249,21 +372,28 @@ func (m *Manager) sendProcessSnapshot(ctx context.Context, ch chan<- *Event) {
 	})
 }
 
-func (m *Manager) SubscribeClient(ctx context.Context, topics []string, sendProcessSnapshot bool) <-chan *Event {
+func (m *Manager) SubscribeClient(ctx context.Context, topics []string, filter *EventFilter, sendProcessSnapshot bool) <-chan *Event {
 	topicsMap := make(map[string]struct{}, len(topics))
 	for _, topic := range topics {
+		// Normalize topic aliases (e.g., "http" -> "request")
+		if canonical, ok := topicAliases[topic]; ok {
+			topic = canonical
+		}
 		topicsMap[topic] = struct{}{}
 	}
 
 	ch := make(chan *Event, 100)
 
 	m.mu.Lock()
-	m.clients[ch] = topicsMap
+	m.clients[ch] = &ClientSubscription{
+		Topics: topicsMap,
+		Filter: filter,
+	}
 	m.mu.Unlock()
 
 	// send a snapshot of the current processes if subscribed
 	if sendProcessSnapshot && (len(topics) == 0 || slices.Contains(topics, "process")) {
-		go m.sendProcessSnapshot(ctx, ch)
+		go m.sendProcessSnapshot(ctx, ch, filter)
 	}
 
 	// unsubscribe on ctx done


### PR DESCRIPTION
## Summary

Adds server-side filtering to the devtools events endpoint, allowing clients to subscribe only to the events they care about. This reduces client-side processing and eliminates unnecessary bandwidth.

## Filter Syntax

Filters use the format `<entity>.<attribute>.<operator>=<value>`:

```bash
# Filter by HTTP status (errors only)
curl "http://localhost:10002/devtools/api/events?http.status.gte=400"

# Filter by domain
curl "http://localhost:10002/devtools/api/events?http.domain.eq=api.slack.com"

# Filter by process
curl "http://localhost:10002/devtools/api/events?process.pid.eq=1234"

# Combined filters (AND logic)
curl "http://localhost:10002/devtools/api/events?http.domain.contains=slack&http.status.gte=200&http.status.lt=300"
```

## Supported Operators

| Operator | Description |
|----------|-------------|
| `eq` | Equals |
| `neq` | Not equals |
| `in` | In comma-separated list |
| `gt`, `gte` | Greater than (or equal) |
| `lt`, `lte` | Less than (or equal) |
| `prefix` | String starts with |
| `contains` | String contains |

## Filter Entities

| Entity | Applies To | Example Attributes |
|--------|------------|-------------------|
| `http` | HTTP request/response events | `method`, `status`, `domain`, `path`, `direction`, `duration` |
| `process` | Process, connection, and HTTP events | `pid`, `binary`, `container`, `pod` |
| `connection` | Connection and HTTP events | `direction`, `protocol`, `dstPort`, `srcIp` |

## Cross-Entity Filtering

Filters can apply across related entities. For example, `process.container.eq=nginx` will filter:
- Process events for that container
- Connection events from that container
- HTTP events from that container (via connection lookup)

## Topic Alias

The `http` topic is now an alias for `request`, providing consistency with the filter entity naming:

```bash
# These are equivalent
curl "http://localhost:10002/devtools/api/events?topics=http"
curl "http://localhost:10002/devtools/api/events?topics=request"
```
