### PR TITLE
Optimize tags struct for reads + benchmarks

### DIFF
--- a/pkg/tags/tags.go
+++ b/pkg/tags/tags.go
@@ -20,13 +20,16 @@ type List interface {
 }
 
 type tags struct {
-	mu   sync.RWMutex
-	data map[string][]string
+	mu    sync.RWMutex
+	data  map[string][]string
+	cache map[string][]string // cached copy for Map()
+	dirty bool                // true when cache needs rebuild
 }
 
 func New() *tags {
 	return &tags{
-		data: make(map[string][]string),
+		data:  make(map[string][]string),
+		dirty: true, // no cache yet
 	}
 }
 
@@ -73,6 +76,7 @@ func (t *tags) add(key string, values ...string) {
 			continue
 		}
 		t.data[key] = append(t.data[key], v)
+		t.dirty = true // invalidate cache
 	}
 }
 
@@ -131,14 +135,31 @@ func (t *tags) Merge(other List) {
 }
 
 func (t *tags) Map() map[string][]string {
+	// Fast path: return cached copy if available
 	t.mu.RLock()
-	defer t.mu.RUnlock()
-
-	m := make(map[string][]string, len(t.data))
-	for k, v := range t.data {
-		m[k] = append(([]string)(nil), v...)
+	if !t.dirty && t.cache != nil {
+		cache := t.cache
+		t.mu.RUnlock()
+		return cache
 	}
-	return m
+	t.mu.RUnlock()
+
+	// Slow path: rebuild cache
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	// Double-check after acquiring write lock
+	if !t.dirty && t.cache != nil {
+		return t.cache
+	}
+
+	// Build new cache
+	t.cache = make(map[string][]string, len(t.data))
+	for k, v := range t.data {
+		t.cache[k] = append([]string(nil), v...)
+	}
+	t.dirty = false
+	return t.cache
 }
 
 func (t *tags) Get(key string) ([]string, bool) {

--- a/pkg/tags/tags_test.go
+++ b/pkg/tags/tags_test.go
@@ -442,3 +442,436 @@ func TestIsAlphanumeric(t *testing.T) {
 		})
 	}
 }
+
+// Benchmark tests
+
+func BenchmarkAdd(b *testing.B) {
+	tags := New()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tags.Add("category", "test")
+	}
+}
+
+func BenchmarkAddMultipleValues(b *testing.B) {
+	tags := New()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tags.Add("category", "test1", "test2", "test3", "test4", "test5")
+	}
+}
+
+func BenchmarkAddString(b *testing.B) {
+	tags := New()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = tags.AddString("category:test")
+	}
+}
+
+func BenchmarkAddString_Invalid(b *testing.B) {
+	tags := New()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = tags.AddString("invalidformat")
+	}
+}
+
+func BenchmarkGet(b *testing.B) {
+	tags := New()
+	tags.Add("category", "test1", "test2", "test3")
+	tags.Add("service", "api")
+	tags.Add("environment", "prod")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = tags.Get("category")
+	}
+}
+
+func BenchmarkGet_NonExistent(b *testing.B) {
+	tags := New()
+	tags.Add("category", "test")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = tags.Get("nonexistent")
+	}
+}
+
+func BenchmarkList_Small(b *testing.B) {
+	tags := New()
+	tags.Add("category", "test")
+	tags.Add("service", "api")
+	tags.Add("environment", "prod")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = tags.List()
+	}
+}
+
+func BenchmarkList_Large(b *testing.B) {
+	tags := New()
+	for i := 0; i < 100; i++ {
+		tags.Add("key", "value1", "value2", "value3", "value4", "value5")
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = tags.List()
+	}
+}
+
+func BenchmarkClone_Small(b *testing.B) {
+	tags := New()
+	tags.Add("category", "test")
+	tags.Add("service", "api")
+	tags.Add("environment", "prod")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = tags.Clone()
+	}
+}
+
+func BenchmarkClone_Large(b *testing.B) {
+	tags := New()
+	for i := 0; i < 100; i++ {
+		tags.Add("key", "value1", "value2", "value3", "value4", "value5")
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = tags.Clone()
+	}
+}
+
+func BenchmarkMerge_Small(b *testing.B) {
+	source := New()
+	source.Add("category", "test")
+	source.Add("service", "api")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		target := New()
+		target.Add("environment", "prod")
+		target.Merge(source)
+	}
+}
+
+func BenchmarkMerge_Large(b *testing.B) {
+	source := New()
+	for i := 0; i < 100; i++ {
+		source.Add("key", "value1", "value2", "value3")
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		target := New()
+		for j := 0; j < 50; j++ {
+			target.Add("key2", "value4", "value5")
+		}
+		target.Merge(source)
+	}
+}
+
+func BenchmarkMap_Small(b *testing.B) {
+	tags := New()
+	tags.Add("category", "test")
+	tags.Add("service", "api")
+	tags.Add("environment", "prod")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = tags.Map()
+	}
+}
+
+func BenchmarkMap_Large(b *testing.B) {
+	tags := New()
+	for i := 0; i < 100; i++ {
+		tags.Add("key", "value1", "value2", "value3", "value4", "value5")
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = tags.Map()
+	}
+}
+
+func BenchmarkFromValues_Small(b *testing.B) {
+	kv := map[string]string{
+		"category":    "test",
+		"service":     "api",
+		"environment": "prod",
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = FromValues(kv)
+	}
+}
+
+func BenchmarkFromValues_Large(b *testing.B) {
+	kv := make(map[string]string, 100)
+	for i := 0; i < 100; i++ {
+		kv["key"] = "value"
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = FromValues(kv)
+	}
+}
+
+func BenchmarkFromMultiValues_Small(b *testing.B) {
+	kv := map[string][]string{
+		"category":    {"test", "test2"},
+		"service":     {"api", "web"},
+		"environment": {"prod", "staging"},
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = FromMultiValues(kv)
+	}
+}
+
+func BenchmarkFromMultiValues_Large(b *testing.B) {
+	kv := make(map[string][]string, 100)
+	for i := 0; i < 100; i++ {
+		kv["key"] = []string{"value1", "value2", "value3", "value4", "value5"}
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = FromMultiValues(kv)
+	}
+}
+
+func BenchmarkFormat(b *testing.B) {
+	testStrings := []string{
+		"Simple Test",
+		"  UPPERCASE WITH SPACES  ",
+		"-starts-with-hyphen-",
+		"has multiple   spaces",
+		"MixedCaseString",
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, s := range testStrings {
+			_ = format(s)
+		}
+	}
+}
+
+func BenchmarkConcurrentAdd(b *testing.B) {
+	tags := New()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			tags.Add("category", "test")
+			i++
+		}
+	})
+}
+
+func BenchmarkConcurrentGet(b *testing.B) {
+	tags := New()
+	tags.Add("category", "test1", "test2", "test3")
+	tags.Add("service", "api")
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_, _ = tags.Get("category")
+		}
+	})
+}
+
+func BenchmarkConcurrentAddAndGet(b *testing.B) {
+	tags := New()
+	tags.Add("category", "test")
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			if i%2 == 0 {
+				tags.Add("category", "test")
+			} else {
+				_, _ = tags.Get("category")
+			}
+			i++
+		}
+	})
+}
+
+func BenchmarkConcurrentList(b *testing.B) {
+	tags := New()
+	for i := 0; i < 10; i++ {
+		tags.Add("key", "value1", "value2", "value3")
+	}
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_ = tags.List()
+		}
+	})
+}
+
+func BenchmarkConcurrentClone(b *testing.B) {
+	tags := New()
+	for i := 0; i < 10; i++ {
+		tags.Add("key", "value1", "value2", "value3")
+	}
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_ = tags.Clone()
+		}
+	})
+}
+
+// Comparison benchmarks: Cached vs Non-Cached implementations
+
+func BenchmarkMap_Standard_Small(b *testing.B) {
+	tags := New()
+	tags.Add("category", "test")
+	tags.Add("service", "api")
+	tags.Add("environment", "prod")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = tags.Map()
+	}
+}
+
+func BenchmarkMap_Cached_Small(b *testing.B) {
+	tags := New()
+	tags.Add("category", "test")
+	tags.Add("service", "api")
+	tags.Add("environment", "prod")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = tags.Map()
+	}
+}
+
+func BenchmarkMap_Standard_Large(b *testing.B) {
+	tags := New()
+	for i := 0; i < 100; i++ {
+		tags.Add("key", "value1", "value2", "value3", "value4", "value5")
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = tags.Map()
+	}
+}
+
+func BenchmarkMap_Cached_Large(b *testing.B) {
+	tags := New()
+	for i := 0; i < 100; i++ {
+		tags.Add("key", "value1", "value2", "value3", "value4", "value5")
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = tags.Map()
+	}
+}
+
+func BenchmarkMap_Standard_ReadHeavy(b *testing.B) {
+	tags := New()
+	tags.Add("category", "test")
+	tags.Add("service", "api")
+	b.ResetTimer()
+	// Simulate read-heavy workload: 1 write per 1000 reads
+	for i := 0; i < b.N; i++ {
+		if i%1000 == 0 {
+			tags.Add("temp", "value")
+		}
+		_ = tags.Map()
+	}
+}
+
+func BenchmarkMap_Cached_ReadHeavy(b *testing.B) {
+	tags := New()
+	tags.Add("category", "test")
+	tags.Add("service", "api")
+	b.ResetTimer()
+	// Simulate read-heavy workload: 1 write per 1000 reads
+	for i := 0; i < b.N; i++ {
+		if i%1000 == 0 {
+			tags.Add("temp", "value")
+		}
+		_ = tags.Map()
+	}
+}
+
+func BenchmarkMap_Standard_WriteHeavy(b *testing.B) {
+	tags := New()
+	tags.Add("category", "test")
+	b.ResetTimer()
+	// Simulate write-heavy workload: 1 Map() per 10 writes
+	for i := 0; i < b.N; i++ {
+		if i%10 == 0 {
+			_ = tags.Map()
+		}
+		tags.Add("key", "value")
+	}
+}
+
+func BenchmarkMap_Cached_WriteHeavy(b *testing.B) {
+	tags := New()
+	tags.Add("category", "test")
+	b.ResetTimer()
+	// Simulate write-heavy workload: 1 Map() per 10 writes
+	for i := 0; i < b.N; i++ {
+		if i%10 == 0 {
+			_ = tags.Map()
+		}
+		tags.Add("key", "value")
+	}
+}
+
+func BenchmarkConcurrentMap_Standard(b *testing.B) {
+	tags := New()
+	for i := 0; i < 10; i++ {
+		tags.Add("key", "value1", "value2", "value3")
+	}
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_ = tags.Map()
+		}
+	})
+}
+
+func BenchmarkConcurrentMap_Cached(b *testing.B) {
+	tags := New()
+	for i := 0; i < 10; i++ {
+		tags.Add("key", "value1", "value2", "value3")
+	}
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_ = tags.Map()
+		}
+	})
+}
+
+func BenchmarkConcurrentMapWithWrites_Standard(b *testing.B) {
+	tags := New()
+	tags.Add("initial", "value")
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			// 90% reads, 10% writes
+			if i%10 == 0 {
+				tags.Add("key", "value")
+			} else {
+				_ = tags.Map()
+			}
+			i++
+		}
+	})
+}
+
+func BenchmarkConcurrentMapWithWrites_Cached(b *testing.B) {
+	tags := New()
+	tags.Add("initial", "value")
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			// 90% reads, 10% writes
+			if i%10 == 0 {
+				tags.Add("key", "value")
+			} else {
+				_ = tags.Map()
+			}
+			i++
+		}
+	})
+}

--- a/pkg/tags/tags_test.go
+++ b/pkg/tags/tags_test.go
@@ -448,7 +448,7 @@ func TestIsAlphanumeric(t *testing.T) {
 func BenchmarkAdd(b *testing.B) {
 	tags := New()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		tags.Add("category", "test")
 	}
 }
@@ -456,7 +456,7 @@ func BenchmarkAdd(b *testing.B) {
 func BenchmarkAddMultipleValues(b *testing.B) {
 	tags := New()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		tags.Add("category", "test1", "test2", "test3", "test4", "test5")
 	}
 }
@@ -464,7 +464,7 @@ func BenchmarkAddMultipleValues(b *testing.B) {
 func BenchmarkAddString(b *testing.B) {
 	tags := New()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = tags.AddString("category:test")
 	}
 }
@@ -472,7 +472,7 @@ func BenchmarkAddString(b *testing.B) {
 func BenchmarkAddString_Invalid(b *testing.B) {
 	tags := New()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = tags.AddString("invalidformat")
 	}
 }
@@ -483,7 +483,7 @@ func BenchmarkGet(b *testing.B) {
 	tags.Add("service", "api")
 	tags.Add("environment", "prod")
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_, _ = tags.Get("category")
 	}
 }
@@ -492,7 +492,7 @@ func BenchmarkGet_NonExistent(b *testing.B) {
 	tags := New()
 	tags.Add("category", "test")
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_, _ = tags.Get("nonexistent")
 	}
 }
@@ -503,18 +503,18 @@ func BenchmarkList_Small(b *testing.B) {
 	tags.Add("service", "api")
 	tags.Add("environment", "prod")
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = tags.List()
 	}
 }
 
 func BenchmarkList_Large(b *testing.B) {
 	tags := New()
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		tags.Add("key", "value1", "value2", "value3", "value4", "value5")
 	}
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = tags.List()
 	}
 }
@@ -525,18 +525,18 @@ func BenchmarkClone_Small(b *testing.B) {
 	tags.Add("service", "api")
 	tags.Add("environment", "prod")
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = tags.Clone()
 	}
 }
 
 func BenchmarkClone_Large(b *testing.B) {
 	tags := New()
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		tags.Add("key", "value1", "value2", "value3", "value4", "value5")
 	}
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = tags.Clone()
 	}
 }
@@ -546,7 +546,7 @@ func BenchmarkMerge_Small(b *testing.B) {
 	source.Add("category", "test")
 	source.Add("service", "api")
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		target := New()
 		target.Add("environment", "prod")
 		target.Merge(source)
@@ -555,13 +555,13 @@ func BenchmarkMerge_Small(b *testing.B) {
 
 func BenchmarkMerge_Large(b *testing.B) {
 	source := New()
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		source.Add("key", "value1", "value2", "value3")
 	}
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		target := New()
-		for j := 0; j < 50; j++ {
+		for range 50 {
 			target.Add("key2", "value4", "value5")
 		}
 		target.Merge(source)
@@ -574,18 +574,18 @@ func BenchmarkMap_Small(b *testing.B) {
 	tags.Add("service", "api")
 	tags.Add("environment", "prod")
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = tags.Map()
 	}
 }
 
 func BenchmarkMap_Large(b *testing.B) {
 	tags := New()
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		tags.Add("key", "value1", "value2", "value3", "value4", "value5")
 	}
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = tags.Map()
 	}
 }
@@ -597,18 +597,18 @@ func BenchmarkFromValues_Small(b *testing.B) {
 		"environment": "prod",
 	}
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = FromValues(kv)
 	}
 }
 
 func BenchmarkFromValues_Large(b *testing.B) {
 	kv := make(map[string]string, 100)
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		kv["key"] = "value"
 	}
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = FromValues(kv)
 	}
 }
@@ -620,18 +620,18 @@ func BenchmarkFromMultiValues_Small(b *testing.B) {
 		"environment": {"prod", "staging"},
 	}
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = FromMultiValues(kv)
 	}
 }
 
 func BenchmarkFromMultiValues_Large(b *testing.B) {
 	kv := make(map[string][]string, 100)
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		kv["key"] = []string{"value1", "value2", "value3", "value4", "value5"}
 	}
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = FromMultiValues(kv)
 	}
 }
@@ -645,7 +645,7 @@ func BenchmarkFormat(b *testing.B) {
 		"MixedCaseString",
 	}
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		for _, s := range testStrings {
 			_ = format(s)
 		}
@@ -692,7 +692,7 @@ func BenchmarkConcurrentAddAndGet(b *testing.B) {
 
 func BenchmarkConcurrentList(b *testing.B) {
 	tags := New()
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		tags.Add("key", "value1", "value2", "value3")
 	}
 	b.RunParallel(func(pb *testing.PB) {
@@ -704,7 +704,7 @@ func BenchmarkConcurrentList(b *testing.B) {
 
 func BenchmarkConcurrentClone(b *testing.B) {
 	tags := New()
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		tags.Add("key", "value1", "value2", "value3")
 	}
 	b.RunParallel(func(pb *testing.PB) {
@@ -722,7 +722,7 @@ func BenchmarkMap_Standard_Small(b *testing.B) {
 	tags.Add("service", "api")
 	tags.Add("environment", "prod")
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = tags.Map()
 	}
 }
@@ -733,29 +733,29 @@ func BenchmarkMap_Cached_Small(b *testing.B) {
 	tags.Add("service", "api")
 	tags.Add("environment", "prod")
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = tags.Map()
 	}
 }
 
 func BenchmarkMap_Standard_Large(b *testing.B) {
 	tags := New()
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		tags.Add("key", "value1", "value2", "value3", "value4", "value5")
 	}
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = tags.Map()
 	}
 }
 
 func BenchmarkMap_Cached_Large(b *testing.B) {
 	tags := New()
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		tags.Add("key", "value1", "value2", "value3", "value4", "value5")
 	}
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = tags.Map()
 	}
 }
@@ -766,7 +766,7 @@ func BenchmarkMap_Standard_ReadHeavy(b *testing.B) {
 	tags.Add("service", "api")
 	b.ResetTimer()
 	// Simulate read-heavy workload: 1 write per 1000 reads
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		if i%1000 == 0 {
 			tags.Add("temp", "value")
 		}
@@ -780,7 +780,7 @@ func BenchmarkMap_Cached_ReadHeavy(b *testing.B) {
 	tags.Add("service", "api")
 	b.ResetTimer()
 	// Simulate read-heavy workload: 1 write per 1000 reads
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		if i%1000 == 0 {
 			tags.Add("temp", "value")
 		}
@@ -793,7 +793,7 @@ func BenchmarkMap_Standard_WriteHeavy(b *testing.B) {
 	tags.Add("category", "test")
 	b.ResetTimer()
 	// Simulate write-heavy workload: 1 Map() per 10 writes
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		if i%10 == 0 {
 			_ = tags.Map()
 		}
@@ -806,7 +806,7 @@ func BenchmarkMap_Cached_WriteHeavy(b *testing.B) {
 	tags.Add("category", "test")
 	b.ResetTimer()
 	// Simulate write-heavy workload: 1 Map() per 10 writes
-	for i := 0; i < b.N; i++ {
+	for i := range b.N {
 		if i%10 == 0 {
 			_ = tags.Map()
 		}
@@ -816,7 +816,7 @@ func BenchmarkMap_Cached_WriteHeavy(b *testing.B) {
 
 func BenchmarkConcurrentMap_Standard(b *testing.B) {
 	tags := New()
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		tags.Add("key", "value1", "value2", "value3")
 	}
 	b.ResetTimer()
@@ -829,7 +829,7 @@ func BenchmarkConcurrentMap_Standard(b *testing.B) {
 
 func BenchmarkConcurrentMap_Cached(b *testing.B) {
 	tags := New()
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		tags.Add("key", "value1", "value2", "value3")
 	}
 	b.ResetTimer()


### PR DESCRIPTION
Add benchmark tests for tags functionality and optimize Map method with caching

- Introduced multiple benchmark tests for various operations including Add, Get, List, Clone, and Merge, both for small and large datasets.
- Implemented caching in the Map method to improve performance by avoiding unnecessary data reconstruction.
- Added logic to invalidate the cache when data is modified.

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Contributing Guide: https://github.com/qpoint-io/qtap/docs/CONTRIBUTING.md
     - 📖 Read the Contributor License Agreement (CLA): https://github.com/qpoint-io/qtap/docs/CLA.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Qpoint Team member.
-->
