### PR TITLE
Add queue event type notifs

### DIFF
--- a/pkg/synq/queue.go
+++ b/pkg/synq/queue.go
@@ -15,6 +15,14 @@ var (
 	ErrQueueDraining = errors.New("queue draining")
 )
 
+// Op represents a queue operation type for notifications
+type Op int
+
+const (
+	Pushed Op = iota // Item was pushed to queue
+	Popped           // Item was popped from queue
+)
+
 // Prioritized is an interface for items that can be prioritized in the queue
 type Prioritized interface {
 	QueuePriority() int
@@ -36,7 +44,7 @@ type Queue struct {
 	draining atomic.Bool
 	count    int64
 
-	notify chan struct{}
+	notify chan Op // signals queue operations (Pushed/Popped)
 }
 
 func NewQueue(ctx context.Context) *Queue {
@@ -44,7 +52,7 @@ func NewQueue(ctx context.Context) *Queue {
 	return &Queue{
 		ctx:    qCtx,
 		cancel: cancel,
-		notify: make(chan struct{}, 1),
+		notify: make(chan Op, 1),
 	}
 }
 
@@ -67,7 +75,7 @@ func (q *Queue) Push(values ...any) error {
 
 	// Signal waiting consumers
 	select {
-	case q.notify <- struct{}{}:
+	case q.notify <- Pushed:
 	default:
 	}
 
@@ -142,6 +150,14 @@ func (q *Queue) pop() any {
 	}
 	atomic.AddInt64(&q.count, -1)
 
+	// Signal drain waiters that an item was popped
+	if q.draining.Load() {
+		select {
+		case q.notify <- Popped:
+		default:
+		}
+	}
+
 	return value
 }
 
@@ -180,6 +196,15 @@ func (q *Queue) Next() (any, bool) {
 				q.tail = nil
 			}
 			atomic.AddInt64(&q.count, -1)
+
+			// Signal drain waiters that an item was popped
+			if q.draining.Load() {
+				select {
+				case q.notify <- Popped:
+				default:
+				}
+			}
+
 			q.mu.Unlock()
 			return value, true
 		}
@@ -192,6 +217,7 @@ func (q *Queue) Next() (any, bool) {
 		// Wait for new items or context cancellation
 		select {
 		case <-q.notify:
+			// Any operation (Pushed/Popped) means we should check the queue again
 			continue
 		case <-q.ctx.Done():
 			return nil, false
@@ -234,11 +260,13 @@ func (q *Queue) Drain(d time.Duration) error {
 		}
 		q.mu.Unlock()
 
+		// Wait for any operation or timeout
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		default:
-			time.Sleep(10 * time.Millisecond) // Small delay to avoid busy-waiting
+		case <-q.notify:
+			// Any operation means we should check if queue is empty
+			continue
 		}
 	}
 }

--- a/pkg/synq/queue_bench_test.go
+++ b/pkg/synq/queue_bench_test.go
@@ -1,0 +1,339 @@
+package synq
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+// Helper functions for benchmark setup
+
+// populateQueue populates the queue with n integer items
+func populateQueue(q *Queue, n int) {
+	for i := range n {
+		_ = q.Push(i)
+	}
+}
+
+// populateQueuePriority populates the queue with n prioritized items
+func populateQueuePriority(q *Queue, n int) {
+	for i := range n {
+		_ = q.Push(prioritizedItem{
+			value:    fmt.Sprintf("item-%d", i),
+			priority: i,
+		})
+	}
+}
+
+// Group A: Basic Operations Benchmarks
+
+func BenchmarkQueue_Push(b *testing.B) {
+	ctx := b.Context()
+	q := NewQueue(ctx)
+
+	b.ResetTimer()
+	for range b.N {
+		_ = q.Push(1)
+	}
+}
+
+func BenchmarkQueue_PushBatch(b *testing.B) {
+	ctx := b.Context()
+	q := NewQueue(ctx)
+
+	b.ResetTimer()
+	for range b.N {
+		_ = q.Push(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+	}
+}
+
+func BenchmarkQueue_Pop(b *testing.B) {
+	ctx := b.Context()
+	q := NewQueue(ctx)
+	populateQueue(q, 1000)
+
+	b.ResetTimer()
+	for range b.N {
+		_ = q.Pop()
+	}
+}
+
+func BenchmarkQueue_PopN(b *testing.B) {
+	ctx := b.Context()
+	q := NewQueue(ctx)
+	populateQueue(q, 10000)
+
+	b.ResetTimer()
+	for range b.N {
+		_ = q.PopN(10)
+	}
+}
+
+func BenchmarkQueue_Next(b *testing.B) {
+	ctx := b.Context()
+	q := NewQueue(ctx)
+	populateQueue(q, b.N)
+
+	b.ResetTimer()
+	for range b.N {
+		_, _ = q.Next()
+	}
+}
+
+func BenchmarkQueue_Len(b *testing.B) {
+	ctx := b.Context()
+	q := NewQueue(ctx)
+	populateQueue(q, 1000)
+
+	b.ResetTimer()
+	for range b.N {
+		_ = q.Len()
+	}
+}
+
+// Group B: Priority Operations Benchmarks
+
+func BenchmarkQueue_PushPriorityEmpty(b *testing.B) {
+	ctx := b.Context()
+
+	b.ResetTimer()
+	for range b.N {
+		q := NewQueue(ctx)
+		_ = q.Push(prioritizedItem{value: "test", priority: 50})
+	}
+}
+
+func BenchmarkQueue_PushPriorityHead(b *testing.B) {
+	ctx := b.Context()
+	q := NewQueue(ctx)
+	populateQueuePriority(q, 100)
+
+	b.ResetTimer()
+	for range b.N {
+		_ = q.Push(prioritizedItem{value: "highest", priority: -1})
+	}
+}
+
+func BenchmarkQueue_PushPriorityMiddle(b *testing.B) {
+	ctx := b.Context()
+	q := NewQueue(ctx)
+	populateQueuePriority(q, 100)
+
+	b.ResetTimer()
+	for range b.N {
+		_ = q.Push(prioritizedItem{value: "middle", priority: 50})
+	}
+}
+
+func BenchmarkQueue_PushPriorityTail(b *testing.B) {
+	ctx := b.Context()
+	q := NewQueue(ctx)
+	populateQueuePriority(q, 100)
+
+	b.ResetTimer()
+	for range b.N {
+		_ = q.Push(prioritizedItem{value: "lowest", priority: 1000})
+	}
+}
+
+func BenchmarkQueue_PushMixed(b *testing.B) {
+	ctx := b.Context()
+	q := NewQueue(ctx)
+
+	b.ResetTimer()
+	for range b.N {
+		_ = q.Push(
+			prioritizedItem{value: "p1", priority: 1},
+			prioritizedItem{value: "p2", priority: 2},
+			prioritizedItem{value: "p3", priority: 3},
+			prioritizedItem{value: "p4", priority: 4},
+			prioritizedItem{value: "p5", priority: 5},
+			1, 2, 3, 4, 5, // non-priority items
+		)
+	}
+}
+
+// Group C: Concurrent Operations Benchmarks
+
+func BenchmarkQueue_Concurrent1Writer(b *testing.B) {
+	ctx := b.Context()
+	q := NewQueue(ctx)
+
+	b.ResetTimer()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		for range b.N {
+			_ = q.Push(1)
+		}
+	}()
+
+	wg.Wait()
+}
+
+func BenchmarkQueue_Concurrent10Writers(b *testing.B) {
+	ctx := b.Context()
+	q := NewQueue(ctx)
+
+	b.ResetTimer()
+
+	var wg sync.WaitGroup
+	concurrency := 10
+	itemsPerWorker := b.N / concurrency
+
+	for range concurrency {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range itemsPerWorker {
+				_ = q.Push(1)
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+func BenchmarkQueue_Concurrent10Readers(b *testing.B) {
+	ctx := b.Context()
+	q := NewQueue(ctx)
+	populateQueue(q, b.N)
+
+	b.ResetTimer()
+
+	var wg sync.WaitGroup
+	concurrency := 10
+	itemsPerWorker := b.N / concurrency
+
+	for range concurrency {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range itemsPerWorker {
+				_ = q.Pop()
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+func BenchmarkQueue_Concurrent1W1R(b *testing.B) {
+	ctx := b.Context()
+	q := NewQueue(ctx)
+
+	b.ResetTimer()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Writer
+	go func() {
+		defer wg.Done()
+		for range b.N {
+			_ = q.Push(1)
+		}
+	}()
+
+	// Reader
+	go func() {
+		defer wg.Done()
+		for range b.N {
+			_, _ = q.Next()
+		}
+	}()
+
+	wg.Wait()
+}
+
+func BenchmarkQueue_Concurrent10W10R(b *testing.B) {
+	ctx := b.Context()
+	q := NewQueue(ctx)
+
+	b.ResetTimer()
+
+	var wg sync.WaitGroup
+	concurrency := 10
+	itemsPerWorker := b.N / concurrency
+
+	// Writers
+	for range concurrency {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range itemsPerWorker {
+				_ = q.Push(1)
+			}
+		}()
+	}
+
+	// Readers
+	for range concurrency {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range itemsPerWorker {
+				_ = q.Pop()
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+// Group D: Special Scenarios Benchmarks
+
+func BenchmarkQueue_AlternatingPushPop(b *testing.B) {
+	ctx := b.Context()
+	q := NewQueue(ctx)
+
+	b.ResetTimer()
+	for range b.N {
+		_ = q.Push(1)
+		_ = q.Pop()
+	}
+}
+
+func BenchmarkQueue_LargeQueue(b *testing.B) {
+	ctx := b.Context()
+	q := NewQueue(ctx)
+	populateQueue(q, 10000)
+
+	b.ResetTimer()
+	for range b.N {
+		_ = q.Push(1)
+	}
+}
+
+func BenchmarkQueue_EmptyPop(b *testing.B) {
+	ctx := b.Context()
+	q := NewQueue(ctx)
+
+	b.ResetTimer()
+	for range b.N {
+		_ = q.Pop()
+	}
+}
+
+func BenchmarkQueue_Drain(b *testing.B) {
+	ctx := b.Context()
+
+	b.ResetTimer()
+	for range b.N {
+		q := NewQueue(ctx)
+		populateQueue(q, 100)
+
+		// Start a goroutine to pop items
+		go func() {
+			for range 100 {
+				q.Pop()
+			}
+		}()
+
+		_ = q.Drain(time.Second)
+	}
+}


### PR DESCRIPTION
Replaces the sleep when draining with typed operations. We also trigger on both operations a bit more to get jobs processed a bit faster. Added benchmarks.

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Contributing Guide: https://github.com/qpoint-io/qtap/docs/CONTRIBUTING.md
     - 📖 Read the Contributor License Agreement (CLA): https://github.com/qpoint-io/qtap/docs/CLA.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Qpoint Team member.
-->
