### PR TITLE
Devtools events filter rulekit

### DIFF
--- a/pkg/devtools/cache.go
+++ b/pkg/devtools/cache.go
@@ -1,0 +1,62 @@
+package devtools
+
+import (
+	lru "github.com/hashicorp/golang-lru/v2"
+)
+
+const (
+	// DefaultCacheMaxSize is the default maximum number of connections to cache
+	DefaultCacheMaxSize = 10000
+)
+
+// ConnectionCache stores connection data for cross-entity filtering lookups.
+// It allows request/issue/pii events to be filtered by connection or process attributes.
+type ConnectionCache struct {
+	cache *lru.Cache[string, map[string]any]
+}
+
+// NewConnectionCache creates a new connection cache with the specified max size
+func NewConnectionCache(maxSize int) *ConnectionCache {
+	if maxSize <= 0 {
+		maxSize = DefaultCacheMaxSize
+	}
+	cache, err := lru.New[string, map[string]any](maxSize)
+	if err != nil {
+		panic(err)
+	}
+	return &ConnectionCache{
+		cache: cache,
+	}
+}
+
+// Set adds or updates a connection in the cache
+func (c *ConnectionCache) Set(connId string, data map[string]any) {
+	if connId == "" {
+		return
+	}
+	c.cache.Add(connId, data)
+}
+
+// Get retrieves connection data from the cache
+func (c *ConnectionCache) Get(connId string) map[string]any {
+	if connId == "" {
+		return nil
+	}
+	if data, ok := c.cache.Get(connId); ok {
+		return data
+	}
+	return nil
+}
+
+// Delete removes a connection from the cache
+func (c *ConnectionCache) Delete(connId string) {
+	if connId == "" {
+		return
+	}
+	c.cache.Remove(connId)
+}
+
+// Len returns the current number of cached connections
+func (c *ConnectionCache) Len() int {
+	return c.cache.Len()
+}

--- a/pkg/devtools/filter.go
+++ b/pkg/devtools/filter.go
@@ -102,16 +102,14 @@ func (f *EventFilter) IsEmpty() bool {
 // This enables cross-entity filtering (e.g., process.* filters apply to connection events).
 // Note: "http" filter entity applies to "request" topic events (request.created, request.http_transaction)
 var entityAppliesTo = map[string]map[string]bool{
-	"process":    {"process": true, "connection": true, "request": true, "issue": true, "pii": true},
-	"connection": {"connection": true, "request": true, "issue": true, "pii": true},
+	"process":    {"process": true, "connection": true, "request": true},
+	"connection": {"connection": true, "request": true},
 	"http":       {"request": true},
-	"issue":      {"issue": true},
-	"pii":        {"pii": true},
 }
 
 // Matches checks if an event matches the filter conditions.
 // The cache parameter enables cross-entity filtering by looking up connection data
-// for request/issue/pii events.
+// for request events.
 // Returns true if:
 // - No applicable conditions exist for this event's entity type (pass through)
 // - All applicable conditions match (AND logic)
@@ -174,11 +172,11 @@ func extractAttributeWithCache(filterEntity, eventEntity string, data map[string
 		// Connection events have process data embedded in source
 		return extractProcessFromConnection(data, attr)
 
-	case filterEntity == "process" && (eventEntity == "request" || eventEntity == "issue" || eventEntity == "pii"):
+	case filterEntity == "process" && eventEntity == "request":
 		// Need to lookup connection, then extract process data
 		return extractProcessFromRequest(data, cache, attr)
 
-	case filterEntity == "connection" && (eventEntity == "request" || eventEntity == "issue" || eventEntity == "pii"):
+	case filterEntity == "connection" && eventEntity == "request":
 		// Need to lookup connection data from cache
 		return extractConnectionFromRequest(data, cache, attr)
 	}
@@ -320,10 +318,6 @@ func extractAttribute(entity string, data map[string]any, attr string) any {
 		return extractHttpAttribute(data, attr)
 	case "connection":
 		return extractConnectionAttribute(data, attr)
-	case "issue":
-		return extractIssueAttribute(data, attr)
-	case "pii":
-		return extractPIIAttribute(data, attr)
 	default:
 		return nil
 	}
@@ -552,54 +546,6 @@ func extractEndpointPort(data map[string]any, endpoint string) any {
 		}
 	}
 	return nil
-}
-
-// extractIssueAttribute extracts attributes from issue event data
-func extractIssueAttribute(data map[string]any, attr string) any {
-	issueData := toMapAny(data["data"])
-	if issueData == nil {
-		issueData = data
-	}
-
-	switch attr {
-	case "method":
-		return issueData["method"]
-	case "status":
-		return issueData["status"]
-	case "path":
-		return issueData["path"]
-	case "url":
-		return issueData["url"]
-	case "direction":
-		return issueData["direction"]
-	case "error":
-		return issueData["error"]
-	default:
-		return nil
-	}
-}
-
-// extractPIIAttribute extracts attributes from PII event data
-func extractPIIAttribute(data map[string]any, attr string) any {
-	piiData := toMapAny(data["data"])
-	if piiData == nil {
-		piiData = data
-	}
-
-	switch attr {
-	case "entityType":
-		return piiData["entityType"]
-	case "entitySource":
-		return piiData["entitySource"]
-	case "fieldPath":
-		return piiData["fieldPath"]
-	case "requestMethod":
-		return piiData["requestMethod"]
-	case "requestPath":
-		return piiData["requestPath"]
-	default:
-		return nil
-	}
 }
 
 // matchCondition checks if a value matches a filter condition

--- a/pkg/devtools/filter.go
+++ b/pkg/devtools/filter.go
@@ -3,7 +3,7 @@ package devtools
 import (
 	"encoding/json"
 	"net/url"
-	"strings"
+	"path/filepath"
 
 	"github.com/qpoint-io/qtap/pkg/rulekitext"
 	"github.com/qpoint-io/rulekit"
@@ -153,13 +153,6 @@ func (f *EventFilter) Matches(event *Event, cache *ConnectionCache) bool {
 		Functions: rulekitext.Functions,
 		KV:        kv,
 	})
-
-	// Missing fields are not errors - they just don't match
-	if !res.Ok() {
-		// Critical errors (invalid syntax, etc.) should not match
-		// Missing fields also don't match
-		return false
-	}
 
 	return res.Pass()
 }

--- a/pkg/devtools/filter.go
+++ b/pkg/devtools/filter.go
@@ -1,0 +1,796 @@
+package devtools
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// FilterOperator defines comparison operations for event filtering
+type FilterOperator string
+
+const (
+	OpEq       FilterOperator = "eq"
+	OpNeq      FilterOperator = "neq"
+	OpIn       FilterOperator = "in"
+	OpGt       FilterOperator = "gt"
+	OpGte      FilterOperator = "gte"
+	OpLt       FilterOperator = "lt"
+	OpLte      FilterOperator = "lte"
+	OpPrefix   FilterOperator = "prefix"
+	OpContains FilterOperator = "contains"
+)
+
+// validOperators is the set of recognized operators
+var validOperators = map[FilterOperator]struct{}{
+	OpEq:       {},
+	OpNeq:      {},
+	OpIn:       {},
+	OpGt:       {},
+	OpGte:      {},
+	OpLt:       {},
+	OpLte:      {},
+	OpPrefix:   {},
+	OpContains: {},
+}
+
+// FilterCondition represents a single filter condition
+type FilterCondition struct {
+	Entity    string         // e.g., "process", "request", "connection"
+	Attribute string         // e.g., "pid", "method", "container"
+	Operator  FilterOperator // e.g., "eq", "gte", "prefix"
+	Value     string         // raw value from query param
+}
+
+// EventFilter holds parsed filter conditions grouped by entity
+type EventFilter struct {
+	Conditions map[string][]FilterCondition // entity -> conditions
+}
+
+// ParseFilters parses query parameters into an EventFilter.
+// Query params should be in the format: entity.attribute.operator=value
+// Example: process.pid.eq=1234, request.status.gte=400
+func ParseFilters(query url.Values) (*EventFilter, error) {
+	filter := &EventFilter{
+		Conditions: make(map[string][]FilterCondition),
+	}
+
+	for key, values := range query {
+		// Skip empty values
+		if len(values) == 0 || values[0] == "" {
+			continue
+		}
+
+		// Parse the key: entity.attribute.operator
+		parts := strings.Split(key, ".")
+		if len(parts) != 3 {
+			// Not a filter param, skip (could be other query params)
+			continue
+		}
+
+		entity := parts[0]
+		attribute := parts[1]
+		operator := FilterOperator(parts[2])
+
+		// Validate operator
+		if _, ok := validOperators[operator]; !ok {
+			return nil, fmt.Errorf("invalid operator %q in filter %q", operator, key)
+		}
+
+		// Create condition (use first value if multiple provided)
+		condition := FilterCondition{
+			Entity:    entity,
+			Attribute: attribute,
+			Operator:  operator,
+			Value:     values[0],
+		}
+
+		filter.Conditions[entity] = append(filter.Conditions[entity], condition)
+	}
+
+	return filter, nil
+}
+
+// IsEmpty returns true if no filter conditions are defined
+func (f *EventFilter) IsEmpty() bool {
+	return f == nil || len(f.Conditions) == 0
+}
+
+// entityAppliesTo defines which event types each filter entity applies to.
+// This enables cross-entity filtering (e.g., process.* filters apply to connection events).
+// Note: "http" filter entity applies to "request" topic events (request.created, request.http_transaction)
+var entityAppliesTo = map[string]map[string]bool{
+	"process":    {"process": true, "connection": true, "request": true, "issue": true, "pii": true},
+	"connection": {"connection": true, "request": true, "issue": true, "pii": true},
+	"http":       {"request": true},
+	"issue":      {"issue": true},
+	"pii":        {"pii": true},
+}
+
+// Matches checks if an event matches the filter conditions.
+// The cache parameter enables cross-entity filtering by looking up connection data
+// for request/issue/pii events.
+// Returns true if:
+// - No applicable conditions exist for this event's entity type (pass through)
+// - All applicable conditions match (AND logic)
+func (f *EventFilter) Matches(event *Event, cache *ConnectionCache) bool {
+	if f.IsEmpty() {
+		return true
+	}
+
+	// Extract entity from topic (e.g., "request.created" -> "request")
+	eventEntity := event.TopLevelTopic()
+
+	// System events always pass through
+	if eventEntity == "system" {
+		return true
+	}
+
+	// Extract the data from the event
+	data, ok := event.Data.(map[string]any)
+	if !ok {
+		// Can't extract data, pass through
+		return true
+	}
+
+	// Check each filter entity's conditions
+	for filterEntity, conditions := range f.Conditions {
+		// Check if this filter entity applies to the event's entity type
+		appliesTo, exists := entityAppliesTo[filterEntity]
+		if !exists || !appliesTo[eventEntity] {
+			// This filter entity doesn't apply to this event type, skip
+			continue
+		}
+
+		// All conditions for this filter entity must match
+		for _, cond := range conditions {
+			attrValue := extractAttributeWithCache(filterEntity, eventEntity, data, cond.Attribute, cache)
+			if !matchCondition(attrValue, cond) {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+// extractAttributeWithCache extracts an attribute value, using cache for cross-entity lookups
+func extractAttributeWithCache(filterEntity, eventEntity string, data map[string]any, attr string, cache *ConnectionCache) any {
+	// Same entity - direct extraction
+	if filterEntity == eventEntity {
+		return extractAttribute(filterEntity, data, attr)
+	}
+
+	// "http" filter entity maps to "request" event entity
+	if filterEntity == "http" && eventEntity == "request" {
+		return extractAttribute("http", data, attr)
+	}
+
+	// Cross-entity extraction
+	switch {
+	case filterEntity == "process" && eventEntity == "connection":
+		// Connection events have process data embedded in source
+		return extractProcessFromConnection(data, attr)
+
+	case filterEntity == "process" && (eventEntity == "request" || eventEntity == "issue" || eventEntity == "pii"):
+		// Need to lookup connection, then extract process data
+		return extractProcessFromRequest(data, cache, attr)
+
+	case filterEntity == "connection" && (eventEntity == "request" || eventEntity == "issue" || eventEntity == "pii"):
+		// Need to lookup connection data from cache
+		return extractConnectionFromRequest(data, cache, attr)
+	}
+
+	return nil
+}
+
+// extractProcessFromConnection extracts process attributes from connection event data
+// Connection events have process info embedded in the source endpoint
+func extractProcessFromConnection(data map[string]any, attr string) any {
+	// Connection data is nested under "data" key
+	connData := toMapAny(data["data"])
+	if connData == nil {
+		connData = data
+	}
+
+	// Get source endpoint (local process info)
+	source := toMapAny(connData["source"])
+	if source == nil {
+		return nil
+	}
+
+	switch attr {
+	case "pid":
+		return source["pid"]
+	case "hostname":
+		return source["hostname"]
+	case "user":
+		return source["user"]
+	case "userId":
+		return source["userId"]
+	case "path":
+		return source["exe"]
+	case "binary":
+		// Extract basename from exe path
+		if exe, ok := source["exe"].(string); ok {
+			parts := strings.Split(exe, "/")
+			if len(parts) > 0 {
+				return parts[len(parts)-1]
+			}
+		}
+		return nil
+	case "container":
+		if container := toMapAny(source["container"]); container != nil {
+			return container["name"]
+		}
+		return nil
+	case "containerId":
+		if container := toMapAny(source["container"]); container != nil {
+			return container["id"]
+		}
+		return nil
+	case "containerImage":
+		if container := toMapAny(source["container"]); container != nil {
+			return container["image"]
+		}
+		return nil
+	case "pod":
+		if container := toMapAny(source["container"]); container != nil {
+			if pod := toMapAny(container["pod"]); pod != nil {
+				return pod["name"]
+			}
+		}
+		return nil
+	case "podNamespace":
+		if container := toMapAny(source["container"]); container != nil {
+			if pod := toMapAny(container["pod"]); pod != nil {
+				return pod["namespace"]
+			}
+		}
+		return nil
+	}
+
+	return nil
+}
+
+// extractConnectionFromRequest extracts connection attributes from request data via cache lookup
+func extractConnectionFromRequest(data map[string]any, cache *ConnectionCache, attr string) any {
+	if cache == nil {
+		return nil
+	}
+
+	// Request data is nested under "data" key
+	reqData := toMapAny(data["data"])
+	if reqData == nil {
+		reqData = data
+	}
+
+	// Get connectionId from request
+	connId, ok := reqData["connectionId"].(string)
+	if !ok {
+		return nil
+	}
+
+	// Lookup connection from cache
+	connData := cache.Get(connId)
+	if connData == nil {
+		return nil
+	}
+
+	// Extract the attribute from connection data
+	return extractConnectionAttribute(map[string]any{"data": connData}, attr)
+}
+
+// extractProcessFromRequest extracts process attributes from request data via cache lookup
+func extractProcessFromRequest(data map[string]any, cache *ConnectionCache, attr string) any {
+	if cache == nil {
+		return nil
+	}
+
+	// Request data is nested under "data" key
+	reqData := toMapAny(data["data"])
+	if reqData == nil {
+		reqData = data
+	}
+
+	// Get connectionId from request
+	connId, ok := reqData["connectionId"].(string)
+	if !ok {
+		return nil
+	}
+
+	// Lookup connection from cache
+	connData := cache.Get(connId)
+	if connData == nil {
+		return nil
+	}
+
+	// Extract process data from connection's source
+	return extractProcessFromConnection(map[string]any{"data": connData}, attr)
+}
+
+// extractAttribute extracts an attribute value from event data based on entity type and attribute name
+func extractAttribute(entity string, data map[string]any, attr string) any {
+	switch entity {
+	case "process":
+		return extractProcessAttribute(data, attr)
+	case "http":
+		return extractHttpAttribute(data, attr)
+	case "connection":
+		return extractConnectionAttribute(data, attr)
+	case "issue":
+		return extractIssueAttribute(data, attr)
+	case "pii":
+		return extractPIIAttribute(data, attr)
+	default:
+		return nil
+	}
+}
+
+// extractProcessAttribute extracts attributes from process event data
+func extractProcessAttribute(data map[string]any, attr string) any {
+	switch attr {
+	case "pid":
+		return data["pid"]
+	case "binary":
+		return data["binary"]
+	case "path":
+		return data["path"]
+	case "hostname":
+		return data["hostname"]
+	case "user":
+		if user, ok := data["user"].(map[string]any); ok {
+			return user["name"]
+		}
+		return nil
+	case "userId":
+		if user, ok := data["user"].(map[string]any); ok {
+			return user["id"]
+		}
+		return nil
+	case "container":
+		if container, ok := data["container"].(map[string]any); ok {
+			return container["name"]
+		}
+		return nil
+	case "containerId":
+		if container, ok := data["container"].(map[string]any); ok {
+			return container["id"]
+		}
+		return nil
+	case "containerImage":
+		if container, ok := data["container"].(map[string]any); ok {
+			return container["image"]
+		}
+		return nil
+	case "pod":
+		if pod, ok := data["pod"].(map[string]any); ok {
+			return pod["name"]
+		}
+		return nil
+	case "podNamespace":
+		if pod, ok := data["pod"].(map[string]any); ok {
+			return pod["namespace"]
+		}
+		return nil
+	default:
+		return nil
+	}
+}
+
+// extractHttpAttribute extracts attributes from HTTP event data.
+// Handles both request.created events (from EventStore) and request.http_transaction
+// events (from ObjectStore/Artifact) which have different data structures.
+func extractHttpAttribute(data map[string]any, attr string) any {
+	// HTTP data is nested under "data" key from eventstore
+	httpData := toMapAny(data["data"])
+	if httpData == nil {
+		// Try direct access (in case structure varies)
+		httpData = data
+	}
+
+	// Check if this is an http_transaction artifact (has "summary" field)
+	// These come from ObjectStore and have a different structure
+	if summary := toMapAny(httpData["summary"]); summary != nil {
+		return extractFromHttpSummary(summary, attr)
+	}
+
+	// Standard request.created event structure
+	switch attr {
+	case "method":
+		return httpData["method"]
+	case "status":
+		return httpData["status"]
+	case "path":
+		return httpData["path"]
+	case "url":
+		return httpData["url"]
+	case "domain":
+		// Extract domain from URL
+		if urlStr, ok := httpData["url"].(string); ok {
+			if parsed, err := url.Parse(urlStr); err == nil {
+				return parsed.Hostname()
+			}
+		}
+		return nil
+	case "direction":
+		return httpData["direction"]
+	case "category":
+		return httpData["category"]
+	case "contentType":
+		return httpData["contentType"]
+	case "agent":
+		return httpData["agent"]
+	case "duration":
+		return httpData["duration"]
+	case "bytesSent":
+		return httpData["bytesSent"]
+	case "bytesReceived":
+		return httpData["bytesReceived"]
+	case "connectionId":
+		return httpData["connectionId"]
+	case "requestId":
+		return httpData["requestId"]
+	default:
+		return nil
+	}
+}
+
+// extractFromHttpSummary extracts attributes from http_transaction summary data.
+// Summary fields use snake_case naming like request_host, request_method, etc.
+func extractFromHttpSummary(summary map[string]any, attr string) any {
+	switch attr {
+	case "method":
+		return summary["request_method"]
+	case "status":
+		return summary["response_status"]
+	case "path":
+		return summary["request_path"]
+	case "domain":
+		return summary["request_host"]
+	case "direction":
+		return summary["direction"]
+	case "protocol":
+		return summary["request_protocol"]
+	case "scheme":
+		return summary["request_scheme"]
+	case "requestContentType":
+		return summary["request_content_type"]
+	case "responseContentType":
+		return summary["response_content_type"]
+	case "duration":
+		return summary["duration_ms"]
+	case "connectionId":
+		return summary["connection_id"]
+	case "requestId":
+		return summary["request_id"]
+	case "container":
+		return summary["container_name"]
+	case "containerImage":
+		return summary["container_image"]
+	case "pod":
+		return summary["pod_name"]
+	case "podNamespace":
+		return summary["pod_namespace"]
+	case "binary":
+		return summary["process_exe"]
+	default:
+		return nil
+	}
+}
+
+// extractConnectionAttribute extracts attributes from connection event data
+func extractConnectionAttribute(data map[string]any, attr string) any {
+	// Connection data is nested under "data" key from eventstore
+	connData := toMapAny(data["data"])
+	if connData == nil {
+		connData = data
+	}
+
+	switch attr {
+	case "direction":
+		return connData["direction"]
+	case "protocol":
+		return connData["l7Protocol"]
+	case "socketProtocol":
+		return connData["socketProtocol"]
+	case "vendorId":
+		return connData["vendorId"]
+	case "tlsVersion":
+		return connData["tlsVersion"]
+	case "pid":
+		return extractEndpointField(connData, "source", "pid")
+	case "container":
+		if src := toMapAny(connData["source"]); src != nil {
+			if container := toMapAny(src["container"]); container != nil {
+				return container["name"]
+			}
+		}
+		return nil
+	case "hostname":
+		return extractEndpointField(connData, "source", "hostname")
+	case "exe":
+		return extractEndpointField(connData, "source", "exe")
+	case "srcIp":
+		return extractEndpointIP(connData, "source")
+	case "srcPort":
+		return extractEndpointPort(connData, "source")
+	case "dstIp":
+		return extractEndpointIP(connData, "destination")
+	case "dstPort":
+		return extractEndpointPort(connData, "destination")
+	default:
+		return nil
+	}
+}
+
+// extractEndpointField extracts a field from a connection endpoint
+func extractEndpointField(data map[string]any, endpoint, field string) any {
+	if ep := toMapAny(data[endpoint]); ep != nil {
+		return ep[field]
+	}
+	return nil
+}
+
+// extractEndpointIP extracts the IP address from a connection endpoint
+func extractEndpointIP(data map[string]any, endpoint string) any {
+	if ep := toMapAny(data[endpoint]); ep != nil {
+		if addr := toMapAny(ep["address"]); addr != nil {
+			return addr["ip"]
+		}
+	}
+	return nil
+}
+
+// extractEndpointPort extracts the port from a connection endpoint
+func extractEndpointPort(data map[string]any, endpoint string) any {
+	if ep := toMapAny(data[endpoint]); ep != nil {
+		if addr := toMapAny(ep["address"]); addr != nil {
+			return addr["port"]
+		}
+	}
+	return nil
+}
+
+// extractIssueAttribute extracts attributes from issue event data
+func extractIssueAttribute(data map[string]any, attr string) any {
+	issueData := toMapAny(data["data"])
+	if issueData == nil {
+		issueData = data
+	}
+
+	switch attr {
+	case "method":
+		return issueData["method"]
+	case "status":
+		return issueData["status"]
+	case "path":
+		return issueData["path"]
+	case "url":
+		return issueData["url"]
+	case "direction":
+		return issueData["direction"]
+	case "error":
+		return issueData["error"]
+	default:
+		return nil
+	}
+}
+
+// extractPIIAttribute extracts attributes from PII event data
+func extractPIIAttribute(data map[string]any, attr string) any {
+	piiData := toMapAny(data["data"])
+	if piiData == nil {
+		piiData = data
+	}
+
+	switch attr {
+	case "entityType":
+		return piiData["entityType"]
+	case "entitySource":
+		return piiData["entitySource"]
+	case "fieldPath":
+		return piiData["fieldPath"]
+	case "requestMethod":
+		return piiData["requestMethod"]
+	case "requestPath":
+		return piiData["requestPath"]
+	default:
+		return nil
+	}
+}
+
+// matchCondition checks if a value matches a filter condition
+func matchCondition(value any, cond FilterCondition) bool {
+	if value == nil {
+		// If the attribute doesn't exist, the condition doesn't match
+		// unless we're using neq (not equals)
+		return cond.Operator == OpNeq
+	}
+
+	switch cond.Operator {
+	case OpEq:
+		return compareEqual(value, cond.Value)
+	case OpNeq:
+		return !compareEqual(value, cond.Value)
+	case OpIn:
+		return compareIn(value, cond.Value)
+	case OpGt:
+		return compareNumeric(value, cond.Value, func(a, b int64) bool { return a > b })
+	case OpGte:
+		return compareNumeric(value, cond.Value, func(a, b int64) bool { return a >= b })
+	case OpLt:
+		return compareNumeric(value, cond.Value, func(a, b int64) bool { return a < b })
+	case OpLte:
+		return compareNumeric(value, cond.Value, func(a, b int64) bool { return a <= b })
+	case OpPrefix:
+		return comparePrefix(value, cond.Value)
+	case OpContains:
+		return compareContains(value, cond.Value)
+	default:
+		return false
+	}
+}
+
+// compareEqual compares a value for equality with a filter value
+func compareEqual(value any, filterValue string) bool {
+	switch v := value.(type) {
+	case string:
+		return v == filterValue
+	case int:
+		if fv, err := strconv.Atoi(filterValue); err == nil {
+			return v == fv
+		}
+	case int64:
+		if fv, err := strconv.ParseInt(filterValue, 10, 64); err == nil {
+			return v == fv
+		}
+	case float64:
+		// JSON numbers are often float64
+		if fv, err := strconv.ParseFloat(filterValue, 64); err == nil {
+			return v == fv
+		}
+		// Also try int comparison for integer values
+		if fv, err := strconv.ParseInt(filterValue, 10, 64); err == nil {
+			return int64(v) == fv
+		}
+	case uint32:
+		if fv, err := strconv.ParseUint(filterValue, 10, 32); err == nil {
+			return v == uint32(fv)
+		}
+	case uint16:
+		if fv, err := strconv.ParseUint(filterValue, 10, 16); err == nil {
+			return v == uint16(fv)
+		}
+	}
+	// Fallback: convert both to string
+	return fmt.Sprintf("%v", value) == filterValue
+}
+
+// compareIn checks if a value is in a comma-separated list
+func compareIn(value any, filterValue string) bool {
+	parts := strings.Split(filterValue, ",")
+	for _, part := range parts {
+		if compareEqual(value, strings.TrimSpace(part)) {
+			return true
+		}
+	}
+	return false
+}
+
+// compareNumeric performs a numeric comparison
+func compareNumeric(value any, filterValue string, cmp func(a, b int64) bool) bool {
+	fv, err := strconv.ParseInt(filterValue, 10, 64)
+	if err != nil {
+		return false
+	}
+
+	var v int64
+	switch val := value.(type) {
+	case int:
+		v = int64(val)
+	case int64:
+		v = val
+	case float64:
+		v = int64(val)
+	case uint32:
+		v = int64(val)
+	case uint16:
+		v = int64(val)
+	default:
+		return false
+	}
+
+	return cmp(v, fv)
+}
+
+// comparePrefix checks if a string value starts with the filter value
+func comparePrefix(value any, filterValue string) bool {
+	if s, ok := value.(string); ok {
+		return strings.HasPrefix(s, filterValue)
+	}
+	return false
+}
+
+// compareContains checks if a string value contains the filter value
+func compareContains(value any, filterValue string) bool {
+	if s, ok := value.(string); ok {
+		return strings.Contains(s, filterValue)
+	}
+	return false
+}
+
+// ParseFiltersFromBody parses filters from a map (from JSON body).
+// The map keys should be in the format: entity.attribute.operator
+// Example: {"process.pid.eq": "1234", "request.status.gte": "400"}
+func ParseFiltersFromBody(filters map[string]string) (*EventFilter, error) {
+	if len(filters) == 0 {
+		return nil, nil
+	}
+
+	// Convert map to url.Values format and reuse ParseFilters
+	values := make(url.Values)
+	for key, val := range filters {
+		values.Set(key, val)
+	}
+	return ParseFilters(values)
+}
+
+// MergeFilters combines two filters, with override taking precedence.
+// Returns override if base is nil, base if override is nil/empty.
+// When both have conditions for the same entity, override's conditions replace base's.
+func MergeFilters(base, override *EventFilter) *EventFilter {
+	if override == nil || override.IsEmpty() {
+		return base
+	}
+	if base == nil || base.IsEmpty() {
+		return override
+	}
+
+	// Merge conditions: override replaces base for same entity
+	merged := &EventFilter{
+		Conditions: make(map[string][]FilterCondition),
+	}
+
+	// Copy base conditions
+	for entity, conds := range base.Conditions {
+		merged.Conditions[entity] = conds
+	}
+
+	// Override with override's conditions
+	for entity, conds := range override.Conditions {
+		merged.Conditions[entity] = conds
+	}
+
+	return merged
+}
+
+// toMapAny converts a value to map[string]any.
+// If the value is already a map[string]any, it returns it directly.
+// If the value is a struct or pointer to struct, it JSON marshals/unmarshals to convert.
+// Returns nil if conversion fails.
+func toMapAny(v any) map[string]any {
+	if v == nil {
+		return nil
+	}
+
+	// Already a map
+	if m, ok := v.(map[string]any); ok {
+		return m
+	}
+
+	// Convert struct via JSON marshal/unmarshal
+	jsonBytes, err := json.Marshal(v)
+	if err != nil {
+		return nil
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(jsonBytes, &result); err != nil {
+		return nil
+	}
+
+	return result
+}

--- a/pkg/devtools/filter.go
+++ b/pkg/devtools/filter.go
@@ -230,8 +230,7 @@ func addProcessFieldsRelational(kv rulekit.KV, connData map[string]any) {
 	setIfNotNil(process, "hostname", source["hostname"])
 	if exe, ok := source["exe"].(string); ok {
 		process["path"] = exe
-		parts := strings.Split(exe, "/")
-		process["binary"] = parts[len(parts)-1]
+		process["binary"] = filepath.Base(exe)
 	}
 	if user := toMapAny(source["user"]); user != nil {
 		process["user"] = user

--- a/pkg/devtools/filter.go
+++ b/pkg/devtools/filter.go
@@ -9,6 +9,93 @@ import (
 	"github.com/qpoint-io/rulekit"
 )
 
+/*
+Filter Fields Per Topic
+
+This package supports filtering events using rulekit expressions. Each topic has
+its own set of available fields. Native properties (belonging to the event type)
+have no prefix. Relational properties (from associated entities) are prefixed.
+
+Process Topic:
+  Native properties - no prefix needed.
+    binary              Process executable name
+    path                Full executable path
+    hostname            Process hostname
+    user.name           Username
+    user.id             User ID
+    container.name      Container name
+    container.id        Container ID
+    container.image     Container image
+    container.labels.*  Container labels (e.g., container.labels.app)
+    pod.name            Pod name
+    pod.namespace       Pod namespace
+    pod.labels.*        Pod labels (e.g., pod.labels.app)
+
+Connection Topic:
+  Native connection properties + relational process, container, and pod fields.
+    direction           Connection direction (egress, ingress)
+    protocol            L7 protocol (http, http2, etc.)
+    type                Socket type (tcp, udp)
+    src.ip              Source IP address
+    src.port            Source port
+    dst.ip              Destination IP address
+    dst.port            Destination port
+    dst.domain          Destination domain
+    tls.enabled         TLS enabled
+    tls.version         TLS version
+    tls.sni             TLS SNI
+    process.binary      Process executable name
+    process.path        Full executable path
+    process.hostname    Process hostname
+    process.user.name   Username
+    process.user.id     User ID
+    container.name      Container name
+    container.id        Container ID
+    container.image     Container image
+    container.labels.*  Container labels
+    pod.name            Pod name
+    pod.namespace       Pod namespace
+    pod.labels.*        Pod labels
+
+HTTP Topic:
+  Native HTTP properties (req and res) + relational connection/process fields.
+    req.method          HTTP method (GET, POST, etc.)
+    req.path            Request path
+    req.host            Request host
+    req.url             Full URL
+    res.status          Response status code
+    direction           Connection direction
+    protocol            L7 protocol
+    src.ip              Source IP address
+    src.port            Source port
+    dst.ip              Destination IP address
+    dst.port            Destination port
+    dst.domain          Destination domain
+    tls.enabled         TLS enabled
+    tls.version         TLS version
+    tls.sni             TLS SNI
+    process.binary      Process executable name
+    process.path        Full executable path
+    process.hostname    Process hostname
+    process.user.name   Username
+    process.user.id     User ID
+    container.name      Container name
+    container.id        Container ID
+    container.image     Container image
+    container.labels.*  Container labels
+    pod.name            Pod name
+    pod.namespace       Pod namespace
+    pod.labels.*        Pod labels
+
+Example Filters:
+  Process:    binary == 'nginx'
+  Process:    container.name == 'web' AND pod.namespace == 'production'
+  Connection: dst.port == 443 AND process.binary == 'curl'
+  Connection: direction == 'egress' AND dst.domain contains 'example.com'
+  HTTP:       res.status >= 400 AND req.method == 'POST'
+  HTTP:       in_zone(req.host, 'example.com') AND container.name == 'api'
+*/
+
 // EventFilter holds a compiled rulekit expression for filtering events
 type EventFilter struct {
 	expr string       // original expression string
@@ -77,7 +164,8 @@ func (f *EventFilter) Matches(event *Event, cache *ConnectionCache) bool {
 	return res.Pass()
 }
 
-// buildEventKV creates a flattened key-value map from event data for rulekit evaluation
+// buildEventKV creates a nested key-value map from event data for rulekit evaluation.
+// The structure follows the principle: native properties have no prefix, relational properties are prefixed.
 func buildEventKV(event *Event, cache *ConnectionCache) rulekit.KV {
 	kv := make(rulekit.KV)
 
@@ -86,253 +174,209 @@ func buildEventKV(event *Event, cache *ConnectionCache) rulekit.KV {
 		return kv
 	}
 
-	eventEntity := event.TopLevelTopic()
-
-	switch eventEntity {
+	switch event.TopLevelTopic() {
 	case "process":
-		addProcessKV(kv, data)
+		// Native properties - no prefix
+		addProcessFieldsNative(kv, data)
+		addContainerFieldsNative(kv, data)
+		addPodFieldsNative(kv, data)
 
 	case "connection":
-		addConnectionKV(kv, data)
-		// Connection events include process data from source endpoint
-		addProcessFromConnectionKV(kv, data)
+		connData := toMapAny(data["data"])
+		if connData == nil {
+			connData = data
+		}
+		// Native connection properties - no prefix
+		addConnectionFieldsNative(kv, connData)
+		// Relational properties - prefixed
+		addProcessFieldsRelational(kv, connData)
+		// Container/pod stay unprefixed
+		addContainerFieldsFromConnection(kv, connData)
+		addPodFieldsFromConnection(kv, connData)
 
 	case "request":
-		addHttpKV(kv, data)
-		// Request events need cache lookups for connection/process data
-		addConnectionFromCacheKV(kv, data, cache)
-		addProcessFromCacheKV(kv, data, cache)
+		// Native HTTP properties - req.*/res.* (no http. prefix)
+		addHttpFieldsNative(kv, data)
+		// Lookup connection data from cache for relational fields
+		if connData := lookupConnection(data, cache); connData != nil {
+			addConnectionFieldsNative(kv, connData)
+			addProcessFieldsRelational(kv, connData)
+			addContainerFieldsFromConnection(kv, connData)
+			addPodFieldsFromConnection(kv, connData)
+		}
 	}
 
 	return kv
 }
 
-// addProcessKV adds process.* keys to the KV map from process event data
-func addProcessKV(kv rulekit.KV, data map[string]any) {
-	setIfNotNil(kv, "process.pid", data["pid"])
-	setIfNotNil(kv, "process.binary", data["binary"])
-	setIfNotNil(kv, "process.path", data["path"])
-	setIfNotNil(kv, "process.hostname", data["hostname"])
-
-	if user, ok := data["user"].(map[string]any); ok {
-		setIfNotNil(kv, "process.user", user["name"])
-		setIfNotNil(kv, "process.userId", user["id"])
-	}
-
-	if container, ok := data["container"].(map[string]any); ok {
-		setIfNotNil(kv, "process.container", container["name"])
-		setIfNotNil(kv, "process.containerId", container["id"])
-		setIfNotNil(kv, "process.containerImage", container["image"])
-	}
-
-	if pod, ok := data["pod"].(map[string]any); ok {
-		setIfNotNil(kv, "process.pod", pod["name"])
-		setIfNotNil(kv, "process.podNamespace", pod["namespace"])
+// addProcessFieldsNative adds process fields at root level (no prefix) for process topic
+func addProcessFieldsNative(kv rulekit.KV, data map[string]any) {
+	setIfNotNil(kv, "binary", data["binary"])
+	setIfNotNil(kv, "path", data["path"])
+	setIfNotNil(kv, "hostname", data["hostname"])
+	if user := toMapAny(data["user"]); user != nil {
+		kv["user"] = user
 	}
 }
 
-// addConnectionKV adds connection.* keys to the KV map from connection event data
-func addConnectionKV(kv rulekit.KV, data map[string]any) {
-	// Connection data is nested under "data" key
-	connData := toMapAny(data["data"])
-	if connData == nil {
-		connData = data
-	}
-
-	setIfNotNil(kv, "connection.direction", connData["direction"])
-	setIfNotNil(kv, "connection.protocol", connData["l7Protocol"])
-	setIfNotNil(kv, "connection.socketProtocol", connData["socketProtocol"])
-	setIfNotNil(kv, "connection.vendorId", connData["vendorId"])
-	setIfNotNil(kv, "connection.tlsVersion", connData["tlsVersion"])
-
-	// Source endpoint
-	if src := toMapAny(connData["source"]); src != nil {
-		if addr := toMapAny(src["address"]); addr != nil {
-			setIfNotNil(kv, "connection.srcIp", addr["ip"])
-			setIfNotNil(kv, "connection.srcPort", addr["port"])
-		}
-	}
-
-	// Destination endpoint
-	if dst := toMapAny(connData["destination"]); dst != nil {
-		if addr := toMapAny(dst["address"]); addr != nil {
-			setIfNotNil(kv, "connection.dstIp", addr["ip"])
-			setIfNotNil(kv, "connection.dstPort", addr["port"])
-		}
-	}
-}
-
-// addProcessFromConnectionKV extracts process.* keys from a connection's source endpoint
-func addProcessFromConnectionKV(kv rulekit.KV, data map[string]any) {
-	// Connection data is nested under "data" key
-	connData := toMapAny(data["data"])
-	if connData == nil {
-		connData = data
-	}
-
-	// Get source endpoint (local process info)
+// addProcessFieldsRelational adds process fields with process.* prefix for connection/http topics
+func addProcessFieldsRelational(kv rulekit.KV, connData map[string]any) {
 	source := toMapAny(connData["source"])
 	if source == nil {
 		return
 	}
 
-	setIfNotNil(kv, "process.pid", source["pid"])
-	setIfNotNil(kv, "process.hostname", source["hostname"])
-	setIfNotNil(kv, "process.user", source["user"])
-	setIfNotNil(kv, "process.userId", source["userId"])
-	setIfNotNil(kv, "process.path", source["exe"])
-
-	// Extract binary name from exe path
+	process := make(map[string]any)
+	setIfNotNil(process, "hostname", source["hostname"])
 	if exe, ok := source["exe"].(string); ok {
+		process["path"] = exe
 		parts := strings.Split(exe, "/")
-		if len(parts) > 0 {
-			kv["process.binary"] = parts[len(parts)-1]
+		process["binary"] = parts[len(parts)-1]
+	}
+	if user := toMapAny(source["user"]); user != nil {
+		process["user"] = user
+	} else {
+		// Handle flat user fields
+		user := make(map[string]any)
+		setIfNotNil(user, "name", source["user"])
+		setIfNotNil(user, "id", source["userId"])
+		if len(user) > 0 {
+			process["user"] = user
 		}
 	}
+	if len(process) > 0 {
+		kv["process"] = process
+	}
+}
 
+// addContainerFieldsNative adds container fields at root level for process topic
+func addContainerFieldsNative(kv rulekit.KV, data map[string]any) {
+	if container := toMapAny(data["container"]); container != nil {
+		kv["container"] = container
+	}
+}
+
+// addContainerFieldsFromConnection adds container fields at root level from connection source
+func addContainerFieldsFromConnection(kv rulekit.KV, connData map[string]any) {
+	source := toMapAny(connData["source"])
+	if source == nil {
+		return
+	}
 	if container := toMapAny(source["container"]); container != nil {
-		setIfNotNil(kv, "process.container", container["name"])
-		setIfNotNil(kv, "process.containerId", container["id"])
-		setIfNotNil(kv, "process.containerImage", container["image"])
+		kv["container"] = container
+	}
+}
 
+// addPodFieldsNative adds pod fields at root level for process topic
+func addPodFieldsNative(kv rulekit.KV, data map[string]any) {
+	if pod := toMapAny(data["pod"]); pod != nil {
+		kv["pod"] = pod
+	}
+}
+
+// addPodFieldsFromConnection adds pod fields at root level from connection source
+func addPodFieldsFromConnection(kv rulekit.KV, connData map[string]any) {
+	source := toMapAny(connData["source"])
+	if source == nil {
+		return
+	}
+	// Pod may be nested under container
+	if container := toMapAny(source["container"]); container != nil {
 		if pod := toMapAny(container["pod"]); pod != nil {
-			setIfNotNil(kv, "process.pod", pod["name"])
-			setIfNotNil(kv, "process.podNamespace", pod["namespace"])
+			kv["pod"] = pod
 		}
 	}
 }
 
-// addHttpKV adds http.* keys to the KV map from request event data
-func addHttpKV(kv rulekit.KV, data map[string]any) {
+// addConnectionFieldsNative adds connection fields (direction, protocol, src.*, dst.*, tls.*)
+func addConnectionFieldsNative(kv rulekit.KV, connData map[string]any) {
+	setIfNotNil(kv, "direction", connData["direction"])
+	setIfNotNil(kv, "protocol", connData["l7Protocol"])
+	setIfNotNil(kv, "type", connData["socketProtocol"])
+
+	// src (network address only - process info goes in process.*)
+	if source := toMapAny(connData["source"]); source != nil {
+		src := make(map[string]any)
+		if addr := toMapAny(source["address"]); addr != nil {
+			setIfNotNil(src, "ip", addr["ip"])
+			setIfNotNil(src, "port", addr["port"])
+		}
+		if len(src) > 0 {
+			kv["src"] = src
+		}
+	}
+
+	// dst (network address + domain)
+	if dest := toMapAny(connData["destination"]); dest != nil {
+		dst := make(map[string]any)
+		if addr := toMapAny(dest["address"]); addr != nil {
+			setIfNotNil(dst, "ip", addr["ip"])
+			setIfNotNil(dst, "port", addr["port"])
+		}
+		setIfNotNil(dst, "domain", dest["domain"])
+		if len(dst) > 0 {
+			kv["dst"] = dst
+		}
+	}
+
+	// tls
+	if tls := toMapAny(connData["tls"]); tls != nil {
+		kv["tls"] = tls
+	}
+}
+
+// addHttpFieldsNative adds HTTP fields (req.*, res.* at root - no http. prefix)
+func addHttpFieldsNative(kv rulekit.KV, data map[string]any) {
 	httpData := toMapAny(data["data"])
 	if httpData == nil {
-		httpData = data
+		return
 	}
 
-	// Check for http_transaction summary format
+	req := make(map[string]any)
+	res := make(map[string]any)
+
+	// Check for summary format (http_transaction)
 	if summary := toMapAny(httpData["summary"]); summary != nil {
-		addHttpFromSummaryKV(kv, summary)
-		return
-	}
-
-	// Standard request.created format
-	setIfNotNil(kv, "http.method", httpData["method"])
-	setIfNotNil(kv, "http.status", httpData["status"])
-	setIfNotNil(kv, "http.path", httpData["path"])
-	setIfNotNil(kv, "http.url", httpData["url"])
-	setIfNotNil(kv, "http.direction", httpData["direction"])
-	setIfNotNil(kv, "http.category", httpData["category"])
-	setIfNotNil(kv, "http.contentType", httpData["contentType"])
-	setIfNotNil(kv, "http.agent", httpData["agent"])
-	setIfNotNil(kv, "http.duration", httpData["duration"])
-	setIfNotNil(kv, "http.bytesSent", httpData["bytesSent"])
-	setIfNotNil(kv, "http.bytesReceived", httpData["bytesReceived"])
-	setIfNotNil(kv, "http.connectionId", httpData["connectionId"])
-	setIfNotNil(kv, "http.requestId", httpData["requestId"])
-
-	// Extract domain from URL
-	if urlStr, ok := httpData["url"].(string); ok {
-		if parsed, err := url.Parse(urlStr); err == nil {
-			kv["http.domain"] = parsed.Hostname()
+		setIfNotNil(req, "method", summary["request_method"])
+		setIfNotNil(req, "path", summary["request_path"])
+		setIfNotNil(req, "host", summary["request_host"])
+		setIfNotNil(res, "status", summary["response_status"])
+	} else {
+		// Standard request format
+		setIfNotNil(req, "method", httpData["method"])
+		setIfNotNil(req, "path", httpData["path"])
+		setIfNotNil(req, "url", httpData["url"])
+		// Extract host from URL
+		if urlStr, ok := httpData["url"].(string); ok {
+			if parsed, err := url.Parse(urlStr); err == nil {
+				req["host"] = parsed.Hostname()
+			}
 		}
+		setIfNotNil(res, "status", httpData["status"])
+	}
+
+	if len(req) > 0 {
+		kv["req"] = req
+	}
+	if len(res) > 0 {
+		kv["res"] = res
 	}
 }
 
-// addHttpFromSummaryKV extracts http.* keys from http_transaction summary data
-func addHttpFromSummaryKV(kv rulekit.KV, summary map[string]any) {
-	setIfNotNil(kv, "http.method", summary["request_method"])
-	setIfNotNil(kv, "http.status", summary["response_status"])
-	setIfNotNil(kv, "http.path", summary["request_path"])
-	setIfNotNil(kv, "http.domain", summary["request_host"])
-	setIfNotNil(kv, "http.direction", summary["direction"])
-	setIfNotNil(kv, "http.protocol", summary["request_protocol"])
-	setIfNotNil(kv, "http.scheme", summary["request_scheme"])
-	setIfNotNil(kv, "http.requestContentType", summary["request_content_type"])
-	setIfNotNil(kv, "http.responseContentType", summary["response_content_type"])
-	setIfNotNil(kv, "http.duration", summary["duration_ms"])
-	setIfNotNil(kv, "http.connectionId", summary["connection_id"])
-	setIfNotNil(kv, "http.requestId", summary["request_id"])
-
-	// Also add process info from summary if available
-	setIfNotNil(kv, "process.container", summary["container_name"])
-	setIfNotNil(kv, "process.containerImage", summary["container_image"])
-	setIfNotNil(kv, "process.pod", summary["pod_name"])
-	setIfNotNil(kv, "process.podNamespace", summary["pod_namespace"])
-	setIfNotNil(kv, "process.binary", summary["process_exe"])
-}
-
-// addConnectionFromCacheKV looks up connection data from cache and adds connection.* keys
-func addConnectionFromCacheKV(kv rulekit.KV, data map[string]any, cache *ConnectionCache) {
+// lookupConnection retrieves connection data from cache by connectionId
+func lookupConnection(data map[string]any, cache *ConnectionCache) map[string]any {
 	if cache == nil {
-		return
+		return nil
 	}
-
-	// Request data is nested under "data" key
 	reqData := toMapAny(data["data"])
 	if reqData == nil {
-		reqData = data
+		return nil
 	}
-
-	// Get connectionId from request
 	connId, ok := reqData["connectionId"].(string)
 	if !ok {
-		return
+		return nil
 	}
-
-	// Lookup connection from cache
-	connData := cache.Get(connId)
-	if connData == nil {
-		return
-	}
-
-	// Add connection attributes
-	setIfNotNil(kv, "connection.direction", connData["direction"])
-	setIfNotNil(kv, "connection.protocol", connData["l7Protocol"])
-	setIfNotNil(kv, "connection.socketProtocol", connData["socketProtocol"])
-	setIfNotNil(kv, "connection.vendorId", connData["vendorId"])
-	setIfNotNil(kv, "connection.tlsVersion", connData["tlsVersion"])
-
-	if src := toMapAny(connData["source"]); src != nil {
-		if addr := toMapAny(src["address"]); addr != nil {
-			setIfNotNil(kv, "connection.srcIp", addr["ip"])
-			setIfNotNil(kv, "connection.srcPort", addr["port"])
-		}
-	}
-
-	if dst := toMapAny(connData["destination"]); dst != nil {
-		if addr := toMapAny(dst["address"]); addr != nil {
-			setIfNotNil(kv, "connection.dstIp", addr["ip"])
-			setIfNotNil(kv, "connection.dstPort", addr["port"])
-		}
-	}
-}
-
-// addProcessFromCacheKV looks up connection data from cache and adds process.* keys
-func addProcessFromCacheKV(kv rulekit.KV, data map[string]any, cache *ConnectionCache) {
-	if cache == nil {
-		return
-	}
-
-	// Request data is nested under "data" key
-	reqData := toMapAny(data["data"])
-	if reqData == nil {
-		reqData = data
-	}
-
-	// Get connectionId from request
-	connId, ok := reqData["connectionId"].(string)
-	if !ok {
-		return
-	}
-
-	// Lookup connection from cache
-	connData := cache.Get(connId)
-	if connData == nil {
-		return
-	}
-
-	// Extract process data from connection's source
-	addProcessFromConnectionKV(kv, map[string]any{"data": connData})
+	return cache.Get(connId)
 }
 
 // setIfNotNil sets a key in the KV map only if the value is not nil

--- a/pkg/devtools/filter.go
+++ b/pkg/devtools/filter.go
@@ -2,191 +2,168 @@ package devtools
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/url"
-	"strconv"
 	"strings"
+
+	"github.com/qpoint-io/qtap/pkg/rulekitext"
+	"github.com/qpoint-io/rulekit"
 )
 
-// FilterOperator defines comparison operations for event filtering
-type FilterOperator string
-
-const (
-	OpEq       FilterOperator = "eq"
-	OpNeq      FilterOperator = "neq"
-	OpIn       FilterOperator = "in"
-	OpGt       FilterOperator = "gt"
-	OpGte      FilterOperator = "gte"
-	OpLt       FilterOperator = "lt"
-	OpLte      FilterOperator = "lte"
-	OpPrefix   FilterOperator = "prefix"
-	OpContains FilterOperator = "contains"
-)
-
-// validOperators is the set of recognized operators
-var validOperators = map[FilterOperator]struct{}{
-	OpEq:       {},
-	OpNeq:      {},
-	OpIn:       {},
-	OpGt:       {},
-	OpGte:      {},
-	OpLt:       {},
-	OpLte:      {},
-	OpPrefix:   {},
-	OpContains: {},
-}
-
-// FilterCondition represents a single filter condition
-type FilterCondition struct {
-	Entity    string         // e.g., "process", "request", "connection"
-	Attribute string         // e.g., "pid", "method", "container"
-	Operator  FilterOperator // e.g., "eq", "gte", "prefix"
-	Value     string         // raw value from query param
-}
-
-// EventFilter holds parsed filter conditions grouped by entity
+// EventFilter holds a compiled rulekit expression for filtering events
 type EventFilter struct {
-	Conditions map[string][]FilterCondition // entity -> conditions
+	expr string       // original expression string
+	rule rulekit.Rule // compiled rule
 }
 
-// ParseFilters parses query parameters into an EventFilter.
-// Query params should be in the format: entity.attribute.operator=value
-// Example: process.pid.eq=1234, request.status.gte=400
-func ParseFilters(query url.Values) (*EventFilter, error) {
-	filter := &EventFilter{
-		Conditions: make(map[string][]FilterCondition),
+// ParseFilter parses a rulekit expression string into an EventFilter
+func ParseFilter(expr string) (*EventFilter, error) {
+	if expr == "" {
+		return nil, nil
 	}
 
-	for key, values := range query {
-		// Skip empty values
-		if len(values) == 0 || values[0] == "" {
-			continue
-		}
-
-		// Parse the key: entity.attribute.operator
-		parts := strings.Split(key, ".")
-		if len(parts) != 3 {
-			// Not a filter param, skip (could be other query params)
-			continue
-		}
-
-		entity := parts[0]
-		attribute := parts[1]
-		operator := FilterOperator(parts[2])
-
-		// Validate operator
-		if _, ok := validOperators[operator]; !ok {
-			return nil, fmt.Errorf("invalid operator %q in filter %q", operator, key)
-		}
-
-		// Create condition (use first value if multiple provided)
-		condition := FilterCondition{
-			Entity:    entity,
-			Attribute: attribute,
-			Operator:  operator,
-			Value:     values[0],
-		}
-
-		filter.Conditions[entity] = append(filter.Conditions[entity], condition)
+	rule, err := rulekit.Parse(expr)
+	if err != nil {
+		return nil, err
 	}
 
-	return filter, nil
+	return &EventFilter{
+		expr: expr,
+		rule: rule,
+	}, nil
 }
 
-// IsEmpty returns true if no filter conditions are defined
+// IsEmpty returns true if no filter is defined
 func (f *EventFilter) IsEmpty() bool {
-	return f == nil || len(f.Conditions) == 0
+	return f == nil || f.rule == nil
 }
 
-// entityAppliesTo defines which event types each filter entity applies to.
-// This enables cross-entity filtering (e.g., process.* filters apply to connection events).
-// Note: "http" filter entity applies to "request" topic events (request.created, request.http_transaction)
-var entityAppliesTo = map[string]map[string]bool{
-	"process":    {"process": true, "connection": true, "request": true},
-	"connection": {"connection": true, "request": true},
-	"http":       {"request": true},
+// Expression returns the original expression string
+func (f *EventFilter) Expression() string {
+	if f == nil {
+		return ""
+	}
+	return f.expr
 }
 
-// Matches checks if an event matches the filter conditions.
+// Matches checks if an event matches the filter expression.
 // The cache parameter enables cross-entity filtering by looking up connection data
 // for request events.
-// Returns true if:
-// - No applicable conditions exist for this event's entity type (pass through)
-// - All applicable conditions match (AND logic)
 func (f *EventFilter) Matches(event *Event, cache *ConnectionCache) bool {
 	if f.IsEmpty() {
 		return true
 	}
 
-	// Extract entity from topic (e.g., "request.created" -> "request")
-	eventEntity := event.TopLevelTopic()
-
 	// System events always pass through
-	if eventEntity == "system" {
+	if event.TopLevelTopic() == "system" {
 		return true
 	}
 
-	// Extract the data from the event
+	// Build KV map from event data
+	kv := buildEventKV(event, cache)
+
+	// Evaluate rule
+	res := f.rule.Eval(&rulekit.Ctx{
+		Functions: rulekitext.Functions,
+		KV:        kv,
+	})
+
+	// Missing fields are not errors - they just don't match
+	if !res.Ok() {
+		// Critical errors (invalid syntax, etc.) should not match
+		// Missing fields also don't match
+		return false
+	}
+
+	return res.Pass()
+}
+
+// buildEventKV creates a flattened key-value map from event data for rulekit evaluation
+func buildEventKV(event *Event, cache *ConnectionCache) rulekit.KV {
+	kv := make(rulekit.KV)
+
 	data, ok := event.Data.(map[string]any)
 	if !ok {
-		// Can't extract data, pass through
-		return true
+		return kv
 	}
 
-	// Check each filter entity's conditions
-	for filterEntity, conditions := range f.Conditions {
-		// Check if this filter entity applies to the event's entity type
-		appliesTo, exists := entityAppliesTo[filterEntity]
-		if !exists || !appliesTo[eventEntity] {
-			// This filter entity doesn't apply to this event type, skip
-			continue
-		}
+	eventEntity := event.TopLevelTopic()
 
-		// All conditions for this filter entity must match
-		for _, cond := range conditions {
-			attrValue := extractAttributeWithCache(filterEntity, eventEntity, data, cond.Attribute, cache)
-			if !matchCondition(attrValue, cond) {
-				return false
-			}
-		}
+	switch eventEntity {
+	case "process":
+		addProcessKV(kv, data)
+
+	case "connection":
+		addConnectionKV(kv, data)
+		// Connection events include process data from source endpoint
+		addProcessFromConnectionKV(kv, data)
+
+	case "request":
+		addHttpKV(kv, data)
+		// Request events need cache lookups for connection/process data
+		addConnectionFromCacheKV(kv, data, cache)
+		addProcessFromCacheKV(kv, data, cache)
 	}
 
-	return true
+	return kv
 }
 
-// extractAttributeWithCache extracts an attribute value, using cache for cross-entity lookups
-func extractAttributeWithCache(filterEntity, eventEntity string, data map[string]any, attr string, cache *ConnectionCache) any {
-	// Same entity - direct extraction
-	if filterEntity == eventEntity {
-		return extractAttribute(filterEntity, data, attr)
+// addProcessKV adds process.* keys to the KV map from process event data
+func addProcessKV(kv rulekit.KV, data map[string]any) {
+	setIfNotNil(kv, "process.pid", data["pid"])
+	setIfNotNil(kv, "process.binary", data["binary"])
+	setIfNotNil(kv, "process.path", data["path"])
+	setIfNotNil(kv, "process.hostname", data["hostname"])
+
+	if user, ok := data["user"].(map[string]any); ok {
+		setIfNotNil(kv, "process.user", user["name"])
+		setIfNotNil(kv, "process.userId", user["id"])
 	}
 
-	// "http" filter entity maps to "request" event entity
-	if filterEntity == "http" && eventEntity == "request" {
-		return extractAttribute("http", data, attr)
+	if container, ok := data["container"].(map[string]any); ok {
+		setIfNotNil(kv, "process.container", container["name"])
+		setIfNotNil(kv, "process.containerId", container["id"])
+		setIfNotNil(kv, "process.containerImage", container["image"])
 	}
 
-	// Cross-entity extraction
-	switch {
-	case filterEntity == "process" && eventEntity == "connection":
-		// Connection events have process data embedded in source
-		return extractProcessFromConnection(data, attr)
-
-	case filterEntity == "process" && eventEntity == "request":
-		// Need to lookup connection, then extract process data
-		return extractProcessFromRequest(data, cache, attr)
-
-	case filterEntity == "connection" && eventEntity == "request":
-		// Need to lookup connection data from cache
-		return extractConnectionFromRequest(data, cache, attr)
+	if pod, ok := data["pod"].(map[string]any); ok {
+		setIfNotNil(kv, "process.pod", pod["name"])
+		setIfNotNil(kv, "process.podNamespace", pod["namespace"])
 	}
-
-	return nil
 }
 
-// extractProcessFromConnection extracts process attributes from connection event data
-// Connection events have process info embedded in the source endpoint
-func extractProcessFromConnection(data map[string]any, attr string) any {
+// addConnectionKV adds connection.* keys to the KV map from connection event data
+func addConnectionKV(kv rulekit.KV, data map[string]any) {
+	// Connection data is nested under "data" key
+	connData := toMapAny(data["data"])
+	if connData == nil {
+		connData = data
+	}
+
+	setIfNotNil(kv, "connection.direction", connData["direction"])
+	setIfNotNil(kv, "connection.protocol", connData["l7Protocol"])
+	setIfNotNil(kv, "connection.socketProtocol", connData["socketProtocol"])
+	setIfNotNil(kv, "connection.vendorId", connData["vendorId"])
+	setIfNotNil(kv, "connection.tlsVersion", connData["tlsVersion"])
+
+	// Source endpoint
+	if src := toMapAny(connData["source"]); src != nil {
+		if addr := toMapAny(src["address"]); addr != nil {
+			setIfNotNil(kv, "connection.srcIp", addr["ip"])
+			setIfNotNil(kv, "connection.srcPort", addr["port"])
+		}
+	}
+
+	// Destination endpoint
+	if dst := toMapAny(connData["destination"]); dst != nil {
+		if addr := toMapAny(dst["address"]); addr != nil {
+			setIfNotNil(kv, "connection.dstIp", addr["ip"])
+			setIfNotNil(kv, "connection.dstPort", addr["port"])
+		}
+	}
+}
+
+// addProcessFromConnectionKV extracts process.* keys from a connection's source endpoint
+func addProcessFromConnectionKV(kv rulekit.KV, data map[string]any) {
 	// Connection data is nested under "data" key
 	connData := toMapAny(data["data"])
 	if connData == nil {
@@ -196,521 +173,173 @@ func extractProcessFromConnection(data map[string]any, attr string) any {
 	// Get source endpoint (local process info)
 	source := toMapAny(connData["source"])
 	if source == nil {
-		return nil
+		return
 	}
 
-	switch attr {
-	case "pid":
-		return source["pid"]
-	case "hostname":
-		return source["hostname"]
-	case "user":
-		return source["user"]
-	case "userId":
-		return source["userId"]
-	case "path":
-		return source["exe"]
-	case "binary":
-		// Extract basename from exe path
-		if exe, ok := source["exe"].(string); ok {
-			parts := strings.Split(exe, "/")
-			if len(parts) > 0 {
-				return parts[len(parts)-1]
-			}
+	setIfNotNil(kv, "process.pid", source["pid"])
+	setIfNotNil(kv, "process.hostname", source["hostname"])
+	setIfNotNil(kv, "process.user", source["user"])
+	setIfNotNil(kv, "process.userId", source["userId"])
+	setIfNotNil(kv, "process.path", source["exe"])
+
+	// Extract binary name from exe path
+	if exe, ok := source["exe"].(string); ok {
+		parts := strings.Split(exe, "/")
+		if len(parts) > 0 {
+			kv["process.binary"] = parts[len(parts)-1]
 		}
-		return nil
-	case "container":
-		if container := toMapAny(source["container"]); container != nil {
-			return container["name"]
+	}
+
+	if container := toMapAny(source["container"]); container != nil {
+		setIfNotNil(kv, "process.container", container["name"])
+		setIfNotNil(kv, "process.containerId", container["id"])
+		setIfNotNil(kv, "process.containerImage", container["image"])
+
+		if pod := toMapAny(container["pod"]); pod != nil {
+			setIfNotNil(kv, "process.pod", pod["name"])
+			setIfNotNil(kv, "process.podNamespace", pod["namespace"])
 		}
-		return nil
-	case "containerId":
-		if container := toMapAny(source["container"]); container != nil {
-			return container["id"]
-		}
-		return nil
-	case "containerImage":
-		if container := toMapAny(source["container"]); container != nil {
-			return container["image"]
-		}
-		return nil
-	case "pod":
-		if container := toMapAny(source["container"]); container != nil {
-			if pod := toMapAny(container["pod"]); pod != nil {
-				return pod["name"]
-			}
-		}
-		return nil
-	case "podNamespace":
-		if container := toMapAny(source["container"]); container != nil {
-			if pod := toMapAny(container["pod"]); pod != nil {
-				return pod["namespace"]
-			}
-		}
-		return nil
-	}
-
-	return nil
-}
-
-// extractConnectionFromRequest extracts connection attributes from request data via cache lookup
-func extractConnectionFromRequest(data map[string]any, cache *ConnectionCache, attr string) any {
-	if cache == nil {
-		return nil
-	}
-
-	// Request data is nested under "data" key
-	reqData := toMapAny(data["data"])
-	if reqData == nil {
-		reqData = data
-	}
-
-	// Get connectionId from request
-	connId, ok := reqData["connectionId"].(string)
-	if !ok {
-		return nil
-	}
-
-	// Lookup connection from cache
-	connData := cache.Get(connId)
-	if connData == nil {
-		return nil
-	}
-
-	// Extract the attribute from connection data
-	return extractConnectionAttribute(map[string]any{"data": connData}, attr)
-}
-
-// extractProcessFromRequest extracts process attributes from request data via cache lookup
-func extractProcessFromRequest(data map[string]any, cache *ConnectionCache, attr string) any {
-	if cache == nil {
-		return nil
-	}
-
-	// Request data is nested under "data" key
-	reqData := toMapAny(data["data"])
-	if reqData == nil {
-		reqData = data
-	}
-
-	// Get connectionId from request
-	connId, ok := reqData["connectionId"].(string)
-	if !ok {
-		return nil
-	}
-
-	// Lookup connection from cache
-	connData := cache.Get(connId)
-	if connData == nil {
-		return nil
-	}
-
-	// Extract process data from connection's source
-	return extractProcessFromConnection(map[string]any{"data": connData}, attr)
-}
-
-// extractAttribute extracts an attribute value from event data based on entity type and attribute name
-func extractAttribute(entity string, data map[string]any, attr string) any {
-	switch entity {
-	case "process":
-		return extractProcessAttribute(data, attr)
-	case "http":
-		return extractHttpAttribute(data, attr)
-	case "connection":
-		return extractConnectionAttribute(data, attr)
-	default:
-		return nil
 	}
 }
 
-// extractProcessAttribute extracts attributes from process event data
-func extractProcessAttribute(data map[string]any, attr string) any {
-	switch attr {
-	case "pid":
-		return data["pid"]
-	case "binary":
-		return data["binary"]
-	case "path":
-		return data["path"]
-	case "hostname":
-		return data["hostname"]
-	case "user":
-		if user, ok := data["user"].(map[string]any); ok {
-			return user["name"]
-		}
-		return nil
-	case "userId":
-		if user, ok := data["user"].(map[string]any); ok {
-			return user["id"]
-		}
-		return nil
-	case "container":
-		if container, ok := data["container"].(map[string]any); ok {
-			return container["name"]
-		}
-		return nil
-	case "containerId":
-		if container, ok := data["container"].(map[string]any); ok {
-			return container["id"]
-		}
-		return nil
-	case "containerImage":
-		if container, ok := data["container"].(map[string]any); ok {
-			return container["image"]
-		}
-		return nil
-	case "pod":
-		if pod, ok := data["pod"].(map[string]any); ok {
-			return pod["name"]
-		}
-		return nil
-	case "podNamespace":
-		if pod, ok := data["pod"].(map[string]any); ok {
-			return pod["namespace"]
-		}
-		return nil
-	default:
-		return nil
-	}
-}
-
-// extractHttpAttribute extracts attributes from HTTP event data.
-// Handles both request.created events (from EventStore) and request.http_transaction
-// events (from ObjectStore/Artifact) which have different data structures.
-func extractHttpAttribute(data map[string]any, attr string) any {
-	// HTTP data is nested under "data" key from eventstore
+// addHttpKV adds http.* keys to the KV map from request event data
+func addHttpKV(kv rulekit.KV, data map[string]any) {
 	httpData := toMapAny(data["data"])
 	if httpData == nil {
-		// Try direct access (in case structure varies)
 		httpData = data
 	}
 
-	// Check if this is an http_transaction artifact (has "summary" field)
-	// These come from ObjectStore and have a different structure
+	// Check for http_transaction summary format
 	if summary := toMapAny(httpData["summary"]); summary != nil {
-		return extractFromHttpSummary(summary, attr)
+		addHttpFromSummaryKV(kv, summary)
+		return
 	}
 
-	// Standard request.created event structure
-	switch attr {
-	case "method":
-		return httpData["method"]
-	case "status":
-		return httpData["status"]
-	case "path":
-		return httpData["path"]
-	case "url":
-		return httpData["url"]
-	case "domain":
-		// Extract domain from URL
-		if urlStr, ok := httpData["url"].(string); ok {
-			if parsed, err := url.Parse(urlStr); err == nil {
-				return parsed.Hostname()
-			}
+	// Standard request.created format
+	setIfNotNil(kv, "http.method", httpData["method"])
+	setIfNotNil(kv, "http.status", httpData["status"])
+	setIfNotNil(kv, "http.path", httpData["path"])
+	setIfNotNil(kv, "http.url", httpData["url"])
+	setIfNotNil(kv, "http.direction", httpData["direction"])
+	setIfNotNil(kv, "http.category", httpData["category"])
+	setIfNotNil(kv, "http.contentType", httpData["contentType"])
+	setIfNotNil(kv, "http.agent", httpData["agent"])
+	setIfNotNil(kv, "http.duration", httpData["duration"])
+	setIfNotNil(kv, "http.bytesSent", httpData["bytesSent"])
+	setIfNotNil(kv, "http.bytesReceived", httpData["bytesReceived"])
+	setIfNotNil(kv, "http.connectionId", httpData["connectionId"])
+	setIfNotNil(kv, "http.requestId", httpData["requestId"])
+
+	// Extract domain from URL
+	if urlStr, ok := httpData["url"].(string); ok {
+		if parsed, err := url.Parse(urlStr); err == nil {
+			kv["http.domain"] = parsed.Hostname()
 		}
-		return nil
-	case "direction":
-		return httpData["direction"]
-	case "category":
-		return httpData["category"]
-	case "contentType":
-		return httpData["contentType"]
-	case "agent":
-		return httpData["agent"]
-	case "duration":
-		return httpData["duration"]
-	case "bytesSent":
-		return httpData["bytesSent"]
-	case "bytesReceived":
-		return httpData["bytesReceived"]
-	case "connectionId":
-		return httpData["connectionId"]
-	case "requestId":
-		return httpData["requestId"]
-	default:
-		return nil
 	}
 }
 
-// extractFromHttpSummary extracts attributes from http_transaction summary data.
-// Summary fields use snake_case naming like request_host, request_method, etc.
-func extractFromHttpSummary(summary map[string]any, attr string) any {
-	switch attr {
-	case "method":
-		return summary["request_method"]
-	case "status":
-		return summary["response_status"]
-	case "path":
-		return summary["request_path"]
-	case "domain":
-		return summary["request_host"]
-	case "direction":
-		return summary["direction"]
-	case "protocol":
-		return summary["request_protocol"]
-	case "scheme":
-		return summary["request_scheme"]
-	case "requestContentType":
-		return summary["request_content_type"]
-	case "responseContentType":
-		return summary["response_content_type"]
-	case "duration":
-		return summary["duration_ms"]
-	case "connectionId":
-		return summary["connection_id"]
-	case "requestId":
-		return summary["request_id"]
-	case "container":
-		return summary["container_name"]
-	case "containerImage":
-		return summary["container_image"]
-	case "pod":
-		return summary["pod_name"]
-	case "podNamespace":
-		return summary["pod_namespace"]
-	case "binary":
-		return summary["process_exe"]
-	default:
-		return nil
-	}
+// addHttpFromSummaryKV extracts http.* keys from http_transaction summary data
+func addHttpFromSummaryKV(kv rulekit.KV, summary map[string]any) {
+	setIfNotNil(kv, "http.method", summary["request_method"])
+	setIfNotNil(kv, "http.status", summary["response_status"])
+	setIfNotNil(kv, "http.path", summary["request_path"])
+	setIfNotNil(kv, "http.domain", summary["request_host"])
+	setIfNotNil(kv, "http.direction", summary["direction"])
+	setIfNotNil(kv, "http.protocol", summary["request_protocol"])
+	setIfNotNil(kv, "http.scheme", summary["request_scheme"])
+	setIfNotNil(kv, "http.requestContentType", summary["request_content_type"])
+	setIfNotNil(kv, "http.responseContentType", summary["response_content_type"])
+	setIfNotNil(kv, "http.duration", summary["duration_ms"])
+	setIfNotNil(kv, "http.connectionId", summary["connection_id"])
+	setIfNotNil(kv, "http.requestId", summary["request_id"])
+
+	// Also add process info from summary if available
+	setIfNotNil(kv, "process.container", summary["container_name"])
+	setIfNotNil(kv, "process.containerImage", summary["container_image"])
+	setIfNotNil(kv, "process.pod", summary["pod_name"])
+	setIfNotNil(kv, "process.podNamespace", summary["pod_namespace"])
+	setIfNotNil(kv, "process.binary", summary["process_exe"])
 }
 
-// extractConnectionAttribute extracts attributes from connection event data
-func extractConnectionAttribute(data map[string]any, attr string) any {
-	// Connection data is nested under "data" key from eventstore
-	connData := toMapAny(data["data"])
+// addConnectionFromCacheKV looks up connection data from cache and adds connection.* keys
+func addConnectionFromCacheKV(kv rulekit.KV, data map[string]any, cache *ConnectionCache) {
+	if cache == nil {
+		return
+	}
+
+	// Request data is nested under "data" key
+	reqData := toMapAny(data["data"])
+	if reqData == nil {
+		reqData = data
+	}
+
+	// Get connectionId from request
+	connId, ok := reqData["connectionId"].(string)
+	if !ok {
+		return
+	}
+
+	// Lookup connection from cache
+	connData := cache.Get(connId)
 	if connData == nil {
-		connData = data
+		return
 	}
 
-	switch attr {
-	case "direction":
-		return connData["direction"]
-	case "protocol":
-		return connData["l7Protocol"]
-	case "socketProtocol":
-		return connData["socketProtocol"]
-	case "vendorId":
-		return connData["vendorId"]
-	case "tlsVersion":
-		return connData["tlsVersion"]
-	case "pid":
-		return extractEndpointField(connData, "source", "pid")
-	case "container":
-		if src := toMapAny(connData["source"]); src != nil {
-			if container := toMapAny(src["container"]); container != nil {
-				return container["name"]
-			}
-		}
-		return nil
-	case "hostname":
-		return extractEndpointField(connData, "source", "hostname")
-	case "exe":
-		return extractEndpointField(connData, "source", "exe")
-	case "srcIp":
-		return extractEndpointIP(connData, "source")
-	case "srcPort":
-		return extractEndpointPort(connData, "source")
-	case "dstIp":
-		return extractEndpointIP(connData, "destination")
-	case "dstPort":
-		return extractEndpointPort(connData, "destination")
-	default:
-		return nil
-	}
-}
+	// Add connection attributes
+	setIfNotNil(kv, "connection.direction", connData["direction"])
+	setIfNotNil(kv, "connection.protocol", connData["l7Protocol"])
+	setIfNotNil(kv, "connection.socketProtocol", connData["socketProtocol"])
+	setIfNotNil(kv, "connection.vendorId", connData["vendorId"])
+	setIfNotNil(kv, "connection.tlsVersion", connData["tlsVersion"])
 
-// extractEndpointField extracts a field from a connection endpoint
-func extractEndpointField(data map[string]any, endpoint, field string) any {
-	if ep := toMapAny(data[endpoint]); ep != nil {
-		return ep[field]
-	}
-	return nil
-}
-
-// extractEndpointIP extracts the IP address from a connection endpoint
-func extractEndpointIP(data map[string]any, endpoint string) any {
-	if ep := toMapAny(data[endpoint]); ep != nil {
-		if addr := toMapAny(ep["address"]); addr != nil {
-			return addr["ip"]
+	if src := toMapAny(connData["source"]); src != nil {
+		if addr := toMapAny(src["address"]); addr != nil {
+			setIfNotNil(kv, "connection.srcIp", addr["ip"])
+			setIfNotNil(kv, "connection.srcPort", addr["port"])
 		}
 	}
-	return nil
-}
 
-// extractEndpointPort extracts the port from a connection endpoint
-func extractEndpointPort(data map[string]any, endpoint string) any {
-	if ep := toMapAny(data[endpoint]); ep != nil {
-		if addr := toMapAny(ep["address"]); addr != nil {
-			return addr["port"]
+	if dst := toMapAny(connData["destination"]); dst != nil {
+		if addr := toMapAny(dst["address"]); addr != nil {
+			setIfNotNil(kv, "connection.dstIp", addr["ip"])
+			setIfNotNil(kv, "connection.dstPort", addr["port"])
 		}
 	}
-	return nil
 }
 
-// matchCondition checks if a value matches a filter condition
-func matchCondition(value any, cond FilterCondition) bool {
-	if value == nil {
-		// If the attribute doesn't exist, the condition doesn't match
-		// unless we're using neq (not equals)
-		return cond.Operator == OpNeq
+// addProcessFromCacheKV looks up connection data from cache and adds process.* keys
+func addProcessFromCacheKV(kv rulekit.KV, data map[string]any, cache *ConnectionCache) {
+	if cache == nil {
+		return
 	}
 
-	switch cond.Operator {
-	case OpEq:
-		return compareEqual(value, cond.Value)
-	case OpNeq:
-		return !compareEqual(value, cond.Value)
-	case OpIn:
-		return compareIn(value, cond.Value)
-	case OpGt:
-		return compareNumeric(value, cond.Value, func(a, b int64) bool { return a > b })
-	case OpGte:
-		return compareNumeric(value, cond.Value, func(a, b int64) bool { return a >= b })
-	case OpLt:
-		return compareNumeric(value, cond.Value, func(a, b int64) bool { return a < b })
-	case OpLte:
-		return compareNumeric(value, cond.Value, func(a, b int64) bool { return a <= b })
-	case OpPrefix:
-		return comparePrefix(value, cond.Value)
-	case OpContains:
-		return compareContains(value, cond.Value)
-	default:
-		return false
+	// Request data is nested under "data" key
+	reqData := toMapAny(data["data"])
+	if reqData == nil {
+		reqData = data
 	}
+
+	// Get connectionId from request
+	connId, ok := reqData["connectionId"].(string)
+	if !ok {
+		return
+	}
+
+	// Lookup connection from cache
+	connData := cache.Get(connId)
+	if connData == nil {
+		return
+	}
+
+	// Extract process data from connection's source
+	addProcessFromConnectionKV(kv, map[string]any{"data": connData})
 }
 
-// compareEqual compares a value for equality with a filter value
-func compareEqual(value any, filterValue string) bool {
-	switch v := value.(type) {
-	case string:
-		return v == filterValue
-	case int:
-		if fv, err := strconv.Atoi(filterValue); err == nil {
-			return v == fv
-		}
-	case int64:
-		if fv, err := strconv.ParseInt(filterValue, 10, 64); err == nil {
-			return v == fv
-		}
-	case float64:
-		// JSON numbers are often float64
-		if fv, err := strconv.ParseFloat(filterValue, 64); err == nil {
-			return v == fv
-		}
-		// Also try int comparison for integer values
-		if fv, err := strconv.ParseInt(filterValue, 10, 64); err == nil {
-			return int64(v) == fv
-		}
-	case uint32:
-		if fv, err := strconv.ParseUint(filterValue, 10, 32); err == nil {
-			return v == uint32(fv)
-		}
-	case uint16:
-		if fv, err := strconv.ParseUint(filterValue, 10, 16); err == nil {
-			return v == uint16(fv)
-		}
+// setIfNotNil sets a key in the KV map only if the value is not nil
+func setIfNotNil(kv rulekit.KV, key string, value any) {
+	if value != nil {
+		kv[key] = value
 	}
-	// Fallback: convert both to string
-	return fmt.Sprintf("%v", value) == filterValue
-}
-
-// compareIn checks if a value is in a comma-separated list
-func compareIn(value any, filterValue string) bool {
-	parts := strings.Split(filterValue, ",")
-	for _, part := range parts {
-		if compareEqual(value, strings.TrimSpace(part)) {
-			return true
-		}
-	}
-	return false
-}
-
-// compareNumeric performs a numeric comparison
-func compareNumeric(value any, filterValue string, cmp func(a, b int64) bool) bool {
-	fv, err := strconv.ParseInt(filterValue, 10, 64)
-	if err != nil {
-		return false
-	}
-
-	var v int64
-	switch val := value.(type) {
-	case int:
-		v = int64(val)
-	case int64:
-		v = val
-	case float64:
-		v = int64(val)
-	case uint32:
-		v = int64(val)
-	case uint16:
-		v = int64(val)
-	default:
-		return false
-	}
-
-	return cmp(v, fv)
-}
-
-// comparePrefix checks if a string value starts with the filter value
-func comparePrefix(value any, filterValue string) bool {
-	if s, ok := value.(string); ok {
-		return strings.HasPrefix(s, filterValue)
-	}
-	return false
-}
-
-// compareContains checks if a string value contains the filter value
-func compareContains(value any, filterValue string) bool {
-	if s, ok := value.(string); ok {
-		return strings.Contains(s, filterValue)
-	}
-	return false
-}
-
-// ParseFiltersFromBody parses filters from a map (from JSON body).
-// The map keys should be in the format: entity.attribute.operator
-// Example: {"process.pid.eq": "1234", "request.status.gte": "400"}
-func ParseFiltersFromBody(filters map[string]string) (*EventFilter, error) {
-	if len(filters) == 0 {
-		return nil, nil
-	}
-
-	// Convert map to url.Values format and reuse ParseFilters
-	values := make(url.Values)
-	for key, val := range filters {
-		values.Set(key, val)
-	}
-	return ParseFilters(values)
-}
-
-// MergeFilters combines two filters, with override taking precedence.
-// Returns override if base is nil, base if override is nil/empty.
-// When both have conditions for the same entity, override's conditions replace base's.
-func MergeFilters(base, override *EventFilter) *EventFilter {
-	if override == nil || override.IsEmpty() {
-		return base
-	}
-	if base == nil || base.IsEmpty() {
-		return override
-	}
-
-	// Merge conditions: override replaces base for same entity
-	merged := &EventFilter{
-		Conditions: make(map[string][]FilterCondition),
-	}
-
-	// Copy base conditions
-	for entity, conds := range base.Conditions {
-		merged.Conditions[entity] = conds
-	}
-
-	// Override with override's conditions
-	for entity, conds := range override.Conditions {
-		merged.Conditions[entity] = conds
-	}
-
-	return merged
 }
 
 // toMapAny converts a value to map[string]any.

--- a/pkg/devtools/filter_test.go
+++ b/pkg/devtools/filter_test.go
@@ -1,0 +1,1018 @@
+package devtools
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestParseFilters(t *testing.T) {
+	tests := []struct {
+		name       string
+		query      string
+		wantErr    bool
+		wantEmpty  bool
+		wantEntity string
+		wantCount  int
+	}{
+		{
+			name:      "empty query",
+			query:     "",
+			wantEmpty: true,
+		},
+		{
+			name:       "single filter",
+			query:      "process.pid.eq=1234",
+			wantEntity: "process",
+			wantCount:  1,
+		},
+		{
+			name:       "multiple filters same entity",
+			query:      "process.pid.eq=1234&process.container.eq=nginx",
+			wantEntity: "process",
+			wantCount:  2,
+		},
+		{
+			name:      "multiple filters different entities",
+			query:     "process.pid.eq=1234&http.method.eq=POST",
+			wantCount: 2, // 1 per entity
+		},
+		{
+			name:    "invalid operator",
+			query:   "process.pid.invalid=1234",
+			wantErr: true,
+		},
+		{
+			name:      "non-filter query params ignored",
+			query:     "foo=bar&baz=qux",
+			wantEmpty: true,
+		},
+		{
+			name:       "mixed filter and non-filter params",
+			query:      "foo=bar&process.pid.eq=1234",
+			wantEntity: "process",
+			wantCount:  1,
+		},
+		{
+			name:       "all operators",
+			query:      "http.status.eq=200&http.status.neq=404&http.status.gt=100&http.status.gte=200&http.status.lt=500&http.status.lte=299&http.path.prefix=/api&http.path.contains=users&http.method.in=GET,POST",
+			wantEntity: "http",
+			wantCount:  9,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			values, err := url.ParseQuery(tt.query)
+			if err != nil {
+				t.Fatalf("failed to parse query: %v", err)
+			}
+
+			filter, err := ParseFilters(values)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if tt.wantEmpty {
+				if !filter.IsEmpty() {
+					t.Errorf("expected empty filter, got %+v", filter.Conditions)
+				}
+				return
+			}
+
+			if tt.wantEntity != "" {
+				conditions, ok := filter.Conditions[tt.wantEntity]
+				if !ok {
+					t.Errorf("expected conditions for entity %q", tt.wantEntity)
+					return
+				}
+				if len(conditions) != tt.wantCount {
+					t.Errorf("expected %d conditions, got %d", tt.wantCount, len(conditions))
+				}
+			} else if tt.wantCount > 0 {
+				// Count total conditions across all entities
+				total := 0
+				for _, conds := range filter.Conditions {
+					total += len(conds)
+				}
+				if total != tt.wantCount {
+					t.Errorf("expected %d total conditions, got %d", tt.wantCount, total)
+				}
+			}
+		})
+	}
+}
+
+func TestEventFilter_Matches(t *testing.T) {
+	tests := []struct {
+		name   string
+		filter *EventFilter
+		event  *Event
+		want   bool
+	}{
+		{
+			name:   "nil filter matches everything",
+			filter: nil,
+			event:  NewEvent("request.created", map[string]any{"data": map[string]any{"method": "GET"}}),
+			want:   true,
+		},
+		{
+			name:   "empty filter matches everything",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{}},
+			event:  NewEvent("request.created", map[string]any{"data": map[string]any{"method": "GET"}}),
+			want:   true,
+		},
+		{
+			name: "system events always pass",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"http": {{Entity: "http", Attribute: "method", Operator: OpEq, Value: "POST"}},
+			}},
+			event: NewEvent("system.connected", map[string]any{"topics": []string{}}),
+			want:  true,
+		},
+		{
+			name: "unfiltered entity passes through",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"http": {{Entity: "http", Attribute: "method", Operator: OpEq, Value: "POST"}},
+			}},
+			event: NewEvent("process.started", map[string]any{"pid": 1234}),
+			want:  true,
+		},
+		{
+			name: "matching eq filter",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"http": {{Entity: "http", Attribute: "method", Operator: OpEq, Value: "GET"}},
+			}},
+			event: NewEvent("request.created", map[string]any{"data": map[string]any{"method": "GET"}}),
+			want:  true,
+		},
+		{
+			name: "non-matching eq filter",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"http": {{Entity: "http", Attribute: "method", Operator: OpEq, Value: "POST"}},
+			}},
+			event: NewEvent("request.created", map[string]any{"data": map[string]any{"method": "GET"}}),
+			want:  false,
+		},
+		{
+			name: "matching neq filter",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"http": {{Entity: "http", Attribute: "method", Operator: OpNeq, Value: "POST"}},
+			}},
+			event: NewEvent("request.created", map[string]any{"data": map[string]any{"method": "GET"}}),
+			want:  true,
+		},
+		{
+			name: "matching in filter",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"http": {{Entity: "http", Attribute: "method", Operator: OpIn, Value: "GET,POST,PUT"}},
+			}},
+			event: NewEvent("request.created", map[string]any{"data": map[string]any{"method": "POST"}}),
+			want:  true,
+		},
+		{
+			name: "non-matching in filter",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"http": {{Entity: "http", Attribute: "method", Operator: OpIn, Value: "GET,POST,PUT"}},
+			}},
+			event: NewEvent("request.created", map[string]any{"data": map[string]any{"method": "DELETE"}}),
+			want:  false,
+		},
+		{
+			name: "matching gte filter",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"http": {{Entity: "http", Attribute: "status", Operator: OpGte, Value: "400"}},
+			}},
+			event: NewEvent("request.created", map[string]any{"data": map[string]any{"status": 500}}),
+			want:  true,
+		},
+		{
+			name: "non-matching gte filter",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"http": {{Entity: "http", Attribute: "status", Operator: OpGte, Value: "400"}},
+			}},
+			event: NewEvent("request.created", map[string]any{"data": map[string]any{"status": 200}}),
+			want:  false,
+		},
+		{
+			name: "matching prefix filter",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"http": {{Entity: "http", Attribute: "path", Operator: OpPrefix, Value: "/api/"}},
+			}},
+			event: NewEvent("request.created", map[string]any{"data": map[string]any{"path": "/api/users/123"}}),
+			want:  true,
+		},
+		{
+			name: "matching contains filter",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"http": {{Entity: "http", Attribute: "path", Operator: OpContains, Value: "users"}},
+			}},
+			event: NewEvent("request.created", map[string]any{"data": map[string]any{"path": "/api/users/123"}}),
+			want:  true,
+		},
+		{
+			name: "multiple conditions AND logic - all match",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"http": {
+					{Entity: "http", Attribute: "method", Operator: OpEq, Value: "POST"},
+					{Entity: "http", Attribute: "status", Operator: OpGte, Value: "400"},
+				},
+			}},
+			event: NewEvent("request.created", map[string]any{"data": map[string]any{"method": "POST", "status": 500}}),
+			want:  true,
+		},
+		{
+			name: "multiple conditions AND logic - one fails",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"http": {
+					{Entity: "http", Attribute: "method", Operator: OpEq, Value: "POST"},
+					{Entity: "http", Attribute: "status", Operator: OpGte, Value: "400"},
+				},
+			}},
+			event: NewEvent("request.created", map[string]any{"data": map[string]any{"method": "POST", "status": 200}}),
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.filter.Matches(tt.event, nil)
+			if got != tt.want {
+				t.Errorf("Matches() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCrossEntityFiltering(t *testing.T) {
+	tests := []struct {
+		name   string
+		filter *EventFilter
+		event  *Event
+		cache  *ConnectionCache
+		want   bool
+	}{
+		{
+			name: "process filter on connection event - matching pid",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"process": {{Entity: "process", Attribute: "pid", Operator: OpEq, Value: "1234"}},
+			}},
+			event: NewEvent("connection.opened", map[string]any{
+				"data": map[string]any{
+					"source": map[string]any{
+						"pid": uint32(1234),
+					},
+				},
+			}),
+			want: true,
+		},
+		{
+			name: "process filter on connection event - non-matching pid",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"process": {{Entity: "process", Attribute: "pid", Operator: OpEq, Value: "1234"}},
+			}},
+			event: NewEvent("connection.opened", map[string]any{
+				"data": map[string]any{
+					"source": map[string]any{
+						"pid": uint32(5678),
+					},
+				},
+			}),
+			want: false,
+		},
+		{
+			name: "process filter on connection event - matching container",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"process": {{Entity: "process", Attribute: "container", Operator: OpEq, Value: "nginx"}},
+			}},
+			event: NewEvent("connection.opened", map[string]any{
+				"data": map[string]any{
+					"source": map[string]any{
+						"container": map[string]any{"name": "nginx", "id": "abc123"},
+					},
+				},
+			}),
+			want: true,
+		},
+		{
+			name: "process filter on process event - still works directly",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"process": {{Entity: "process", Attribute: "pid", Operator: OpEq, Value: "1234"}},
+			}},
+			event: NewEvent("process.started", map[string]any{"pid": 1234}),
+			want:  true,
+		},
+		{
+			name: "http filter does not apply to connection",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"http": {{Entity: "http", Attribute: "method", Operator: OpEq, Value: "POST"}},
+			}},
+			event: NewEvent("connection.opened", map[string]any{
+				"data": map[string]any{"direction": "egress"},
+			}),
+			want: true, // passes through - http filter doesn't apply to connection
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.filter.Matches(tt.event, tt.cache)
+			if got != tt.want {
+				t.Errorf("Matches() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCrossEntityFilteringWithCache(t *testing.T) {
+	// Create a cache with a connection
+	cache := NewConnectionCache(100)
+	cache.Set("conn-123", map[string]any{
+		"connectionId": "conn-123",
+		"direction":    "egress",
+		"source": map[string]any{
+			"pid":      uint32(1234),
+			"hostname": "web-server",
+			"container": map[string]any{
+				"name": "nginx",
+				"id":   "abc123",
+			},
+		},
+		"destination": map[string]any{
+			"address": map[string]any{
+				"ip":   "10.0.0.1",
+				"port": 443,
+			},
+		},
+	})
+
+	tests := []struct {
+		name   string
+		filter *EventFilter
+		event  *Event
+		want   bool
+	}{
+		{
+			name: "process filter on request - matching via cache lookup",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"process": {{Entity: "process", Attribute: "pid", Operator: OpEq, Value: "1234"}},
+			}},
+			event: NewEvent("request.created", map[string]any{
+				"data": map[string]any{
+					"connectionId": "conn-123",
+					"method":       "GET",
+					"status":       200,
+				},
+			}),
+			want: true,
+		},
+		{
+			name: "process filter on request - non-matching via cache lookup",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"process": {{Entity: "process", Attribute: "pid", Operator: OpEq, Value: "9999"}},
+			}},
+			event: NewEvent("request.created", map[string]any{
+				"data": map[string]any{
+					"connectionId": "conn-123",
+					"method":       "GET",
+					"status":       200,
+				},
+			}),
+			want: false,
+		},
+		{
+			name: "process container filter on request via cache",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"process": {{Entity: "process", Attribute: "container", Operator: OpEq, Value: "nginx"}},
+			}},
+			event: NewEvent("request.created", map[string]any{
+				"data": map[string]any{
+					"connectionId": "conn-123",
+					"method":       "POST",
+				},
+			}),
+			want: true,
+		},
+		{
+			name: "connection filter on request - matching dstPort via cache",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"connection": {{Entity: "connection", Attribute: "dstPort", Operator: OpEq, Value: "443"}},
+			}},
+			event: NewEvent("request.created", map[string]any{
+				"data": map[string]any{
+					"connectionId": "conn-123",
+					"method":       "GET",
+				},
+			}),
+			want: true,
+		},
+		{
+			name: "request with unknown connectionId - cache miss, filter fails",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"process": {{Entity: "process", Attribute: "pid", Operator: OpEq, Value: "1234"}},
+			}},
+			event: NewEvent("request.created", map[string]any{
+				"data": map[string]any{
+					"connectionId": "unknown-conn",
+					"method":       "GET",
+				},
+			}),
+			want: false, // Can't verify process.pid without connection data
+		},
+		{
+			name: "combined cross-entity and direct filter",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"process": {{Entity: "process", Attribute: "pid", Operator: OpEq, Value: "1234"}},
+				"http":    {{Entity: "http", Attribute: "status", Operator: OpGte, Value: "400"}},
+			}},
+			event: NewEvent("request.created", map[string]any{
+				"data": map[string]any{
+					"connectionId": "conn-123",
+					"method":       "GET",
+					"status":       500,
+				},
+			}),
+			want: true,
+		},
+		{
+			name: "combined filter - process matches but http fails",
+			filter: &EventFilter{Conditions: map[string][]FilterCondition{
+				"process": {{Entity: "process", Attribute: "pid", Operator: OpEq, Value: "1234"}},
+				"http":    {{Entity: "http", Attribute: "status", Operator: OpGte, Value: "400"}},
+			}},
+			event: NewEvent("request.created", map[string]any{
+				"data": map[string]any{
+					"connectionId": "conn-123",
+					"method":       "GET",
+					"status":       200,
+				},
+			}),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.filter.Matches(tt.event, cache)
+			if got != tt.want {
+				t.Errorf("Matches() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConnectionCache(t *testing.T) {
+	t.Run("basic set and get", func(t *testing.T) {
+		cache := NewConnectionCache(100)
+		data := map[string]any{"direction": "egress"}
+		cache.Set("conn-1", data)
+
+		got := cache.Get("conn-1")
+		if got == nil {
+			t.Error("expected to get cached data, got nil")
+		}
+		if got["direction"] != "egress" {
+			t.Errorf("expected direction=egress, got %v", got["direction"])
+		}
+	})
+
+	t.Run("get non-existent", func(t *testing.T) {
+		cache := NewConnectionCache(100)
+		got := cache.Get("non-existent")
+		if got != nil {
+			t.Errorf("expected nil for non-existent key, got %v", got)
+		}
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		cache := NewConnectionCache(100)
+		cache.Set("conn-1", map[string]any{"direction": "egress"})
+		cache.Delete("conn-1")
+
+		got := cache.Get("conn-1")
+		if got != nil {
+			t.Errorf("expected nil after delete, got %v", got)
+		}
+	})
+
+	t.Run("LRU eviction", func(t *testing.T) {
+		cache := NewConnectionCache(3) // Small cache
+
+		cache.Set("conn-1", map[string]any{"id": 1})
+		cache.Set("conn-2", map[string]any{"id": 2})
+		cache.Set("conn-3", map[string]any{"id": 3})
+
+		// Cache is full, adding conn-4 should evict conn-1
+		cache.Set("conn-4", map[string]any{"id": 4})
+
+		if cache.Get("conn-1") != nil {
+			t.Error("expected conn-1 to be evicted")
+		}
+		if cache.Get("conn-2") == nil {
+			t.Error("expected conn-2 to still exist")
+		}
+		if cache.Get("conn-4") == nil {
+			t.Error("expected conn-4 to exist")
+		}
+	})
+
+	t.Run("update existing", func(t *testing.T) {
+		cache := NewConnectionCache(100)
+		cache.Set("conn-1", map[string]any{"version": 1})
+		cache.Set("conn-1", map[string]any{"version": 2})
+
+		got := cache.Get("conn-1")
+		if got["version"] != 2 {
+			t.Errorf("expected version=2, got %v", got["version"])
+		}
+		if cache.Len() != 1 {
+			t.Errorf("expected cache len=1, got %d", cache.Len())
+		}
+	})
+}
+
+func TestExtractProcessAttribute(t *testing.T) {
+	tests := []struct {
+		name string
+		data map[string]any
+		attr string
+		want any
+	}{
+		{
+			name: "pid",
+			data: map[string]any{"pid": 1234},
+			attr: "pid",
+			want: 1234,
+		},
+		{
+			name: "binary",
+			data: map[string]any{"binary": "nginx"},
+			attr: "binary",
+			want: "nginx",
+		},
+		{
+			name: "container name",
+			data: map[string]any{"container": map[string]any{"name": "web-container", "id": "abc123"}},
+			attr: "container",
+			want: "web-container",
+		},
+		{
+			name: "container id",
+			data: map[string]any{"container": map[string]any{"name": "web-container", "id": "abc123"}},
+			attr: "containerId",
+			want: "abc123",
+		},
+		{
+			name: "pod name",
+			data: map[string]any{"pod": map[string]any{"name": "web-pod", "namespace": "default"}},
+			attr: "pod",
+			want: "web-pod",
+		},
+		{
+			name: "pod namespace",
+			data: map[string]any{"pod": map[string]any{"name": "web-pod", "namespace": "default"}},
+			attr: "podNamespace",
+			want: "default",
+		},
+		{
+			name: "user name",
+			data: map[string]any{"user": map[string]any{"name": "root", "id": uint(0)}},
+			attr: "user",
+			want: "root",
+		},
+		{
+			name: "missing attribute",
+			data: map[string]any{"pid": 1234},
+			attr: "nonexistent",
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractProcessAttribute(tt.data, tt.attr)
+			if got != tt.want {
+				t.Errorf("extractProcessAttribute() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractConnectionAttribute(t *testing.T) {
+	tests := []struct {
+		name string
+		data map[string]any
+		attr string
+		want any
+	}{
+		{
+			name: "direction",
+			data: map[string]any{"data": map[string]any{"direction": "egress"}},
+			attr: "direction",
+			want: "egress",
+		},
+		{
+			name: "protocol",
+			data: map[string]any{"data": map[string]any{"l7Protocol": "http2"}},
+			attr: "protocol",
+			want: "http2",
+		},
+		{
+			name: "srcIp",
+			data: map[string]any{"data": map[string]any{
+				"source": map[string]any{
+					"address": map[string]any{"ip": "192.168.1.1", "port": 8080},
+				},
+			}},
+			attr: "srcIp",
+			want: "192.168.1.1",
+		},
+		{
+			name: "dstPort",
+			data: map[string]any{"data": map[string]any{
+				"destination": map[string]any{
+					"address": map[string]any{"ip": "10.0.0.1", "port": 443},
+				},
+			}},
+			attr: "dstPort",
+			want: 443,
+		},
+		{
+			name: "container from source",
+			data: map[string]any{"data": map[string]any{
+				"source": map[string]any{
+					"container": map[string]any{"name": "web-app"},
+				},
+			}},
+			attr: "container",
+			want: "web-app",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractConnectionAttribute(tt.data, tt.attr)
+			if got != tt.want {
+				t.Errorf("extractConnectionAttribute() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompareEqual(t *testing.T) {
+	tests := []struct {
+		name        string
+		value       any
+		filterValue string
+		want        bool
+	}{
+		{"string match", "hello", "hello", true},
+		{"string no match", "hello", "world", false},
+		{"int match", 42, "42", true},
+		{"int no match", 42, "43", false},
+		{"int64 match", int64(1234567890), "1234567890", true},
+		{"float64 match", float64(200), "200", true},
+		{"float64 decimal", float64(3.14), "3.14", true},
+		{"uint32 match", uint32(443), "443", true},
+		{"uint16 match", uint16(8080), "8080", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := compareEqual(tt.value, tt.filterValue)
+			if got != tt.want {
+				t.Errorf("compareEqual(%v, %q) = %v, want %v", tt.value, tt.filterValue, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompareNumeric(t *testing.T) {
+	tests := []struct {
+		name        string
+		value       any
+		filterValue string
+		op          func(a, b int64) bool
+		want        bool
+	}{
+		{"int gt true", 100, "50", func(a, b int64) bool { return a > b }, true},
+		{"int gt false", 50, "100", func(a, b int64) bool { return a > b }, false},
+		{"int gte equal", 100, "100", func(a, b int64) bool { return a >= b }, true},
+		{"float64 lt", float64(50), "100", func(a, b int64) bool { return a < b }, true},
+		{"uint32 lte", uint32(100), "100", func(a, b int64) bool { return a <= b }, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := compareNumeric(tt.value, tt.filterValue, tt.op)
+			if got != tt.want {
+				t.Errorf("compareNumeric(%v, %q) = %v, want %v", tt.value, tt.filterValue, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractHttpDomain(t *testing.T) {
+	tests := []struct {
+		name string
+		data map[string]any
+		want any
+	}{
+		{
+			name: "extract domain from url",
+			data: map[string]any{"data": map[string]any{"url": "https://api.example.com/v1/users"}},
+			want: "api.example.com",
+		},
+		{
+			name: "extract domain with port",
+			data: map[string]any{"data": map[string]any{"url": "http://localhost:8080/api"}},
+			want: "localhost",
+		},
+		{
+			name: "missing url",
+			data: map[string]any{"data": map[string]any{"method": "GET"}},
+			want: nil,
+		},
+		{
+			name: "invalid url",
+			data: map[string]any{"data": map[string]any{"url": "not-a-url"}},
+			want: "",
+		},
+		{
+			name: "http_transaction summary - domain from request_host",
+			data: map[string]any{"data": map[string]any{
+				"summary": map[string]any{
+					"request_host":   "api.slack.com",
+					"request_method": "POST",
+				},
+			}},
+			want: "api.slack.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractHttpAttribute(tt.data, "domain")
+			if got != tt.want {
+				t.Errorf("extractHttpAttribute(domain) = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractFromHttpTransactionSummary(t *testing.T) {
+	// Simulates the structure of request.http_transaction events from ObjectStore
+	data := map[string]any{
+		"data": map[string]any{
+			"connectionId": "abc123",
+			"type":         "http_transaction",
+			"summary": map[string]any{
+				"request_host":     "api.slack.com",
+				"request_method":   "POST",
+				"response_status":  float64(200), // JSON numbers are float64
+				"request_path":     "/api/chat.postMessage",
+				"direction":        "egress-external",
+				"request_protocol": "http2",
+				"request_scheme":   "https",
+				"connection_id":    "abc123",
+				"container_name":   "myapp",
+				"container_image":  "myapp:latest",
+				"process_exe":      "/usr/bin/node",
+			},
+		},
+	}
+
+	tests := []struct {
+		attr string
+		want any
+	}{
+		{"domain", "api.slack.com"},
+		{"method", "POST"},
+		{"status", float64(200)},
+		{"path", "/api/chat.postMessage"},
+		{"direction", "egress-external"},
+		{"protocol", "http2"},
+		{"scheme", "https"},
+		{"connectionId", "abc123"},
+		{"container", "myapp"},
+		{"containerImage", "myapp:latest"},
+		{"binary", "/usr/bin/node"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.attr, func(t *testing.T) {
+			got := extractHttpAttribute(data, tt.attr)
+			if got != tt.want {
+				t.Errorf("extractHttpAttribute(%q) = %v, want %v", tt.attr, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseFiltersFromBody(t *testing.T) {
+	tests := []struct {
+		name       string
+		filters    map[string]string
+		wantErr    bool
+		wantNil    bool
+		wantEntity string
+		wantCount  int
+	}{
+		{
+			name:    "nil map",
+			filters: nil,
+			wantNil: true,
+		},
+		{
+			name:    "empty map",
+			filters: map[string]string{},
+			wantNil: true,
+		},
+		{
+			name:       "single filter",
+			filters:    map[string]string{"process.pid.eq": "1234"},
+			wantEntity: "process",
+			wantCount:  1,
+		},
+		{
+			name: "multiple filters same entity",
+			filters: map[string]string{
+				"process.pid.eq":       "1234",
+				"process.container.eq": "nginx",
+			},
+			wantEntity: "process",
+			wantCount:  2,
+		},
+		{
+			name: "multiple filters different entities",
+			filters: map[string]string{
+				"process.pid.eq": "1234",
+				"http.method.eq": "POST",
+			},
+			wantCount: 2, // 1 per entity
+		},
+		{
+			name:    "invalid operator",
+			filters: map[string]string{"process.pid.invalid": "1234"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filter, err := ParseFiltersFromBody(tt.filters)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if tt.wantNil {
+				if filter != nil {
+					t.Errorf("expected nil filter, got %+v", filter)
+				}
+				return
+			}
+
+			if tt.wantEntity != "" {
+				conditions, ok := filter.Conditions[tt.wantEntity]
+				if !ok {
+					t.Errorf("expected conditions for entity %q", tt.wantEntity)
+					return
+				}
+				if len(conditions) != tt.wantCount {
+					t.Errorf("expected %d conditions, got %d", tt.wantCount, len(conditions))
+				}
+			} else if tt.wantCount > 0 {
+				// Count total conditions across all entities
+				total := 0
+				for _, conds := range filter.Conditions {
+					total += len(conds)
+				}
+				if total != tt.wantCount {
+					t.Errorf("expected %d total conditions, got %d", tt.wantCount, total)
+				}
+			}
+		})
+	}
+}
+
+func TestMergeFilters(t *testing.T) {
+	tests := []struct {
+		name     string
+		base     *EventFilter
+		override *EventFilter
+		wantNil  bool
+		check    func(*EventFilter) bool
+	}{
+		{
+			name:     "both nil",
+			base:     nil,
+			override: nil,
+			wantNil:  true,
+		},
+		{
+			name: "nil base, non-nil override",
+			base: nil,
+			override: &EventFilter{Conditions: map[string][]FilterCondition{
+				"process": {{Entity: "process", Attribute: "pid", Operator: OpEq, Value: "1234"}},
+			}},
+			check: func(f *EventFilter) bool {
+				return len(f.Conditions["process"]) == 1 && f.Conditions["process"][0].Value == "1234"
+			},
+		},
+		{
+			name: "non-nil base, nil override",
+			base: &EventFilter{Conditions: map[string][]FilterCondition{
+				"process": {{Entity: "process", Attribute: "pid", Operator: OpEq, Value: "1234"}},
+			}},
+			override: nil,
+			check: func(f *EventFilter) bool {
+				return len(f.Conditions["process"]) == 1 && f.Conditions["process"][0].Value == "1234"
+			},
+		},
+		{
+			name: "non-nil base, empty override",
+			base: &EventFilter{Conditions: map[string][]FilterCondition{
+				"process": {{Entity: "process", Attribute: "pid", Operator: OpEq, Value: "1234"}},
+			}},
+			override: &EventFilter{Conditions: map[string][]FilterCondition{}},
+			check: func(f *EventFilter) bool {
+				return len(f.Conditions["process"]) == 1 && f.Conditions["process"][0].Value == "1234"
+			},
+		},
+		{
+			name: "override replaces same entity",
+			base: &EventFilter{Conditions: map[string][]FilterCondition{
+				"process": {{Entity: "process", Attribute: "pid", Operator: OpEq, Value: "1234"}},
+			}},
+			override: &EventFilter{Conditions: map[string][]FilterCondition{
+				"process": {{Entity: "process", Attribute: "pid", Operator: OpEq, Value: "5678"}},
+			}},
+			check: func(f *EventFilter) bool {
+				return len(f.Conditions["process"]) == 1 && f.Conditions["process"][0].Value == "5678"
+			},
+		},
+		{
+			name: "merge different entities",
+			base: &EventFilter{Conditions: map[string][]FilterCondition{
+				"process": {{Entity: "process", Attribute: "pid", Operator: OpEq, Value: "1234"}},
+			}},
+			override: &EventFilter{Conditions: map[string][]FilterCondition{
+				"http": {{Entity: "http", Attribute: "method", Operator: OpEq, Value: "POST"}},
+			}},
+			check: func(f *EventFilter) bool {
+				return len(f.Conditions["process"]) == 1 &&
+					f.Conditions["process"][0].Value == "1234" &&
+					len(f.Conditions["http"]) == 1 &&
+					f.Conditions["http"][0].Value == "POST"
+			},
+		},
+		{
+			name: "override one entity, keep another",
+			base: &EventFilter{Conditions: map[string][]FilterCondition{
+				"process": {{Entity: "process", Attribute: "pid", Operator: OpEq, Value: "1234"}},
+				"http":    {{Entity: "http", Attribute: "method", Operator: OpEq, Value: "GET"}},
+			}},
+			override: &EventFilter{Conditions: map[string][]FilterCondition{
+				"http": {{Entity: "http", Attribute: "method", Operator: OpEq, Value: "POST"}},
+			}},
+			check: func(f *EventFilter) bool {
+				return len(f.Conditions["process"]) == 1 &&
+					f.Conditions["process"][0].Value == "1234" &&
+					len(f.Conditions["http"]) == 1 &&
+					f.Conditions["http"][0].Value == "POST"
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := MergeFilters(tt.base, tt.override)
+			if tt.wantNil {
+				if result != nil {
+					t.Errorf("expected nil, got %+v", result)
+				}
+				return
+			}
+			if result == nil {
+				t.Error("expected non-nil result")
+				return
+			}
+			if tt.check != nil && !tt.check(result) {
+				t.Errorf("check failed for result: %+v", result.Conditions)
+			}
+		})
+	}
+}

--- a/pkg/devtools/filter_test.go
+++ b/pkg/devtools/filter_test.go
@@ -99,10 +99,10 @@ func TestParseFilter(t *testing.T) {
 
 func TestEventFilter_Matches(t *testing.T) {
 	tests := []struct {
-		name   string
-		expr   string
-		event  *Event
-		want   bool
+		name  string
+		expr  string
+		event *Event
+		want  bool
 	}{
 		{
 			name:  "nil filter matches everything",

--- a/pkg/devtools/filter_test.go
+++ b/pkg/devtools/filter_test.go
@@ -1,73 +1,74 @@
 package devtools
 
 import (
-	"net/url"
 	"testing"
+
+	"github.com/qpoint-io/rulekit"
 )
 
-func TestParseFilters(t *testing.T) {
+func TestParseFilter(t *testing.T) {
 	tests := []struct {
-		name       string
-		query      string
-		wantErr    bool
-		wantEmpty  bool
-		wantEntity string
-		wantCount  int
+		name      string
+		expr      string
+		wantErr   bool
+		wantEmpty bool
 	}{
 		{
-			name:      "empty query",
-			query:     "",
+			name:      "empty expression",
+			expr:      "",
 			wantEmpty: true,
 		},
 		{
-			name:       "single filter",
-			query:      "process.pid.eq=1234",
-			wantEntity: "process",
-			wantCount:  1,
+			name: "simple equality",
+			expr: "process.pid == 1234",
 		},
 		{
-			name:       "multiple filters same entity",
-			query:      "process.pid.eq=1234&process.container.eq=nginx",
-			wantEntity: "process",
-			wantCount:  2,
+			name: "string equality",
+			expr: "http.method == 'GET'",
 		},
 		{
-			name:      "multiple filters different entities",
-			query:     "process.pid.eq=1234&http.method.eq=POST",
-			wantCount: 2, // 1 per entity
+			name: "numeric comparison",
+			expr: "http.status >= 400",
 		},
 		{
-			name:    "invalid operator",
-			query:   "process.pid.invalid=1234",
+			name: "compound AND",
+			expr: "process.pid == 1234 AND http.status >= 400",
+		},
+		{
+			name: "compound OR",
+			expr: "http.method == 'GET' OR http.method == 'POST'",
+		},
+		{
+			name: "negation",
+			expr: "NOT http.status == 404",
+		},
+		{
+			name: "contains",
+			expr: "http.path contains '/api/'",
+		},
+		{
+			name: "regex match",
+			expr: "http.path matches /api\\/v[0-9]+/",
+		},
+		{
+			name: "function call",
+			expr: "in_zone(http.domain, 'example.com')",
+		},
+		{
+			name:    "invalid syntax - incomplete",
+			expr:    "process.pid ==",
 			wantErr: true,
 		},
 		{
-			name:      "non-filter query params ignored",
-			query:     "foo=bar&baz=qux",
-			wantEmpty: true,
-		},
-		{
-			name:       "mixed filter and non-filter params",
-			query:      "foo=bar&process.pid.eq=1234",
-			wantEntity: "process",
-			wantCount:  1,
-		},
-		{
-			name:       "all operators",
-			query:      "http.status.eq=200&http.status.neq=404&http.status.gt=100&http.status.gte=200&http.status.lt=500&http.status.lte=299&http.path.prefix=/api&http.path.contains=users&http.method.in=GET,POST",
-			wantEntity: "http",
-			wantCount:  9,
+			name:    "invalid syntax - bad operator",
+			expr:    "process.pid === 1234",
+			wantErr: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			values, err := url.ParseQuery(tt.query)
-			if err != nil {
-				t.Fatalf("failed to parse query: %v", err)
-			}
-
-			filter, err := ParseFilters(values)
+			filter, err := ParseFilter(tt.expr)
 			if tt.wantErr {
 				if err == nil {
 					t.Error("expected error, got nil")
@@ -81,29 +82,16 @@ func TestParseFilters(t *testing.T) {
 
 			if tt.wantEmpty {
 				if !filter.IsEmpty() {
-					t.Errorf("expected empty filter, got %+v", filter.Conditions)
+					t.Error("expected empty filter")
 				}
 				return
 			}
 
-			if tt.wantEntity != "" {
-				conditions, ok := filter.Conditions[tt.wantEntity]
-				if !ok {
-					t.Errorf("expected conditions for entity %q", tt.wantEntity)
-					return
-				}
-				if len(conditions) != tt.wantCount {
-					t.Errorf("expected %d conditions, got %d", tt.wantCount, len(conditions))
-				}
-			} else if tt.wantCount > 0 {
-				// Count total conditions across all entities
-				total := 0
-				for _, conds := range filter.Conditions {
-					total += len(conds)
-				}
-				if total != tt.wantCount {
-					t.Errorf("expected %d total conditions, got %d", tt.wantCount, total)
-				}
+			if filter.IsEmpty() {
+				t.Error("expected non-empty filter")
+			}
+			if filter.Expression() != tt.expr {
+				t.Errorf("Expression() = %q, want %q", filter.Expression(), tt.expr)
 			}
 		})
 	}
@@ -112,137 +100,146 @@ func TestParseFilters(t *testing.T) {
 func TestEventFilter_Matches(t *testing.T) {
 	tests := []struct {
 		name   string
-		filter *EventFilter
+		expr   string
 		event  *Event
 		want   bool
 	}{
 		{
-			name:   "nil filter matches everything",
-			filter: nil,
-			event:  NewEvent("request.created", map[string]any{"data": map[string]any{"method": "GET"}}),
-			want:   true,
+			name:  "nil filter matches everything",
+			expr:  "",
+			event: NewEvent("request.created", map[string]any{"data": map[string]any{"method": "GET"}}),
+			want:  true,
 		},
 		{
-			name:   "empty filter matches everything",
-			filter: &EventFilter{Conditions: map[string][]FilterCondition{}},
-			event:  NewEvent("request.created", map[string]any{"data": map[string]any{"method": "GET"}}),
-			want:   true,
-		},
-		{
-			name: "system events always pass",
-			filter: &EventFilter{Conditions: map[string][]FilterCondition{
-				"http": {{Entity: "http", Attribute: "method", Operator: OpEq, Value: "POST"}},
-			}},
+			name:  "system events always pass",
+			expr:  "http.method == 'POST'",
 			event: NewEvent("system.connected", map[string]any{"topics": []string{}}),
 			want:  true,
 		},
 		{
-			name: "unfiltered entity passes through",
-			filter: &EventFilter{Conditions: map[string][]FilterCondition{
-				"http": {{Entity: "http", Attribute: "method", Operator: OpEq, Value: "POST"}},
-			}},
+			name:  "process pid equals - match",
+			expr:  "process.pid == 1234",
 			event: NewEvent("process.started", map[string]any{"pid": 1234}),
 			want:  true,
 		},
 		{
-			name: "matching eq filter",
-			filter: &EventFilter{Conditions: map[string][]FilterCondition{
-				"http": {{Entity: "http", Attribute: "method", Operator: OpEq, Value: "GET"}},
-			}},
+			name:  "process pid equals - no match",
+			expr:  "process.pid == 1234",
+			event: NewEvent("process.started", map[string]any{"pid": 5678}),
+			want:  false,
+		},
+		{
+			name:  "http method equals - match",
+			expr:  "http.method == 'GET'",
 			event: NewEvent("request.created", map[string]any{"data": map[string]any{"method": "GET"}}),
 			want:  true,
 		},
 		{
-			name: "non-matching eq filter",
-			filter: &EventFilter{Conditions: map[string][]FilterCondition{
-				"http": {{Entity: "http", Attribute: "method", Operator: OpEq, Value: "POST"}},
-			}},
+			name:  "http method equals - no match",
+			expr:  "http.method == 'POST'",
 			event: NewEvent("request.created", map[string]any{"data": map[string]any{"method": "GET"}}),
 			want:  false,
 		},
 		{
-			name: "matching neq filter",
-			filter: &EventFilter{Conditions: map[string][]FilterCondition{
-				"http": {{Entity: "http", Attribute: "method", Operator: OpNeq, Value: "POST"}},
-			}},
-			event: NewEvent("request.created", map[string]any{"data": map[string]any{"method": "GET"}}),
-			want:  true,
-		},
-		{
-			name: "matching in filter",
-			filter: &EventFilter{Conditions: map[string][]FilterCondition{
-				"http": {{Entity: "http", Attribute: "method", Operator: OpIn, Value: "GET,POST,PUT"}},
-			}},
-			event: NewEvent("request.created", map[string]any{"data": map[string]any{"method": "POST"}}),
-			want:  true,
-		},
-		{
-			name: "non-matching in filter",
-			filter: &EventFilter{Conditions: map[string][]FilterCondition{
-				"http": {{Entity: "http", Attribute: "method", Operator: OpIn, Value: "GET,POST,PUT"}},
-			}},
-			event: NewEvent("request.created", map[string]any{"data": map[string]any{"method": "DELETE"}}),
-			want:  false,
-		},
-		{
-			name: "matching gte filter",
-			filter: &EventFilter{Conditions: map[string][]FilterCondition{
-				"http": {{Entity: "http", Attribute: "status", Operator: OpGte, Value: "400"}},
-			}},
+			name:  "http status gte - match",
+			expr:  "http.status >= 400",
 			event: NewEvent("request.created", map[string]any{"data": map[string]any{"status": 500}}),
 			want:  true,
 		},
 		{
-			name: "non-matching gte filter",
-			filter: &EventFilter{Conditions: map[string][]FilterCondition{
-				"http": {{Entity: "http", Attribute: "status", Operator: OpGte, Value: "400"}},
-			}},
+			name:  "http status gte - no match",
+			expr:  "http.status >= 400",
 			event: NewEvent("request.created", map[string]any{"data": map[string]any{"status": 200}}),
 			want:  false,
 		},
 		{
-			name: "matching prefix filter",
-			filter: &EventFilter{Conditions: map[string][]FilterCondition{
-				"http": {{Entity: "http", Attribute: "path", Operator: OpPrefix, Value: "/api/"}},
-			}},
+			name:  "http status gte - boundary match",
+			expr:  "http.status >= 400",
+			event: NewEvent("request.created", map[string]any{"data": map[string]any{"status": 400}}),
+			want:  true,
+		},
+		{
+			name:  "http path contains - match",
+			expr:  "http.path contains 'users'",
 			event: NewEvent("request.created", map[string]any{"data": map[string]any{"path": "/api/users/123"}}),
 			want:  true,
 		},
 		{
-			name: "matching contains filter",
-			filter: &EventFilter{Conditions: map[string][]FilterCondition{
-				"http": {{Entity: "http", Attribute: "path", Operator: OpContains, Value: "users"}},
-			}},
+			name:  "http path contains - no match",
+			expr:  "http.path contains 'products'",
 			event: NewEvent("request.created", map[string]any{"data": map[string]any{"path": "/api/users/123"}}),
-			want:  true,
+			want:  false,
 		},
 		{
-			name: "multiple conditions AND logic - all match",
-			filter: &EventFilter{Conditions: map[string][]FilterCondition{
-				"http": {
-					{Entity: "http", Attribute: "method", Operator: OpEq, Value: "POST"},
-					{Entity: "http", Attribute: "status", Operator: OpGte, Value: "400"},
-				},
-			}},
+			name:  "compound AND - both match",
+			expr:  "http.method == 'POST' AND http.status >= 400",
 			event: NewEvent("request.created", map[string]any{"data": map[string]any{"method": "POST", "status": 500}}),
 			want:  true,
 		},
 		{
-			name: "multiple conditions AND logic - one fails",
-			filter: &EventFilter{Conditions: map[string][]FilterCondition{
-				"http": {
-					{Entity: "http", Attribute: "method", Operator: OpEq, Value: "POST"},
-					{Entity: "http", Attribute: "status", Operator: OpGte, Value: "400"},
-				},
-			}},
+			name:  "compound AND - one fails",
+			expr:  "http.method == 'POST' AND http.status >= 400",
 			event: NewEvent("request.created", map[string]any{"data": map[string]any{"method": "POST", "status": 200}}),
 			want:  false,
+		},
+		{
+			name:  "compound OR - first matches",
+			expr:  "http.method == 'GET' OR http.method == 'POST'",
+			event: NewEvent("request.created", map[string]any{"data": map[string]any{"method": "GET"}}),
+			want:  true,
+		},
+		{
+			name:  "compound OR - second matches",
+			expr:  "http.method == 'GET' OR http.method == 'POST'",
+			event: NewEvent("request.created", map[string]any{"data": map[string]any{"method": "POST"}}),
+			want:  true,
+		},
+		{
+			name:  "compound OR - neither matches",
+			expr:  "http.method == 'GET' OR http.method == 'POST'",
+			event: NewEvent("request.created", map[string]any{"data": map[string]any{"method": "DELETE"}}),
+			want:  false,
+		},
+		{
+			name:  "NOT - negates match",
+			expr:  "http.status != 404",
+			event: NewEvent("request.created", map[string]any{"data": map[string]any{"status": float64(200)}}),
+			want:  true,
+		},
+		{
+			name:  "NOT - negates to false",
+			expr:  "http.status != 404",
+			event: NewEvent("request.created", map[string]any{"data": map[string]any{"status": float64(404)}}),
+			want:  false,
+		},
+		{
+			name:  "missing field - no match",
+			expr:  "http.method == 'GET'",
+			event: NewEvent("request.created", map[string]any{"data": map[string]any{"status": 200}}),
+			want:  false,
+		},
+		{
+			name:  "process container - match",
+			expr:  "process.container == 'nginx'",
+			event: NewEvent("process.started", map[string]any{"container": map[string]any{"name": "nginx", "id": "abc123"}}),
+			want:  true,
+		},
+		{
+			name:  "http domain from url - match",
+			expr:  "http.domain == 'api.example.com'",
+			event: NewEvent("request.created", map[string]any{"data": map[string]any{"url": "https://api.example.com/v1/users"}}),
+			want:  true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := tt.filter.Matches(tt.event, nil)
+			filter, err := ParseFilter(tt.expr)
+			if err != nil {
+				t.Fatalf("failed to parse filter: %v", err)
+			}
+
+			got := filter.Matches(tt.event, nil)
 			if got != tt.want {
 				t.Errorf("Matches() = %v, want %v", got, tt.want)
 			}
@@ -252,21 +249,18 @@ func TestEventFilter_Matches(t *testing.T) {
 
 func TestCrossEntityFiltering(t *testing.T) {
 	tests := []struct {
-		name   string
-		filter *EventFilter
-		event  *Event
-		cache  *ConnectionCache
-		want   bool
+		name  string
+		expr  string
+		event *Event
+		want  bool
 	}{
 		{
 			name: "process filter on connection event - matching pid",
-			filter: &EventFilter{Conditions: map[string][]FilterCondition{
-				"process": {{Entity: "process", Attribute: "pid", Operator: OpEq, Value: "1234"}},
-			}},
+			expr: "process.pid == 1234",
 			event: NewEvent("connection.opened", map[string]any{
 				"data": map[string]any{
 					"source": map[string]any{
-						"pid": uint32(1234),
+						"pid": float64(1234), // JSON numbers decode as float64
 					},
 				},
 			}),
@@ -274,13 +268,11 @@ func TestCrossEntityFiltering(t *testing.T) {
 		},
 		{
 			name: "process filter on connection event - non-matching pid",
-			filter: &EventFilter{Conditions: map[string][]FilterCondition{
-				"process": {{Entity: "process", Attribute: "pid", Operator: OpEq, Value: "1234"}},
-			}},
+			expr: "process.pid == 1234",
 			event: NewEvent("connection.opened", map[string]any{
 				"data": map[string]any{
 					"source": map[string]any{
-						"pid": uint32(5678),
+						"pid": float64(5678),
 					},
 				},
 			}),
@@ -288,9 +280,7 @@ func TestCrossEntityFiltering(t *testing.T) {
 		},
 		{
 			name: "process filter on connection event - matching container",
-			filter: &EventFilter{Conditions: map[string][]FilterCondition{
-				"process": {{Entity: "process", Attribute: "container", Operator: OpEq, Value: "nginx"}},
-			}},
+			expr: "process.container == 'nginx'",
 			event: NewEvent("connection.opened", map[string]any{
 				"data": map[string]any{
 					"source": map[string]any{
@@ -301,28 +291,41 @@ func TestCrossEntityFiltering(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "process filter on process event - still works directly",
-			filter: &EventFilter{Conditions: map[string][]FilterCondition{
-				"process": {{Entity: "process", Attribute: "pid", Operator: OpEq, Value: "1234"}},
-			}},
+			name:  "process filter on process event - direct match",
+			expr:  "process.pid == 1234",
 			event: NewEvent("process.started", map[string]any{"pid": 1234}),
 			want:  true,
 		},
 		{
-			name: "http filter does not apply to connection",
-			filter: &EventFilter{Conditions: map[string][]FilterCondition{
-				"http": {{Entity: "http", Attribute: "method", Operator: OpEq, Value: "POST"}},
-			}},
+			name: "connection filter on connection event - direction match",
+			expr: "connection.direction == 'egress'",
 			event: NewEvent("connection.opened", map[string]any{
 				"data": map[string]any{"direction": "egress"},
 			}),
-			want: true, // passes through - http filter doesn't apply to connection
+			want: true,
+		},
+		{
+			name: "connection filter on connection event - dstPort match",
+			expr: "connection.dstPort == 443",
+			event: NewEvent("connection.opened", map[string]any{
+				"data": map[string]any{
+					"destination": map[string]any{
+						"address": map[string]any{"ip": "10.0.0.1", "port": 443},
+					},
+				},
+			}),
+			want: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := tt.filter.Matches(tt.event, tt.cache)
+			filter, err := ParseFilter(tt.expr)
+			if err != nil {
+				t.Fatalf("failed to parse filter: %v", err)
+			}
+
+			got := filter.Matches(tt.event, nil)
 			if got != tt.want {
 				t.Errorf("Matches() = %v, want %v", got, tt.want)
 			}
@@ -336,8 +339,9 @@ func TestCrossEntityFilteringWithCache(t *testing.T) {
 	cache.Set("conn-123", map[string]any{
 		"connectionId": "conn-123",
 		"direction":    "egress",
+		"l7Protocol":   "http2",
 		"source": map[string]any{
-			"pid":      uint32(1234),
+			"pid":      float64(1234), // JSON numbers decode as float64
 			"hostname": "web-server",
 			"container": map[string]any{
 				"name": "nginx",
@@ -347,22 +351,20 @@ func TestCrossEntityFilteringWithCache(t *testing.T) {
 		"destination": map[string]any{
 			"address": map[string]any{
 				"ip":   "10.0.0.1",
-				"port": 443,
+				"port": float64(443), // JSON numbers decode as float64
 			},
 		},
 	})
 
 	tests := []struct {
-		name   string
-		filter *EventFilter
-		event  *Event
-		want   bool
+		name  string
+		expr  string
+		event *Event
+		want  bool
 	}{
 		{
 			name: "process filter on request - matching via cache lookup",
-			filter: &EventFilter{Conditions: map[string][]FilterCondition{
-				"process": {{Entity: "process", Attribute: "pid", Operator: OpEq, Value: "1234"}},
-			}},
+			expr: "process.pid == 1234",
 			event: NewEvent("request.created", map[string]any{
 				"data": map[string]any{
 					"connectionId": "conn-123",
@@ -374,9 +376,7 @@ func TestCrossEntityFilteringWithCache(t *testing.T) {
 		},
 		{
 			name: "process filter on request - non-matching via cache lookup",
-			filter: &EventFilter{Conditions: map[string][]FilterCondition{
-				"process": {{Entity: "process", Attribute: "pid", Operator: OpEq, Value: "9999"}},
-			}},
+			expr: "process.pid == 9999",
 			event: NewEvent("request.created", map[string]any{
 				"data": map[string]any{
 					"connectionId": "conn-123",
@@ -388,9 +388,7 @@ func TestCrossEntityFilteringWithCache(t *testing.T) {
 		},
 		{
 			name: "process container filter on request via cache",
-			filter: &EventFilter{Conditions: map[string][]FilterCondition{
-				"process": {{Entity: "process", Attribute: "container", Operator: OpEq, Value: "nginx"}},
-			}},
+			expr: "process.container == 'nginx'",
 			event: NewEvent("request.created", map[string]any{
 				"data": map[string]any{
 					"connectionId": "conn-123",
@@ -401,9 +399,18 @@ func TestCrossEntityFilteringWithCache(t *testing.T) {
 		},
 		{
 			name: "connection filter on request - matching dstPort via cache",
-			filter: &EventFilter{Conditions: map[string][]FilterCondition{
-				"connection": {{Entity: "connection", Attribute: "dstPort", Operator: OpEq, Value: "443"}},
-			}},
+			expr: "connection.dstPort == 443",
+			event: NewEvent("request.created", map[string]any{
+				"data": map[string]any{
+					"connectionId": "conn-123",
+					"method":       "GET",
+				},
+			}),
+			want: true,
+		},
+		{
+			name: "connection filter on request - matching protocol via cache",
+			expr: "connection.protocol == 'http2'",
 			event: NewEvent("request.created", map[string]any{
 				"data": map[string]any{
 					"connectionId": "conn-123",
@@ -414,9 +421,7 @@ func TestCrossEntityFilteringWithCache(t *testing.T) {
 		},
 		{
 			name: "request with unknown connectionId - cache miss, filter fails",
-			filter: &EventFilter{Conditions: map[string][]FilterCondition{
-				"process": {{Entity: "process", Attribute: "pid", Operator: OpEq, Value: "1234"}},
-			}},
+			expr: "process.pid == 1234",
 			event: NewEvent("request.created", map[string]any{
 				"data": map[string]any{
 					"connectionId": "unknown-conn",
@@ -426,11 +431,8 @@ func TestCrossEntityFilteringWithCache(t *testing.T) {
 			want: false, // Can't verify process.pid without connection data
 		},
 		{
-			name: "combined cross-entity and direct filter",
-			filter: &EventFilter{Conditions: map[string][]FilterCondition{
-				"process": {{Entity: "process", Attribute: "pid", Operator: OpEq, Value: "1234"}},
-				"http":    {{Entity: "http", Attribute: "status", Operator: OpGte, Value: "400"}},
-			}},
+			name: "combined cross-entity and direct filter - both match",
+			expr: "process.pid == 1234 AND http.status >= 400",
 			event: NewEvent("request.created", map[string]any{
 				"data": map[string]any{
 					"connectionId": "conn-123",
@@ -442,10 +444,7 @@ func TestCrossEntityFilteringWithCache(t *testing.T) {
 		},
 		{
 			name: "combined filter - process matches but http fails",
-			filter: &EventFilter{Conditions: map[string][]FilterCondition{
-				"process": {{Entity: "process", Attribute: "pid", Operator: OpEq, Value: "1234"}},
-				"http":    {{Entity: "http", Attribute: "status", Operator: OpGte, Value: "400"}},
-			}},
+			expr: "process.pid == 1234 AND http.status >= 400",
 			event: NewEvent("request.created", map[string]any{
 				"data": map[string]any{
 					"connectionId": "conn-123",
@@ -459,7 +458,12 @@ func TestCrossEntityFilteringWithCache(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := tt.filter.Matches(tt.event, cache)
+			filter, err := ParseFilter(tt.expr)
+			if err != nil {
+				t.Fatalf("failed to parse filter: %v", err)
+			}
+
+			got := filter.Matches(tt.event, cache)
 			if got != tt.want {
 				t.Errorf("Matches() = %v, want %v", got, tt.want)
 			}
@@ -537,482 +541,233 @@ func TestConnectionCache(t *testing.T) {
 	})
 }
 
-func TestExtractProcessAttribute(t *testing.T) {
-	tests := []struct {
-		name string
-		data map[string]any
-		attr string
-		want any
-	}{
-		{
-			name: "pid",
-			data: map[string]any{"pid": 1234},
-			attr: "pid",
-			want: 1234,
-		},
-		{
-			name: "binary",
-			data: map[string]any{"binary": "nginx"},
-			attr: "binary",
-			want: "nginx",
-		},
-		{
-			name: "container name",
-			data: map[string]any{"container": map[string]any{"name": "web-container", "id": "abc123"}},
-			attr: "container",
-			want: "web-container",
-		},
-		{
-			name: "container id",
-			data: map[string]any{"container": map[string]any{"name": "web-container", "id": "abc123"}},
-			attr: "containerId",
-			want: "abc123",
-		},
-		{
-			name: "pod name",
-			data: map[string]any{"pod": map[string]any{"name": "web-pod", "namespace": "default"}},
-			attr: "pod",
-			want: "web-pod",
-		},
-		{
-			name: "pod namespace",
-			data: map[string]any{"pod": map[string]any{"name": "web-pod", "namespace": "default"}},
-			attr: "podNamespace",
-			want: "default",
-		},
-		{
-			name: "user name",
-			data: map[string]any{"user": map[string]any{"name": "root", "id": uint(0)}},
-			attr: "user",
-			want: "root",
-		},
-		{
-			name: "missing attribute",
-			data: map[string]any{"pid": 1234},
-			attr: "nonexistent",
-			want: nil,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := extractProcessAttribute(tt.data, tt.attr)
-			if got != tt.want {
-				t.Errorf("extractProcessAttribute() = %v, want %v", got, tt.want)
-			}
+func TestBuildEventKV(t *testing.T) {
+	t.Run("process event", func(t *testing.T) {
+		event := NewEvent("process.started", map[string]any{
+			"pid":      1234,
+			"binary":   "nginx",
+			"path":     "/usr/sbin/nginx",
+			"hostname": "web-server",
+			"user":     map[string]any{"name": "root", "id": 0},
+			"container": map[string]any{
+				"name":  "my-container",
+				"id":    "abc123",
+				"image": "nginx:latest",
+			},
+			"pod": map[string]any{
+				"name":      "web-pod",
+				"namespace": "default",
+			},
 		})
-	}
-}
 
-func TestExtractConnectionAttribute(t *testing.T) {
-	tests := []struct {
-		name string
-		data map[string]any
-		attr string
-		want any
-	}{
-		{
-			name: "direction",
-			data: map[string]any{"data": map[string]any{"direction": "egress"}},
-			attr: "direction",
-			want: "egress",
-		},
-		{
-			name: "protocol",
-			data: map[string]any{"data": map[string]any{"l7Protocol": "http2"}},
-			attr: "protocol",
-			want: "http2",
-		},
-		{
-			name: "srcIp",
-			data: map[string]any{"data": map[string]any{
+		kv := buildEventKV(event, nil)
+
+		assertKVValue(t, kv, "process.pid", 1234)
+		assertKVValue(t, kv, "process.binary", "nginx")
+		assertKVValue(t, kv, "process.path", "/usr/sbin/nginx")
+		assertKVValue(t, kv, "process.hostname", "web-server")
+		assertKVValue(t, kv, "process.user", "root")
+		assertKVValue(t, kv, "process.userId", 0)
+		assertKVValue(t, kv, "process.container", "my-container")
+		assertKVValue(t, kv, "process.containerId", "abc123")
+		assertKVValue(t, kv, "process.containerImage", "nginx:latest")
+		assertKVValue(t, kv, "process.pod", "web-pod")
+		assertKVValue(t, kv, "process.podNamespace", "default")
+	})
+
+	t.Run("connection event", func(t *testing.T) {
+		event := NewEvent("connection.opened", map[string]any{
+			"data": map[string]any{
+				"direction":      "egress",
+				"l7Protocol":     "http2",
+				"socketProtocol": "tcp",
 				"source": map[string]any{
-					"address": map[string]any{"ip": "192.168.1.1", "port": 8080},
+					"pid":      float64(1234),
+					"hostname": "web-server",
+					"exe":      "/usr/bin/curl",
+					"address":  map[string]any{"ip": "192.168.1.1", "port": float64(8080)},
 				},
-			}},
-			attr: "srcIp",
-			want: "192.168.1.1",
-		},
-		{
-			name: "dstPort",
-			data: map[string]any{"data": map[string]any{
 				"destination": map[string]any{
-					"address": map[string]any{"ip": "10.0.0.1", "port": 443},
+					"address": map[string]any{"ip": "10.0.0.1", "port": float64(443)},
 				},
-			}},
-			attr: "dstPort",
-			want: 443,
-		},
-		{
-			name: "container from source",
-			data: map[string]any{"data": map[string]any{
-				"source": map[string]any{
-					"container": map[string]any{"name": "web-app"},
-				},
-			}},
-			attr: "container",
-			want: "web-app",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := extractConnectionAttribute(tt.data, tt.attr)
-			if got != tt.want {
-				t.Errorf("extractConnectionAttribute() = %v, want %v", got, tt.want)
-			}
+			},
 		})
-	}
-}
 
-func TestCompareEqual(t *testing.T) {
-	tests := []struct {
-		name        string
-		value       any
-		filterValue string
-		want        bool
-	}{
-		{"string match", "hello", "hello", true},
-		{"string no match", "hello", "world", false},
-		{"int match", 42, "42", true},
-		{"int no match", 42, "43", false},
-		{"int64 match", int64(1234567890), "1234567890", true},
-		{"float64 match", float64(200), "200", true},
-		{"float64 decimal", float64(3.14), "3.14", true},
-		{"uint32 match", uint32(443), "443", true},
-		{"uint16 match", uint16(8080), "8080", true},
-	}
+		kv := buildEventKV(event, nil)
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := compareEqual(tt.value, tt.filterValue)
-			if got != tt.want {
-				t.Errorf("compareEqual(%v, %q) = %v, want %v", tt.value, tt.filterValue, got, tt.want)
-			}
+		assertKVValue(t, kv, "connection.direction", "egress")
+		assertKVValue(t, kv, "connection.protocol", "http2")
+		assertKVValue(t, kv, "connection.socketProtocol", "tcp")
+		assertKVValue(t, kv, "connection.srcIp", "192.168.1.1")
+		assertKVValue(t, kv, "connection.srcPort", float64(8080))
+		assertKVValue(t, kv, "connection.dstIp", "10.0.0.1")
+		assertKVValue(t, kv, "connection.dstPort", float64(443))
+		assertKVValue(t, kv, "process.pid", float64(1234))
+		assertKVValue(t, kv, "process.hostname", "web-server")
+		assertKVValue(t, kv, "process.path", "/usr/bin/curl")
+		assertKVValue(t, kv, "process.binary", "curl")
+	})
+
+	t.Run("request event", func(t *testing.T) {
+		event := NewEvent("request.created", map[string]any{
+			"data": map[string]any{
+				"method":        "POST",
+				"status":        200,
+				"path":          "/api/users",
+				"url":           "https://api.example.com/api/users",
+				"direction":     "egress",
+				"duration":      150,
+				"bytesSent":     1024,
+				"bytesReceived": 2048,
+				"connectionId":  "conn-123",
+				"requestId":     "req-456",
+			},
 		})
-	}
-}
 
-func TestCompareNumeric(t *testing.T) {
-	tests := []struct {
-		name        string
-		value       any
-		filterValue string
-		op          func(a, b int64) bool
-		want        bool
-	}{
-		{"int gt true", 100, "50", func(a, b int64) bool { return a > b }, true},
-		{"int gt false", 50, "100", func(a, b int64) bool { return a > b }, false},
-		{"int gte equal", 100, "100", func(a, b int64) bool { return a >= b }, true},
-		{"float64 lt", float64(50), "100", func(a, b int64) bool { return a < b }, true},
-		{"uint32 lte", uint32(100), "100", func(a, b int64) bool { return a <= b }, true},
-	}
+		kv := buildEventKV(event, nil)
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := compareNumeric(tt.value, tt.filterValue, tt.op)
-			if got != tt.want {
-				t.Errorf("compareNumeric(%v, %q) = %v, want %v", tt.value, tt.filterValue, got, tt.want)
-			}
-		})
-	}
-}
+		assertKVValue(t, kv, "http.method", "POST")
+		assertKVValue(t, kv, "http.status", 200)
+		assertKVValue(t, kv, "http.path", "/api/users")
+		assertKVValue(t, kv, "http.url", "https://api.example.com/api/users")
+		assertKVValue(t, kv, "http.domain", "api.example.com")
+		assertKVValue(t, kv, "http.direction", "egress")
+		assertKVValue(t, kv, "http.duration", 150)
+		assertKVValue(t, kv, "http.bytesSent", 1024)
+		assertKVValue(t, kv, "http.bytesReceived", 2048)
+		assertKVValue(t, kv, "http.connectionId", "conn-123")
+		assertKVValue(t, kv, "http.requestId", "req-456")
+	})
 
-func TestExtractHttpDomain(t *testing.T) {
-	tests := []struct {
-		name string
-		data map[string]any
-		want any
-	}{
-		{
-			name: "extract domain from url",
-			data: map[string]any{"data": map[string]any{"url": "https://api.example.com/v1/users"}},
-			want: "api.example.com",
-		},
-		{
-			name: "extract domain with port",
-			data: map[string]any{"data": map[string]any{"url": "http://localhost:8080/api"}},
-			want: "localhost",
-		},
-		{
-			name: "missing url",
-			data: map[string]any{"data": map[string]any{"method": "GET"}},
-			want: nil,
-		},
-		{
-			name: "invalid url",
-			data: map[string]any{"data": map[string]any{"url": "not-a-url"}},
-			want: "",
-		},
-		{
-			name: "http_transaction summary - domain from request_host",
-			data: map[string]any{"data": map[string]any{
+	t.Run("http_transaction summary event", func(t *testing.T) {
+		event := NewEvent("request.http_transaction", map[string]any{
+			"data": map[string]any{
+				"connectionId": "abc123",
+				"type":         "http_transaction",
 				"summary": map[string]any{
-					"request_host":   "api.slack.com",
-					"request_method": "POST",
+					"request_host":     "api.slack.com",
+					"request_method":   "POST",
+					"response_status":  float64(200),
+					"request_path":     "/api/chat.postMessage",
+					"direction":        "egress-external",
+					"request_protocol": "http2",
+					"request_scheme":   "https",
+					"connection_id":    "abc123",
+					"container_name":   "myapp",
+					"container_image":  "myapp:latest",
+					"process_exe":      "/usr/bin/node",
 				},
-			}},
-			want: "api.slack.com",
+			},
+		})
+
+		kv := buildEventKV(event, nil)
+
+		assertKVValue(t, kv, "http.domain", "api.slack.com")
+		assertKVValue(t, kv, "http.method", "POST")
+		assertKVValue(t, kv, "http.status", float64(200))
+		assertKVValue(t, kv, "http.path", "/api/chat.postMessage")
+		assertKVValue(t, kv, "http.direction", "egress-external")
+		assertKVValue(t, kv, "http.protocol", "http2")
+		assertKVValue(t, kv, "http.scheme", "https")
+		assertKVValue(t, kv, "process.container", "myapp")
+		assertKVValue(t, kv, "process.containerImage", "myapp:latest")
+		assertKVValue(t, kv, "process.binary", "/usr/bin/node")
+	})
+}
+
+func TestRegexMatching(t *testing.T) {
+	tests := []struct {
+		name  string
+		expr  string
+		event *Event
+		want  bool
+	}{
+		{
+			name:  "path matches regex",
+			expr:  "http.path matches /api\\/v[0-9]+/",
+			event: NewEvent("request.created", map[string]any{"data": map[string]any{"path": "/api/v2/users"}}),
+			want:  true,
+		},
+		{
+			name:  "path does not match regex",
+			expr:  "http.path matches /api\\/v[0-9]+/",
+			event: NewEvent("request.created", map[string]any{"data": map[string]any{"path": "/api/users"}}),
+			want:  false,
+		},
+		{
+			name:  "domain matches regex",
+			expr:  "http.domain matches /\\.example\\.com$/",
+			event: NewEvent("request.created", map[string]any{"data": map[string]any{"url": "https://api.example.com/test"}}),
+			want:  true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := extractHttpAttribute(tt.data, "domain")
-			if got != tt.want {
-				t.Errorf("extractHttpAttribute(domain) = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestExtractFromHttpTransactionSummary(t *testing.T) {
-	// Simulates the structure of request.http_transaction events from ObjectStore
-	data := map[string]any{
-		"data": map[string]any{
-			"connectionId": "abc123",
-			"type":         "http_transaction",
-			"summary": map[string]any{
-				"request_host":     "api.slack.com",
-				"request_method":   "POST",
-				"response_status":  float64(200), // JSON numbers are float64
-				"request_path":     "/api/chat.postMessage",
-				"direction":        "egress-external",
-				"request_protocol": "http2",
-				"request_scheme":   "https",
-				"connection_id":    "abc123",
-				"container_name":   "myapp",
-				"container_image":  "myapp:latest",
-				"process_exe":      "/usr/bin/node",
-			},
-		},
-	}
-
-	tests := []struct {
-		attr string
-		want any
-	}{
-		{"domain", "api.slack.com"},
-		{"method", "POST"},
-		{"status", float64(200)},
-		{"path", "/api/chat.postMessage"},
-		{"direction", "egress-external"},
-		{"protocol", "http2"},
-		{"scheme", "https"},
-		{"connectionId", "abc123"},
-		{"container", "myapp"},
-		{"containerImage", "myapp:latest"},
-		{"binary", "/usr/bin/node"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.attr, func(t *testing.T) {
-			got := extractHttpAttribute(data, tt.attr)
-			if got != tt.want {
-				t.Errorf("extractHttpAttribute(%q) = %v, want %v", tt.attr, got, tt.want)
-			}
-		})
-	}
-}
-
-func TestParseFiltersFromBody(t *testing.T) {
-	tests := []struct {
-		name       string
-		filters    map[string]string
-		wantErr    bool
-		wantNil    bool
-		wantEntity string
-		wantCount  int
-	}{
-		{
-			name:    "nil map",
-			filters: nil,
-			wantNil: true,
-		},
-		{
-			name:    "empty map",
-			filters: map[string]string{},
-			wantNil: true,
-		},
-		{
-			name:       "single filter",
-			filters:    map[string]string{"process.pid.eq": "1234"},
-			wantEntity: "process",
-			wantCount:  1,
-		},
-		{
-			name: "multiple filters same entity",
-			filters: map[string]string{
-				"process.pid.eq":       "1234",
-				"process.container.eq": "nginx",
-			},
-			wantEntity: "process",
-			wantCount:  2,
-		},
-		{
-			name: "multiple filters different entities",
-			filters: map[string]string{
-				"process.pid.eq": "1234",
-				"http.method.eq": "POST",
-			},
-			wantCount: 2, // 1 per entity
-		},
-		{
-			name:    "invalid operator",
-			filters: map[string]string{"process.pid.invalid": "1234"},
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			filter, err := ParseFiltersFromBody(tt.filters)
-			if tt.wantErr {
-				if err == nil {
-					t.Error("expected error, got nil")
-				}
-				return
-			}
+			filter, err := ParseFilter(tt.expr)
 			if err != nil {
-				t.Errorf("unexpected error: %v", err)
-				return
+				t.Fatalf("failed to parse filter: %v", err)
 			}
 
-			if tt.wantNil {
-				if filter != nil {
-					t.Errorf("expected nil filter, got %+v", filter)
-				}
-				return
-			}
-
-			if tt.wantEntity != "" {
-				conditions, ok := filter.Conditions[tt.wantEntity]
-				if !ok {
-					t.Errorf("expected conditions for entity %q", tt.wantEntity)
-					return
-				}
-				if len(conditions) != tt.wantCount {
-					t.Errorf("expected %d conditions, got %d", tt.wantCount, len(conditions))
-				}
-			} else if tt.wantCount > 0 {
-				// Count total conditions across all entities
-				total := 0
-				for _, conds := range filter.Conditions {
-					total += len(conds)
-				}
-				if total != tt.wantCount {
-					t.Errorf("expected %d total conditions, got %d", tt.wantCount, total)
-				}
+			got := filter.Matches(tt.event, nil)
+			if got != tt.want {
+				t.Errorf("Matches() = %v, want %v", got, tt.want)
 			}
 		})
 	}
 }
 
-func TestMergeFilters(t *testing.T) {
+func TestCustomFunctions(t *testing.T) {
 	tests := []struct {
-		name     string
-		base     *EventFilter
-		override *EventFilter
-		wantNil  bool
-		check    func(*EventFilter) bool
+		name  string
+		expr  string
+		event *Event
+		want  bool
 	}{
 		{
-			name:     "both nil",
-			base:     nil,
-			override: nil,
-			wantNil:  true,
+			name:  "in_zone - exact match",
+			expr:  "in_zone(http.domain, 'example.com')",
+			event: NewEvent("request.created", map[string]any{"data": map[string]any{"url": "https://example.com/test"}}),
+			want:  true,
 		},
 		{
-			name: "nil base, non-nil override",
-			base: nil,
-			override: &EventFilter{Conditions: map[string][]FilterCondition{
-				"process": {{Entity: "process", Attribute: "pid", Operator: OpEq, Value: "1234"}},
-			}},
-			check: func(f *EventFilter) bool {
-				return len(f.Conditions["process"]) == 1 && f.Conditions["process"][0].Value == "1234"
-			},
+			name:  "in_zone - subdomain match",
+			expr:  "in_zone(http.domain, 'example.com')",
+			event: NewEvent("request.created", map[string]any{"data": map[string]any{"url": "https://api.example.com/test"}}),
+			want:  true,
 		},
 		{
-			name: "non-nil base, nil override",
-			base: &EventFilter{Conditions: map[string][]FilterCondition{
-				"process": {{Entity: "process", Attribute: "pid", Operator: OpEq, Value: "1234"}},
-			}},
-			override: nil,
-			check: func(f *EventFilter) bool {
-				return len(f.Conditions["process"]) == 1 && f.Conditions["process"][0].Value == "1234"
-			},
-		},
-		{
-			name: "non-nil base, empty override",
-			base: &EventFilter{Conditions: map[string][]FilterCondition{
-				"process": {{Entity: "process", Attribute: "pid", Operator: OpEq, Value: "1234"}},
-			}},
-			override: &EventFilter{Conditions: map[string][]FilterCondition{}},
-			check: func(f *EventFilter) bool {
-				return len(f.Conditions["process"]) == 1 && f.Conditions["process"][0].Value == "1234"
-			},
-		},
-		{
-			name: "override replaces same entity",
-			base: &EventFilter{Conditions: map[string][]FilterCondition{
-				"process": {{Entity: "process", Attribute: "pid", Operator: OpEq, Value: "1234"}},
-			}},
-			override: &EventFilter{Conditions: map[string][]FilterCondition{
-				"process": {{Entity: "process", Attribute: "pid", Operator: OpEq, Value: "5678"}},
-			}},
-			check: func(f *EventFilter) bool {
-				return len(f.Conditions["process"]) == 1 && f.Conditions["process"][0].Value == "5678"
-			},
-		},
-		{
-			name: "merge different entities",
-			base: &EventFilter{Conditions: map[string][]FilterCondition{
-				"process": {{Entity: "process", Attribute: "pid", Operator: OpEq, Value: "1234"}},
-			}},
-			override: &EventFilter{Conditions: map[string][]FilterCondition{
-				"http": {{Entity: "http", Attribute: "method", Operator: OpEq, Value: "POST"}},
-			}},
-			check: func(f *EventFilter) bool {
-				return len(f.Conditions["process"]) == 1 &&
-					f.Conditions["process"][0].Value == "1234" &&
-					len(f.Conditions["http"]) == 1 &&
-					f.Conditions["http"][0].Value == "POST"
-			},
-		},
-		{
-			name: "override one entity, keep another",
-			base: &EventFilter{Conditions: map[string][]FilterCondition{
-				"process": {{Entity: "process", Attribute: "pid", Operator: OpEq, Value: "1234"}},
-				"http":    {{Entity: "http", Attribute: "method", Operator: OpEq, Value: "GET"}},
-			}},
-			override: &EventFilter{Conditions: map[string][]FilterCondition{
-				"http": {{Entity: "http", Attribute: "method", Operator: OpEq, Value: "POST"}},
-			}},
-			check: func(f *EventFilter) bool {
-				return len(f.Conditions["process"]) == 1 &&
-					f.Conditions["process"][0].Value == "1234" &&
-					len(f.Conditions["http"]) == 1 &&
-					f.Conditions["http"][0].Value == "POST"
-			},
+			name:  "in_zone - no match",
+			expr:  "in_zone(http.domain, 'example.com')",
+			event: NewEvent("request.created", map[string]any{"data": map[string]any{"url": "https://other.com/test"}}),
+			want:  false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := MergeFilters(tt.base, tt.override)
-			if tt.wantNil {
-				if result != nil {
-					t.Errorf("expected nil, got %+v", result)
-				}
-				return
+			filter, err := ParseFilter(tt.expr)
+			if err != nil {
+				t.Fatalf("failed to parse filter: %v", err)
 			}
-			if result == nil {
-				t.Error("expected non-nil result")
-				return
-			}
-			if tt.check != nil && !tt.check(result) {
-				t.Errorf("check failed for result: %+v", result.Conditions)
+
+			got := filter.Matches(tt.event, nil)
+			if got != tt.want {
+				t.Errorf("Matches() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// Helper function to assert KV values
+func assertKVValue(t *testing.T, kv rulekit.KV, key string, want any) {
+	t.Helper()
+	got, ok := kv[key]
+	if !ok {
+		t.Errorf("key %q not found in KV", key)
+		return
+	}
+	if got != want {
+		t.Errorf("KV[%q] = %v (%T), want %v (%T)", key, got, got, want, want)
 	}
 }

--- a/pkg/devtools/filter_test.go
+++ b/pkg/devtools/filter_test.go
@@ -19,49 +19,49 @@ func TestParseFilter(t *testing.T) {
 			wantEmpty: true,
 		},
 		{
-			name: "simple equality",
-			expr: "process.pid == 1234",
+			name: "simple equality - process binary",
+			expr: "binary == 'nginx'",
 		},
 		{
-			name: "string equality",
-			expr: "http.method == 'GET'",
+			name: "string equality - http method",
+			expr: "req.method == 'GET'",
 		},
 		{
-			name: "numeric comparison",
-			expr: "http.status >= 400",
+			name: "numeric comparison - http status",
+			expr: "res.status >= 400",
 		},
 		{
 			name: "compound AND",
-			expr: "process.pid == 1234 AND http.status >= 400",
+			expr: "binary == 'curl' AND res.status >= 400",
 		},
 		{
 			name: "compound OR",
-			expr: "http.method == 'GET' OR http.method == 'POST'",
+			expr: "req.method == 'GET' OR req.method == 'POST'",
 		},
 		{
 			name: "negation",
-			expr: "NOT http.status == 404",
+			expr: "NOT res.status == 404",
 		},
 		{
 			name: "contains",
-			expr: "http.path contains '/api/'",
+			expr: "req.path contains '/api/'",
 		},
 		{
 			name: "regex match",
-			expr: "http.path matches /api\\/v[0-9]+/",
+			expr: "req.path matches /api\\/v[0-9]+/",
 		},
 		{
 			name: "function call",
-			expr: "in_zone(http.domain, 'example.com')",
+			expr: "in_zone(req.host, 'example.com')",
 		},
 		{
 			name:    "invalid syntax - incomplete",
-			expr:    "process.pid ==",
+			expr:    "binary ==",
 			wantErr: true,
 		},
 		{
 			name:    "invalid syntax - bad operator",
-			expr:    "process.pid === 1234",
+			expr:    "binary === 'nginx'",
 			wantErr: true,
 		},
 	}
@@ -112,121 +112,121 @@ func TestEventFilter_Matches(t *testing.T) {
 		},
 		{
 			name:  "system events always pass",
-			expr:  "http.method == 'POST'",
+			expr:  "req.method == 'POST'",
 			event: NewEvent("system.connected", map[string]any{"topics": []string{}}),
 			want:  true,
 		},
 		{
-			name:  "process pid equals - match",
-			expr:  "process.pid == 1234",
-			event: NewEvent("process.started", map[string]any{"pid": 1234}),
+			name:  "process binary equals - match",
+			expr:  "binary == 'nginx'",
+			event: NewEvent("process.started", map[string]any{"binary": "nginx"}),
 			want:  true,
 		},
 		{
-			name:  "process pid equals - no match",
-			expr:  "process.pid == 1234",
-			event: NewEvent("process.started", map[string]any{"pid": 5678}),
+			name:  "process binary equals - no match",
+			expr:  "binary == 'nginx'",
+			event: NewEvent("process.started", map[string]any{"binary": "curl"}),
 			want:  false,
 		},
 		{
 			name:  "http method equals - match",
-			expr:  "http.method == 'GET'",
+			expr:  "req.method == 'GET'",
 			event: NewEvent("request.created", map[string]any{"data": map[string]any{"method": "GET"}}),
 			want:  true,
 		},
 		{
 			name:  "http method equals - no match",
-			expr:  "http.method == 'POST'",
+			expr:  "req.method == 'POST'",
 			event: NewEvent("request.created", map[string]any{"data": map[string]any{"method": "GET"}}),
 			want:  false,
 		},
 		{
 			name:  "http status gte - match",
-			expr:  "http.status >= 400",
+			expr:  "res.status >= 400",
 			event: NewEvent("request.created", map[string]any{"data": map[string]any{"status": 500}}),
 			want:  true,
 		},
 		{
 			name:  "http status gte - no match",
-			expr:  "http.status >= 400",
+			expr:  "res.status >= 400",
 			event: NewEvent("request.created", map[string]any{"data": map[string]any{"status": 200}}),
 			want:  false,
 		},
 		{
 			name:  "http status gte - boundary match",
-			expr:  "http.status >= 400",
+			expr:  "res.status >= 400",
 			event: NewEvent("request.created", map[string]any{"data": map[string]any{"status": 400}}),
 			want:  true,
 		},
 		{
 			name:  "http path contains - match",
-			expr:  "http.path contains 'users'",
+			expr:  "req.path contains 'users'",
 			event: NewEvent("request.created", map[string]any{"data": map[string]any{"path": "/api/users/123"}}),
 			want:  true,
 		},
 		{
 			name:  "http path contains - no match",
-			expr:  "http.path contains 'products'",
+			expr:  "req.path contains 'products'",
 			event: NewEvent("request.created", map[string]any{"data": map[string]any{"path": "/api/users/123"}}),
 			want:  false,
 		},
 		{
 			name:  "compound AND - both match",
-			expr:  "http.method == 'POST' AND http.status >= 400",
+			expr:  "req.method == 'POST' AND res.status >= 400",
 			event: NewEvent("request.created", map[string]any{"data": map[string]any{"method": "POST", "status": 500}}),
 			want:  true,
 		},
 		{
 			name:  "compound AND - one fails",
-			expr:  "http.method == 'POST' AND http.status >= 400",
+			expr:  "req.method == 'POST' AND res.status >= 400",
 			event: NewEvent("request.created", map[string]any{"data": map[string]any{"method": "POST", "status": 200}}),
 			want:  false,
 		},
 		{
 			name:  "compound OR - first matches",
-			expr:  "http.method == 'GET' OR http.method == 'POST'",
+			expr:  "req.method == 'GET' OR req.method == 'POST'",
 			event: NewEvent("request.created", map[string]any{"data": map[string]any{"method": "GET"}}),
 			want:  true,
 		},
 		{
 			name:  "compound OR - second matches",
-			expr:  "http.method == 'GET' OR http.method == 'POST'",
+			expr:  "req.method == 'GET' OR req.method == 'POST'",
 			event: NewEvent("request.created", map[string]any{"data": map[string]any{"method": "POST"}}),
 			want:  true,
 		},
 		{
 			name:  "compound OR - neither matches",
-			expr:  "http.method == 'GET' OR http.method == 'POST'",
+			expr:  "req.method == 'GET' OR req.method == 'POST'",
 			event: NewEvent("request.created", map[string]any{"data": map[string]any{"method": "DELETE"}}),
 			want:  false,
 		},
 		{
 			name:  "NOT - negates match",
-			expr:  "http.status != 404",
+			expr:  "res.status != 404",
 			event: NewEvent("request.created", map[string]any{"data": map[string]any{"status": float64(200)}}),
 			want:  true,
 		},
 		{
 			name:  "NOT - negates to false",
-			expr:  "http.status != 404",
+			expr:  "res.status != 404",
 			event: NewEvent("request.created", map[string]any{"data": map[string]any{"status": float64(404)}}),
 			want:  false,
 		},
 		{
 			name:  "missing field - no match",
-			expr:  "http.method == 'GET'",
+			expr:  "req.method == 'GET'",
 			event: NewEvent("request.created", map[string]any{"data": map[string]any{"status": 200}}),
 			want:  false,
 		},
 		{
-			name:  "process container - match",
-			expr:  "process.container == 'nginx'",
+			name:  "process container name - match",
+			expr:  "container.name == 'nginx'",
 			event: NewEvent("process.started", map[string]any{"container": map[string]any{"name": "nginx", "id": "abc123"}}),
 			want:  true,
 		},
 		{
-			name:  "http domain from url - match",
-			expr:  "http.domain == 'api.example.com'",
+			name:  "http host from url - match",
+			expr:  "req.host == 'api.example.com'",
 			event: NewEvent("request.created", map[string]any{"data": map[string]any{"url": "https://api.example.com/v1/users"}}),
 			want:  true,
 		},
@@ -255,32 +255,32 @@ func TestCrossEntityFiltering(t *testing.T) {
 		want  bool
 	}{
 		{
-			name: "process filter on connection event - matching pid",
-			expr: "process.pid == 1234",
+			name: "process filter on connection event - matching binary",
+			expr: "process.binary == 'curl'",
 			event: NewEvent("connection.opened", map[string]any{
 				"data": map[string]any{
 					"source": map[string]any{
-						"pid": float64(1234), // JSON numbers decode as float64
+						"exe": "/usr/bin/curl",
 					},
 				},
 			}),
 			want: true,
 		},
 		{
-			name: "process filter on connection event - non-matching pid",
-			expr: "process.pid == 1234",
+			name: "process filter on connection event - non-matching binary",
+			expr: "process.binary == 'curl'",
 			event: NewEvent("connection.opened", map[string]any{
 				"data": map[string]any{
 					"source": map[string]any{
-						"pid": float64(5678),
+						"exe": "/usr/bin/wget",
 					},
 				},
 			}),
 			want: false,
 		},
 		{
-			name: "process filter on connection event - matching container",
-			expr: "process.container == 'nginx'",
+			name: "container filter on connection event - matching container name",
+			expr: "container.name == 'nginx'",
 			event: NewEvent("connection.opened", map[string]any{
 				"data": map[string]any{
 					"source": map[string]any{
@@ -292,21 +292,21 @@ func TestCrossEntityFiltering(t *testing.T) {
 		},
 		{
 			name:  "process filter on process event - direct match",
-			expr:  "process.pid == 1234",
-			event: NewEvent("process.started", map[string]any{"pid": 1234}),
+			expr:  "binary == 'nginx'",
+			event: NewEvent("process.started", map[string]any{"binary": "nginx"}),
 			want:  true,
 		},
 		{
 			name: "connection filter on connection event - direction match",
-			expr: "connection.direction == 'egress'",
+			expr: "direction == 'egress'",
 			event: NewEvent("connection.opened", map[string]any{
 				"data": map[string]any{"direction": "egress"},
 			}),
 			want: true,
 		},
 		{
-			name: "connection filter on connection event - dstPort match",
-			expr: "connection.dstPort == 443",
+			name: "connection filter on connection event - dst.port match",
+			expr: "dst.port == 443",
 			event: NewEvent("connection.opened", map[string]any{
 				"data": map[string]any{
 					"destination": map[string]any{
@@ -341,8 +341,8 @@ func TestCrossEntityFilteringWithCache(t *testing.T) {
 		"direction":    "egress",
 		"l7Protocol":   "http2",
 		"source": map[string]any{
-			"pid":      float64(1234), // JSON numbers decode as float64
 			"hostname": "web-server",
+			"exe":      "/usr/bin/curl",
 			"container": map[string]any{
 				"name": "nginx",
 				"id":   "abc123",
@@ -351,7 +351,7 @@ func TestCrossEntityFilteringWithCache(t *testing.T) {
 		"destination": map[string]any{
 			"address": map[string]any{
 				"ip":   "10.0.0.1",
-				"port": float64(443), // JSON numbers decode as float64
+				"port": float64(443),
 			},
 		},
 	})
@@ -364,7 +364,7 @@ func TestCrossEntityFilteringWithCache(t *testing.T) {
 	}{
 		{
 			name: "process filter on request - matching via cache lookup",
-			expr: "process.pid == 1234",
+			expr: "process.binary == 'curl'",
 			event: NewEvent("request.created", map[string]any{
 				"data": map[string]any{
 					"connectionId": "conn-123",
@@ -376,7 +376,7 @@ func TestCrossEntityFilteringWithCache(t *testing.T) {
 		},
 		{
 			name: "process filter on request - non-matching via cache lookup",
-			expr: "process.pid == 9999",
+			expr: "process.binary == 'wget'",
 			event: NewEvent("request.created", map[string]any{
 				"data": map[string]any{
 					"connectionId": "conn-123",
@@ -387,8 +387,8 @@ func TestCrossEntityFilteringWithCache(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "process container filter on request via cache",
-			expr: "process.container == 'nginx'",
+			name: "container filter on request via cache",
+			expr: "container.name == 'nginx'",
 			event: NewEvent("request.created", map[string]any{
 				"data": map[string]any{
 					"connectionId": "conn-123",
@@ -398,8 +398,8 @@ func TestCrossEntityFilteringWithCache(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "connection filter on request - matching dstPort via cache",
-			expr: "connection.dstPort == 443",
+			name: "connection filter on request - matching dst.port via cache",
+			expr: "dst.port == 443",
 			event: NewEvent("request.created", map[string]any{
 				"data": map[string]any{
 					"connectionId": "conn-123",
@@ -410,7 +410,7 @@ func TestCrossEntityFilteringWithCache(t *testing.T) {
 		},
 		{
 			name: "connection filter on request - matching protocol via cache",
-			expr: "connection.protocol == 'http2'",
+			expr: "protocol == 'http2'",
 			event: NewEvent("request.created", map[string]any{
 				"data": map[string]any{
 					"connectionId": "conn-123",
@@ -421,18 +421,18 @@ func TestCrossEntityFilteringWithCache(t *testing.T) {
 		},
 		{
 			name: "request with unknown connectionId - cache miss, filter fails",
-			expr: "process.pid == 1234",
+			expr: "process.binary == 'curl'",
 			event: NewEvent("request.created", map[string]any{
 				"data": map[string]any{
 					"connectionId": "unknown-conn",
 					"method":       "GET",
 				},
 			}),
-			want: false, // Can't verify process.pid without connection data
+			want: false, // Can't verify process.binary without connection data
 		},
 		{
 			name: "combined cross-entity and direct filter - both match",
-			expr: "process.pid == 1234 AND http.status >= 400",
+			expr: "process.binary == 'curl' AND res.status >= 400",
 			event: NewEvent("request.created", map[string]any{
 				"data": map[string]any{
 					"connectionId": "conn-123",
@@ -444,7 +444,7 @@ func TestCrossEntityFilteringWithCache(t *testing.T) {
 		},
 		{
 			name: "combined filter - process matches but http fails",
-			expr: "process.pid == 1234 AND http.status >= 400",
+			expr: "process.binary == 'curl' AND res.status >= 400",
 			event: NewEvent("request.created", map[string]any{
 				"data": map[string]any{
 					"connectionId": "conn-123",
@@ -542,7 +542,7 @@ func TestConnectionCache(t *testing.T) {
 }
 
 func TestBuildEventKV(t *testing.T) {
-	t.Run("process event", func(t *testing.T) {
+	t.Run("process event - native fields at root", func(t *testing.T) {
 		event := NewEvent("process.started", map[string]any{
 			"pid":      1234,
 			"binary":   "nginx",
@@ -562,81 +562,92 @@ func TestBuildEventKV(t *testing.T) {
 
 		kv := buildEventKV(event, nil)
 
-		assertKVValue(t, kv, "process.pid", 1234)
-		assertKVValue(t, kv, "process.binary", "nginx")
-		assertKVValue(t, kv, "process.path", "/usr/sbin/nginx")
-		assertKVValue(t, kv, "process.hostname", "web-server")
-		assertKVValue(t, kv, "process.user", "root")
-		assertKVValue(t, kv, "process.userId", 0)
-		assertKVValue(t, kv, "process.container", "my-container")
-		assertKVValue(t, kv, "process.containerId", "abc123")
-		assertKVValue(t, kv, "process.containerImage", "nginx:latest")
-		assertKVValue(t, kv, "process.pod", "web-pod")
-		assertKVValue(t, kv, "process.podNamespace", "default")
+		// Native process fields - no prefix
+		assertKVValue(t, kv, "binary", "nginx")
+		assertKVValue(t, kv, "path", "/usr/sbin/nginx")
+		assertKVValue(t, kv, "hostname", "web-server")
+
+		// User nested under user.*
+		assertNestedKVValue(t, kv, "user", "name", "root")
+		assertNestedKVValue(t, kv, "user", "id", 0)
+
+		// Container nested under container.*
+		assertNestedKVValue(t, kv, "container", "name", "my-container")
+		assertNestedKVValue(t, kv, "container", "id", "abc123")
+		assertNestedKVValue(t, kv, "container", "image", "nginx:latest")
+
+		// Pod nested under pod.*
+		assertNestedKVValue(t, kv, "pod", "name", "web-pod")
+		assertNestedKVValue(t, kv, "pod", "namespace", "default")
 	})
 
-	t.Run("connection event", func(t *testing.T) {
+	t.Run("connection event - native + relational process", func(t *testing.T) {
 		event := NewEvent("connection.opened", map[string]any{
 			"data": map[string]any{
 				"direction":      "egress",
 				"l7Protocol":     "http2",
 				"socketProtocol": "tcp",
 				"source": map[string]any{
-					"pid":      float64(1234),
 					"hostname": "web-server",
 					"exe":      "/usr/bin/curl",
 					"address":  map[string]any{"ip": "192.168.1.1", "port": float64(8080)},
+					"container": map[string]any{
+						"name": "my-container",
+						"id":   "abc123",
+					},
 				},
 				"destination": map[string]any{
 					"address": map[string]any{"ip": "10.0.0.1", "port": float64(443)},
+					"domain":  "api.example.com",
 				},
 			},
 		})
 
 		kv := buildEventKV(event, nil)
 
-		assertKVValue(t, kv, "connection.direction", "egress")
-		assertKVValue(t, kv, "connection.protocol", "http2")
-		assertKVValue(t, kv, "connection.socketProtocol", "tcp")
-		assertKVValue(t, kv, "connection.srcIp", "192.168.1.1")
-		assertKVValue(t, kv, "connection.srcPort", float64(8080))
-		assertKVValue(t, kv, "connection.dstIp", "10.0.0.1")
-		assertKVValue(t, kv, "connection.dstPort", float64(443))
-		assertKVValue(t, kv, "process.pid", float64(1234))
-		assertKVValue(t, kv, "process.hostname", "web-server")
-		assertKVValue(t, kv, "process.path", "/usr/bin/curl")
-		assertKVValue(t, kv, "process.binary", "curl")
+		// Native connection fields
+		assertKVValue(t, kv, "direction", "egress")
+		assertKVValue(t, kv, "protocol", "http2")
+		assertKVValue(t, kv, "type", "tcp")
+
+		// src.* nested
+		assertNestedKVValue(t, kv, "src", "ip", "192.168.1.1")
+		assertNestedKVValue(t, kv, "src", "port", float64(8080))
+
+		// dst.* nested
+		assertNestedKVValue(t, kv, "dst", "ip", "10.0.0.1")
+		assertNestedKVValue(t, kv, "dst", "port", float64(443))
+		assertNestedKVValue(t, kv, "dst", "domain", "api.example.com")
+
+		// Relational process.* from source
+		assertNestedKVValue(t, kv, "process", "hostname", "web-server")
+		assertNestedKVValue(t, kv, "process", "path", "/usr/bin/curl")
+		assertNestedKVValue(t, kv, "process", "binary", "curl")
+
+		// Container at root (native to connection via source)
+		assertNestedKVValue(t, kv, "container", "name", "my-container")
+		assertNestedKVValue(t, kv, "container", "id", "abc123")
 	})
 
-	t.Run("request event", func(t *testing.T) {
+	t.Run("request event - native http fields", func(t *testing.T) {
 		event := NewEvent("request.created", map[string]any{
 			"data": map[string]any{
-				"method":        "POST",
-				"status":        200,
-				"path":          "/api/users",
-				"url":           "https://api.example.com/api/users",
-				"direction":     "egress",
-				"duration":      150,
-				"bytesSent":     1024,
-				"bytesReceived": 2048,
-				"connectionId":  "conn-123",
-				"requestId":     "req-456",
+				"method":       "POST",
+				"status":       200,
+				"path":         "/api/users",
+				"url":          "https://api.example.com/api/users",
+				"connectionId": "conn-123",
 			},
 		})
 
 		kv := buildEventKV(event, nil)
 
-		assertKVValue(t, kv, "http.method", "POST")
-		assertKVValue(t, kv, "http.status", 200)
-		assertKVValue(t, kv, "http.path", "/api/users")
-		assertKVValue(t, kv, "http.url", "https://api.example.com/api/users")
-		assertKVValue(t, kv, "http.domain", "api.example.com")
-		assertKVValue(t, kv, "http.direction", "egress")
-		assertKVValue(t, kv, "http.duration", 150)
-		assertKVValue(t, kv, "http.bytesSent", 1024)
-		assertKVValue(t, kv, "http.bytesReceived", 2048)
-		assertKVValue(t, kv, "http.connectionId", "conn-123")
-		assertKVValue(t, kv, "http.requestId", "req-456")
+		// Native HTTP fields - req.* and res.*
+		assertNestedKVValue(t, kv, "req", "method", "POST")
+		assertNestedKVValue(t, kv, "req", "path", "/api/users")
+		assertNestedKVValue(t, kv, "req", "url", "https://api.example.com/api/users")
+		assertNestedKVValue(t, kv, "req", "host", "api.example.com")
+		assertNestedKVValue(t, kv, "res", "status", 200)
 	})
 
 	t.Run("http_transaction summary event", func(t *testing.T) {
@@ -645,33 +656,73 @@ func TestBuildEventKV(t *testing.T) {
 				"connectionId": "abc123",
 				"type":         "http_transaction",
 				"summary": map[string]any{
-					"request_host":     "api.slack.com",
-					"request_method":   "POST",
-					"response_status":  float64(200),
-					"request_path":     "/api/chat.postMessage",
-					"direction":        "egress-external",
-					"request_protocol": "http2",
-					"request_scheme":   "https",
-					"connection_id":    "abc123",
-					"container_name":   "myapp",
-					"container_image":  "myapp:latest",
-					"process_exe":      "/usr/bin/node",
+					"request_host":    "api.slack.com",
+					"request_method":  "POST",
+					"response_status": float64(200),
+					"request_path":    "/api/chat.postMessage",
 				},
 			},
 		})
 
 		kv := buildEventKV(event, nil)
 
-		assertKVValue(t, kv, "http.domain", "api.slack.com")
-		assertKVValue(t, kv, "http.method", "POST")
-		assertKVValue(t, kv, "http.status", float64(200))
-		assertKVValue(t, kv, "http.path", "/api/chat.postMessage")
-		assertKVValue(t, kv, "http.direction", "egress-external")
-		assertKVValue(t, kv, "http.protocol", "http2")
-		assertKVValue(t, kv, "http.scheme", "https")
-		assertKVValue(t, kv, "process.container", "myapp")
-		assertKVValue(t, kv, "process.containerImage", "myapp:latest")
-		assertKVValue(t, kv, "process.binary", "/usr/bin/node")
+		// HTTP fields from summary format
+		assertNestedKVValue(t, kv, "req", "host", "api.slack.com")
+		assertNestedKVValue(t, kv, "req", "method", "POST")
+		assertNestedKVValue(t, kv, "req", "path", "/api/chat.postMessage")
+		assertNestedKVValue(t, kv, "res", "status", float64(200))
+	})
+
+	t.Run("request event with cache - relational fields populated", func(t *testing.T) {
+		cache := NewConnectionCache(100)
+		cache.Set("conn-123", map[string]any{
+			"direction":  "egress",
+			"l7Protocol": "http2",
+			"source": map[string]any{
+				"hostname": "web-server",
+				"exe":      "/usr/bin/curl",
+				"container": map[string]any{
+					"name": "nginx",
+					"pod": map[string]any{
+						"name":      "web-pod",
+						"namespace": "production",
+					},
+				},
+			},
+			"destination": map[string]any{
+				"address": map[string]any{"ip": "10.0.0.1", "port": float64(443)},
+				"domain":  "api.example.com",
+			},
+		})
+
+		event := NewEvent("request.created", map[string]any{
+			"data": map[string]any{
+				"method":       "GET",
+				"status":       200,
+				"connectionId": "conn-123",
+			},
+		})
+
+		kv := buildEventKV(event, cache)
+
+		// Native HTTP fields
+		assertNestedKVValue(t, kv, "req", "method", "GET")
+		assertNestedKVValue(t, kv, "res", "status", 200)
+
+		// Relational connection fields from cache
+		assertKVValue(t, kv, "direction", "egress")
+		assertKVValue(t, kv, "protocol", "http2")
+		assertNestedKVValue(t, kv, "dst", "port", float64(443))
+		assertNestedKVValue(t, kv, "dst", "domain", "api.example.com")
+
+		// Relational process fields from cache
+		assertNestedKVValue(t, kv, "process", "hostname", "web-server")
+		assertNestedKVValue(t, kv, "process", "binary", "curl")
+
+		// Container and pod from cache
+		assertNestedKVValue(t, kv, "container", "name", "nginx")
+		assertNestedKVValue(t, kv, "pod", "name", "web-pod")
+		assertNestedKVValue(t, kv, "pod", "namespace", "production")
 	})
 }
 
@@ -684,19 +735,19 @@ func TestRegexMatching(t *testing.T) {
 	}{
 		{
 			name:  "path matches regex",
-			expr:  "http.path matches /api\\/v[0-9]+/",
+			expr:  "req.path matches /api\\/v[0-9]+/",
 			event: NewEvent("request.created", map[string]any{"data": map[string]any{"path": "/api/v2/users"}}),
 			want:  true,
 		},
 		{
 			name:  "path does not match regex",
-			expr:  "http.path matches /api\\/v[0-9]+/",
+			expr:  "req.path matches /api\\/v[0-9]+/",
 			event: NewEvent("request.created", map[string]any{"data": map[string]any{"path": "/api/users"}}),
 			want:  false,
 		},
 		{
-			name:  "domain matches regex",
-			expr:  "http.domain matches /\\.example\\.com$/",
+			name:  "host matches regex",
+			expr:  "req.host matches /\\.example\\.com$/",
 			event: NewEvent("request.created", map[string]any{"data": map[string]any{"url": "https://api.example.com/test"}}),
 			want:  true,
 		},
@@ -726,19 +777,19 @@ func TestCustomFunctions(t *testing.T) {
 	}{
 		{
 			name:  "in_zone - exact match",
-			expr:  "in_zone(http.domain, 'example.com')",
+			expr:  "in_zone(req.host, 'example.com')",
 			event: NewEvent("request.created", map[string]any{"data": map[string]any{"url": "https://example.com/test"}}),
 			want:  true,
 		},
 		{
 			name:  "in_zone - subdomain match",
-			expr:  "in_zone(http.domain, 'example.com')",
+			expr:  "in_zone(req.host, 'example.com')",
 			event: NewEvent("request.created", map[string]any{"data": map[string]any{"url": "https://api.example.com/test"}}),
 			want:  true,
 		},
 		{
 			name:  "in_zone - no match",
-			expr:  "in_zone(http.domain, 'example.com')",
+			expr:  "in_zone(req.host, 'example.com')",
 			event: NewEvent("request.created", map[string]any{"data": map[string]any{"url": "https://other.com/test"}}),
 			want:  false,
 		},
@@ -759,7 +810,7 @@ func TestCustomFunctions(t *testing.T) {
 	}
 }
 
-// Helper function to assert KV values
+// Helper function to assert KV values at root level
 func assertKVValue(t *testing.T, kv rulekit.KV, key string, want any) {
 	t.Helper()
 	got, ok := kv[key]
@@ -769,5 +820,28 @@ func assertKVValue(t *testing.T, kv rulekit.KV, key string, want any) {
 	}
 	if got != want {
 		t.Errorf("KV[%q] = %v (%T), want %v (%T)", key, got, got, want, want)
+	}
+}
+
+// Helper function to assert nested KV values (e.g., req.method, container.name)
+func assertNestedKVValue(t *testing.T, kv rulekit.KV, parent, key string, want any) {
+	t.Helper()
+	parentVal, ok := kv[parent]
+	if !ok {
+		t.Errorf("parent key %q not found in KV", parent)
+		return
+	}
+	parentMap, ok := parentVal.(map[string]any)
+	if !ok {
+		t.Errorf("KV[%q] is not a map, got %T", parent, parentVal)
+		return
+	}
+	got, ok := parentMap[key]
+	if !ok {
+		t.Errorf("key %q not found in KV[%q]", key, parent)
+		return
+	}
+	if got != want {
+		t.Errorf("KV[%q][%q] = %v (%T), want %v (%T)", parent, key, got, got, want, want)
 	}
 }

--- a/pkg/devtools/manager.go
+++ b/pkg/devtools/manager.go
@@ -27,14 +27,28 @@ type Manager struct {
 	eventStore         *EventStoreFactory
 	objectStore        *ObjectStoreFactory
 	processSnapshotter ProcessSnapshotter
+	connectionCache    *ConnectionCache
 	mu                 sync.RWMutex
-	clients            map[chan<- *Event]map[string]struct{}
+	clients            map[chan<- *Event]*ClientSubscription
+}
+
+// topicAliases maps topic aliases to their canonical names.
+// This allows users to use "http" as a topic which maps to "request" events.
+var topicAliases = map[string]string{
+	"http": "request",
+}
+
+// ClientSubscription holds subscription information for a connected client
+type ClientSubscription struct {
+	Topics map[string]struct{} // legacy topic filtering (for backward compat)
+	Filter *EventFilter        // structured filtering via query params
 }
 
 func NewManager(opts ...ManagerOpt) *Manager {
 	m := &Manager{
-		logger:  zap.L(),
-		clients: make(map[chan<- *Event]map[string]struct{}),
+		logger:          zap.L(),
+		clients:         make(map[chan<- *Event]*ClientSubscription),
+		connectionCache: NewConnectionCache(DefaultCacheMaxSize),
 	}
 	m.eventStore = &EventStoreFactory{broadcast: m.broadcast}
 	m.objectStore = &ObjectStoreFactory{broadcast: m.broadcast}
@@ -80,8 +94,9 @@ func (m *Manager) RegisterRoutes(mux *http.ServeMux, prefix string) error {
 }
 
 type APIEventsRequest struct {
-	FilterTopics        []string `json:"filter_topics,omitempty"`
-	SkipProcessSnapshot bool     `json:"skip_process_snapshot,omitempty"`
+	FilterTopics        []string          `json:"filter_topics,omitempty"`
+	Filters             map[string]string `json:"filters,omitempty"`
+	SkipProcessSnapshot bool              `json:"skip_process_snapshot,omitempty"`
 }
 
 func (m *Manager) routeAPIEvents(w http.ResponseWriter, r *http.Request) {
@@ -111,21 +126,54 @@ func (m *Manager) routeAPIEvents(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Parse topics: query params override body
+	topics := req.FilterTopics
+	if topicsParam := r.URL.Query().Get("topics"); topicsParam != "" {
+		topics = strings.Split(topicsParam, ",")
+		// Trim whitespace from each topic
+		for i, t := range topics {
+			topics[i] = strings.TrimSpace(t)
+		}
+	}
+
+	// Parse filters: start with body, then merge/override with query params
+	var filter *EventFilter
+	var err error
+
+	// First, parse from body if present
+	if len(req.Filters) > 0 {
+		filter, err = ParseFiltersFromBody(req.Filters)
+		if err != nil {
+			httpError(ll, w, fmt.Errorf("parsing body filters: %w", err), http.StatusBadRequest)
+			return
+		}
+	}
+
+	// Then, parse from query params (overrides body)
+	queryFilter, err := ParseFilters(r.URL.Query())
+	if err != nil {
+		httpError(ll, w, fmt.Errorf("parsing query filters: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	// Merge: query params override body
+	filter = MergeFilters(filter, queryFilter)
+
 	// init SSE
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
 	w.WriteHeader(http.StatusOK)
 	writeEvent(ll, w, NewEvent("system.connected", map[string]any{
-		"topics": req.FilterTopics,
+		"topics": topics,
 	}))
 	ll.Debug("client connected",
-		zap.Any("topics", req.FilterTopics),
+		zap.Any("topics", topics),
 		zap.Int("total_connected_clients", m.clientCount()+1),
 	)
 
 	// subscribe to events
-	events := m.SubscribeClient(r.Context(), req.FilterTopics, !req.SkipProcessSnapshot)
+	events := m.SubscribeClient(r.Context(), topics, filter, !req.SkipProcessSnapshot)
 	for {
 		select {
 		case <-r.Context().Done():
@@ -205,6 +253,9 @@ func writeEvent(ll *zap.Logger, w http.ResponseWriter, event *Event) {
 }
 
 func (m *Manager) broadcast(event *Event) {
+	// Update connection cache for cross-entity filtering
+	m.updateConnectionCache(event)
+
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
@@ -213,13 +264,18 @@ func (m *Manager) broadcast(event *Event) {
 	}
 
 	topLevelTopic := event.TopLevelTopic()
-	for client, topics := range m.clients {
-		// skip if client is not subscribed to the topic
+	for client, sub := range m.clients {
+		// skip if client is not subscribed to the topic (legacy topic filtering)
 		// `system` topic events will be broadcast to all clients regardless of filtering
-		if topLevelTopic != "" && topLevelTopic != "system" && len(topics) > 0 {
-			if _, ok := topics[topLevelTopic]; !ok {
+		if topLevelTopic != "" && topLevelTopic != "system" && len(sub.Topics) > 0 {
+			if _, ok := sub.Topics[topLevelTopic]; !ok {
 				continue
 			}
+		}
+
+		// Apply structured filter if present (with cache for cross-entity lookups)
+		if sub.Filter != nil && !sub.Filter.Matches(event, m.connectionCache) {
+			continue
 		}
 
 		select {
@@ -231,16 +287,83 @@ func (m *Manager) broadcast(event *Event) {
 	}
 }
 
-func (m *Manager) sendProcessSnapshot(ctx context.Context, ch chan<- *Event) {
+// updateConnectionCache maintains the connection cache for cross-entity filtering
+func (m *Manager) updateConnectionCache(event *Event) {
+	// Only process connection events
+	if !strings.HasPrefix(event.Topic, "connection.") {
+		return
+	}
+
+	data, ok := event.Data.(map[string]any)
+	if !ok {
+		return
+	}
+
+	// Connection data is nested under "data" key
+	innerData, ok := data["data"]
+	if !ok {
+		return
+	}
+
+	// Handle both struct and map types
+	var connId string
+	var connData map[string]any
+
+	switch d := innerData.(type) {
+	case map[string]any:
+		connData = d
+		if meta, ok := d["meta"].(map[string]any); ok {
+			connId, _ = meta["connectionId"].(string)
+		} else {
+			connId, _ = d["connectionId"].(string)
+		}
+	default:
+		// For struct types, we need to extract via JSON marshaling
+		// This handles *eventstore.Connection
+		jsonBytes, err := json.Marshal(innerData)
+		if err != nil {
+			return
+		}
+		if err := json.Unmarshal(jsonBytes, &connData); err != nil {
+			return
+		}
+		if meta, ok := connData["meta"].(map[string]any); ok {
+			connId, _ = meta["connectionId"].(string)
+		} else {
+			connId, _ = connData["connectionId"].(string)
+		}
+	}
+
+	if connId == "" {
+		return
+	}
+
+	switch event.Topic {
+	case "connection.opened", "connection.updated":
+		m.connectionCache.Set(connId, connData)
+	case "connection.closed":
+		// Remove from cache - connection is done, no more requests expected
+		m.connectionCache.Delete(connId)
+	}
+}
+
+func (m *Manager) sendProcessSnapshot(ctx context.Context, ch chan<- *Event, filter *EventFilter) {
 	if m.processSnapshotter == nil {
 		return
 	}
 
 	m.processSnapshotter.SnapshotProcesses(func(pid int, p *process.Process) bool {
+		event := NewEvent("process.started", marshalProcess(p))
+
+		// Apply filter if present (no cache needed for process events)
+		if filter != nil && !filter.Matches(event, nil) {
+			return true // continue to next process
+		}
+
 		select {
 		case <-ctx.Done():
 			return false
-		case ch <- NewEvent("process.started", marshalProcess(p)):
+		case ch <- event:
 		default:
 			m.logger.Warn("client buffer is full, stopping process snapshot")
 			return false
@@ -249,21 +372,28 @@ func (m *Manager) sendProcessSnapshot(ctx context.Context, ch chan<- *Event) {
 	})
 }
 
-func (m *Manager) SubscribeClient(ctx context.Context, topics []string, sendProcessSnapshot bool) <-chan *Event {
+func (m *Manager) SubscribeClient(ctx context.Context, topics []string, filter *EventFilter, sendProcessSnapshot bool) <-chan *Event {
 	topicsMap := make(map[string]struct{}, len(topics))
 	for _, topic := range topics {
+		// Normalize topic aliases (e.g., "http" -> "request")
+		if canonical, ok := topicAliases[topic]; ok {
+			topic = canonical
+		}
 		topicsMap[topic] = struct{}{}
 	}
 
 	ch := make(chan *Event, 100)
 
 	m.mu.Lock()
-	m.clients[ch] = topicsMap
+	m.clients[ch] = &ClientSubscription{
+		Topics: topicsMap,
+		Filter: filter,
+	}
 	m.mu.Unlock()
 
 	// send a snapshot of the current processes if subscribed
 	if sendProcessSnapshot && (len(topics) == 0 || slices.Contains(topics, "process")) {
-		go m.sendProcessSnapshot(ctx, ch)
+		go m.sendProcessSnapshot(ctx, ch, filter)
 	}
 
 	// unsubscribe on ctx done

--- a/pkg/devtools/manager.go
+++ b/pkg/devtools/manager.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"io/fs"
 	"net/http"
-	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -32,16 +31,9 @@ type Manager struct {
 	clients            map[chan<- *Event]*ClientSubscription
 }
 
-// topicAliases maps topic aliases to their canonical names.
-// This allows users to use "http" as a topic which maps to "request" events.
-var topicAliases = map[string]string{
-	"http": "request",
-}
-
 // ClientSubscription holds subscription information for a connected client
 type ClientSubscription struct {
-	Topics map[string]struct{} // legacy topic filtering (for backward compat)
-	Filter *EventFilter        // structured filtering via query params
+	TopicFilters map[string]*EventFilter // topic -> compiled filter (nil = "*" = match all)
 }
 
 func NewManager(opts ...ManagerOpt) *Manager {
@@ -94,9 +86,8 @@ func (m *Manager) RegisterRoutes(mux *http.ServeMux, prefix string) error {
 }
 
 type APIEventsRequest struct {
-	FilterTopics        []string `json:"filter_topics,omitempty"`
-	Filter              string   `json:"filter,omitempty"` // rulekit expression
-	SkipProcessSnapshot bool     `json:"skip_process_snapshot,omitempty"`
+	Topics              map[string]string `json:"topics,omitempty"` // topic -> filter ("*" = all)
+	SkipProcessSnapshot bool              `json:"skip_process_snapshot,omitempty"`
 }
 
 func (m *Manager) routeAPIEvents(w http.ResponseWriter, r *http.Request) {
@@ -126,26 +117,28 @@ func (m *Manager) routeAPIEvents(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Parse topics: query params override body
-	topics := req.FilterTopics
-	if topicsParam := r.URL.Query().Get("topics"); topicsParam != "" {
-		topics = strings.Split(topicsParam, ",")
-		// Trim whitespace from each topic
-		for i, t := range topics {
-			topics[i] = strings.TrimSpace(t)
+	// Apply defaults if no topics specified
+	if len(req.Topics) == 0 {
+		req.Topics = map[string]string{
+			"process":    "*",
+			"connection": "*",
+			"http":       "*",
 		}
 	}
 
-	// Parse filter expression: query param overrides body
-	filterExpr := req.Filter
-	if queryFilter := r.URL.Query().Get("filter"); queryFilter != "" {
-		filterExpr = queryFilter
-	}
-
-	filter, err := ParseFilter(filterExpr)
-	if err != nil {
-		httpError(ll, w, fmt.Errorf("parsing filter expression: %w", err), http.StatusBadRequest)
-		return
+	// Parse filters for each topic
+	topicFilters := make(map[string]*EventFilter)
+	for topic, filterExpr := range req.Topics {
+		if filterExpr == "*" {
+			topicFilters[topic] = nil // nil means match all
+		} else {
+			filter, err := ParseFilter(filterExpr)
+			if err != nil {
+				httpError(ll, w, fmt.Errorf("parsing filter for topic %s: %w", topic, err), http.StatusBadRequest)
+				return
+			}
+			topicFilters[topic] = filter
+		}
 	}
 
 	// init SSE
@@ -154,15 +147,15 @@ func (m *Manager) routeAPIEvents(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Connection", "keep-alive")
 	w.WriteHeader(http.StatusOK)
 	writeEvent(ll, w, NewEvent("system.connected", map[string]any{
-		"topics": topics,
+		"topics": req.Topics,
 	}))
 	ll.Debug("client connected",
-		zap.Any("topics", topics),
+		zap.Any("topics", req.Topics),
 		zap.Int("total_connected_clients", m.clientCount()+1),
 	)
 
 	// subscribe to events
-	events := m.SubscribeClient(r.Context(), topics, filter, !req.SkipProcessSnapshot)
+	events := m.SubscribeClient(r.Context(), topicFilters, !req.SkipProcessSnapshot)
 	for {
 		select {
 		case <-r.Context().Done():
@@ -253,17 +246,31 @@ func (m *Manager) broadcast(event *Event) {
 	}
 
 	topLevelTopic := event.TopLevelTopic()
+
+	// Map event topic to subscription topic ("request" -> "http")
+	subscriptionTopic := topLevelTopic
+	if topLevelTopic == "request" {
+		subscriptionTopic = "http"
+	}
+
 	for client, sub := range m.clients {
-		// skip if client is not subscribed to the topic (legacy topic filtering)
-		// `system` topic events will be broadcast to all clients regardless of filtering
-		if topLevelTopic != "" && topLevelTopic != "system" && len(sub.Topics) > 0 {
-			if _, ok := sub.Topics[topLevelTopic]; !ok {
-				continue
+		// System events always pass through
+		if topLevelTopic == "system" {
+			select {
+			case client <- event:
+			default:
 			}
+			continue
 		}
 
-		// Apply structured filter if present (with cache for cross-entity lookups)
-		if sub.Filter != nil && !sub.Filter.Matches(event, m.connectionCache) {
+		// Check if client is subscribed to this topic
+		filter, subscribed := sub.TopicFilters[subscriptionTopic]
+		if !subscribed {
+			continue
+		}
+
+		// Apply filter if present (nil = match all)
+		if filter != nil && !filter.Matches(event, m.connectionCache) {
 			continue
 		}
 
@@ -361,28 +368,20 @@ func (m *Manager) sendProcessSnapshot(ctx context.Context, ch chan<- *Event, fil
 	})
 }
 
-func (m *Manager) SubscribeClient(ctx context.Context, topics []string, filter *EventFilter, sendProcessSnapshot bool) <-chan *Event {
-	topicsMap := make(map[string]struct{}, len(topics))
-	for _, topic := range topics {
-		// Normalize topic aliases (e.g., "http" -> "request")
-		if canonical, ok := topicAliases[topic]; ok {
-			topic = canonical
-		}
-		topicsMap[topic] = struct{}{}
-	}
-
+func (m *Manager) SubscribeClient(ctx context.Context, topicFilters map[string]*EventFilter, sendProcessSnapshot bool) <-chan *Event {
 	ch := make(chan *Event, 100)
 
 	m.mu.Lock()
 	m.clients[ch] = &ClientSubscription{
-		Topics: topicsMap,
-		Filter: filter,
+		TopicFilters: topicFilters,
 	}
 	m.mu.Unlock()
 
-	// send a snapshot of the current processes if subscribed
-	if sendProcessSnapshot && (len(topics) == 0 || slices.Contains(topics, "process")) {
-		go m.sendProcessSnapshot(ctx, ch, filter)
+	// send a snapshot of the current processes if subscribed to process topic
+	if sendProcessSnapshot {
+		if filter, ok := topicFilters["process"]; ok {
+			go m.sendProcessSnapshot(ctx, ch, filter)
+		}
 	}
 
 	// unsubscribe on ctx done

--- a/pkg/devtools/manager.go
+++ b/pkg/devtools/manager.go
@@ -94,9 +94,9 @@ func (m *Manager) RegisterRoutes(mux *http.ServeMux, prefix string) error {
 }
 
 type APIEventsRequest struct {
-	FilterTopics        []string          `json:"filter_topics,omitempty"`
-	Filters             map[string]string `json:"filters,omitempty"`
-	SkipProcessSnapshot bool              `json:"skip_process_snapshot,omitempty"`
+	FilterTopics        []string `json:"filter_topics,omitempty"`
+	Filter              string   `json:"filter,omitempty"` // rulekit expression
+	SkipProcessSnapshot bool     `json:"skip_process_snapshot,omitempty"`
 }
 
 func (m *Manager) routeAPIEvents(w http.ResponseWriter, r *http.Request) {
@@ -136,28 +136,17 @@ func (m *Manager) routeAPIEvents(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Parse filters: start with body, then merge/override with query params
-	var filter *EventFilter
-	var err error
-
-	// First, parse from body if present
-	if len(req.Filters) > 0 {
-		filter, err = ParseFiltersFromBody(req.Filters)
-		if err != nil {
-			httpError(ll, w, fmt.Errorf("parsing body filters: %w", err), http.StatusBadRequest)
-			return
-		}
+	// Parse filter expression: query param overrides body
+	filterExpr := req.Filter
+	if queryFilter := r.URL.Query().Get("filter"); queryFilter != "" {
+		filterExpr = queryFilter
 	}
 
-	// Then, parse from query params (overrides body)
-	queryFilter, err := ParseFilters(r.URL.Query())
+	filter, err := ParseFilter(filterExpr)
 	if err != nil {
-		httpError(ll, w, fmt.Errorf("parsing query filters: %w", err), http.StatusBadRequest)
+		httpError(ll, w, fmt.Errorf("parsing filter expression: %w", err), http.StatusBadRequest)
 		return
 	}
-
-	// Merge: query params override body
-	filter = MergeFilters(filter, queryFilter)
 
 	// init SSE
 	w.Header().Set("Content-Type", "text/event-stream")


### PR DESCRIPTION
## Summary

Adds server-side filtering to the devtools events endpoint using [rulekit](https://github.com/qpoint-io/rulekit) expressions, allowing clients to subscribe only to the events they care about. This reduces client-side processing and eliminates unnecessary bandwidth.

## API Structure

Subscribe to topics with optional per-topic filters via JSON payload:

```json
{
  "topics": {
    "process": "*",
    "connection": "*",
    "http": "res.status >= 400"
  }
}
```

### Semantics

- **Include topic with `"*"`**: Subscribe to all events of that type
- **Include topic with filter**: Subscribe to filtered events of that type
- **Omit topic**: Don't receive events of that type
- **Empty payload**: Default to subscribing to all topics with `"*"`

## Example Usage

```bash
# Subscribe to all events (default)
curl -X POST "http://localhost:10001/devtools/api/events" \
  -H "Content-Type: application/json" \
  -d '{}'

# Subscribe only to HTTP errors
curl -X POST "http://localhost:10001/devtools/api/events" \
  -H "Content-Type: application/json" \
  -d '{"topics": {"http": "res.status >= 400"}}'

# Subscribe to HTTP events from a specific container
curl -X POST "http://localhost:10001/devtools/api/events" \
  -H "Content-Type: application/json" \
  -d '{"topics": {"http": "container.name == '\''nginx'\'' AND res.status >= 400"}}'

# Subscribe to connections on port 443 only
curl -X POST "http://localhost:10001/devtools/api/events" \
  -H "Content-Type: application/json" \
  -d '{"topics": {"connection": "dst.port == 443"}}'

# Filter by process binary name
curl -X POST "http://localhost:10001/devtools/api/events" \
  -H "Content-Type: application/json" \
  -d '{"topics": {"process": "binary == '\''nginx'\''"}}'

# Multiple topics with different filters
curl -X POST "http://localhost:10001/devtools/api/events" \
  -H "Content-Type: application/json" \
  -d '{"topics": {"process": "*", "http": "res.status >= 400"}}'

# Filter connections by relational process info
curl -X POST "http://localhost:10001/devtools/api/events" \
  -H "Content-Type: application/json" \
  -d '{"topics": {"connection": "process.binary == '\''curl'\'' AND dst.port == 443"}}'
```

## Filter Fields Per Topic

Native properties (belonging to the event type) have no prefix. Relational properties (from associated entities) are prefixed.

### Process Topic

Native properties - no prefix needed.

| Field | Description |
|-------|-------------|
| `binary` | Process executable name |
| `path` | Full executable path |
| `hostname` | Process hostname |
| `user.name` | Username |
| `user.id` | User ID |
| `container.name` | Container name |
| `container.id` | Container ID |
| `container.image` | Container image |
| `container.labels.<key>` | Container labels |
| `pod.name` | Pod name |
| `pod.namespace` | Pod namespace |
| `pod.labels.<key>` | Pod labels |

### Connection Topic

Native connection properties + relational `process.*` fields.

| Field | Description |
|-------|-------------|
| `direction` | Connection direction (egress, ingress) |
| `protocol` | L7 protocol (http, http2, etc.) |
| `type` | Socket type (tcp, udp) |
| `src.ip` | Source IP address |
| `src.port` | Source port |
| `dst.ip` | Destination IP address |
| `dst.port` | Destination port |
| `dst.domain` | Destination domain |
| `tls.enabled` | TLS enabled |
| `tls.version` | TLS version |
| `tls.sni` | TLS SNI |
| `process.binary` | Process executable name |
| `process.path` | Full executable path |
| `process.hostname` | Process hostname |
| `process.user.name` | Username |
| `process.user.id` | User ID |
| `container.name` | Container name |
| `container.id` | Container ID |
| `container.image` | Container image |
| `container.labels.<key>` | Container labels |
| `pod.name` | Pod name |
| `pod.namespace` | Pod namespace |
| `pod.labels.<key>` | Pod labels |

### HTTP Topic

Native HTTP properties (`req.*`/`res.*`) + relational connection/process fields.

| Field | Description |
|-------|-------------|
| `req.method` | HTTP method (GET, POST, etc.) |
| `req.path` | Request path |
| `req.host` | Request host |
| `req.url` | Full URL |
| `res.status` | Response status code |
| `direction` | Connection direction |
| `protocol` | L7 protocol |
| `src.ip` | Source IP address |
| `src.port` | Source port |
| `dst.ip` | Destination IP address |
| `dst.port` | Destination port |
| `dst.domain` | Destination domain |
| `tls.enabled` | TLS enabled |
| `tls.version` | TLS version |
| `tls.sni` | TLS SNI |
| `process.binary` | Process executable name |
| `process.path` | Full executable path |
| `process.hostname` | Process hostname |
| `process.user.name` | Username |
| `process.user.id` | User ID |
| `container.name` | Container name |
| `container.id` | Container ID |
| `container.image` | Container image |
| `container.labels.<key>` | Container labels |
| `pod.name` | Pod name |
| `pod.namespace` | Pod namespace |
| `pod.labels.<key>` | Pod labels |

## Supported Operators

| Operator | Description | Example |
|----------|-------------|---------|
| `==` | Equals | `res.status == 200` |
| `!=` | Not equals | `req.method != "GET"` |
| `>`, `>=` | Greater than (or equal) | `res.status >= 400` |
| `<`, `<=` | Less than (or equal) | `res.status < 500` |
| `contains` | String contains | `req.path contains "/api/"` |
| `matches` | Regex match | `req.path matches /api\/v[0-9]+/` |
| `in` | In array/CIDR | `dst.ip in 10.0.0.0/8` |
| `AND` | Logical AND | `res.status >= 400 AND req.method == "POST"` |
| `OR` | Logical OR | `req.method == "GET" OR req.method == "POST"` |
| `NOT` | Logical NOT | `NOT res.status == 404` |

## Custom Functions

| Function | Description | Example |
|----------|-------------|---------|
| `in_zone(domain, zone)` | Check if domain is in zone | `in_zone(req.host, "example.com")` |
| `zone(domain)` | Extract effective TLD+1 | `zone(req.host) == "example.com"` |

## Cross-Entity Filtering

Filters can apply across related entities. For example, filtering HTTP events by `container.name == "nginx"` will match HTTP requests from that container via connection cache lookup.

Connection and process data is cached and looked up for HTTP events using the `connectionId`, enabling filters like:

```
process.binary == 'curl' AND res.status >= 400
```
