### PR TITLE
Add S3 object store support with IAM credentials and integration tests

### DIFF
--- a/pkg/config/objectstore_test.go
+++ b/pkg/config/objectstore_test.go
@@ -67,6 +67,25 @@ func TestObjectStoreUnmarshal(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:     "s3 objectstore with IAM",
+			filename: "testdata/objectstore_s3_iam.yaml",
+			want: ServiceObjectStore{
+				Type: ObjectStoreType_S3,
+				ID:   "s3-iam-store",
+				ObjectStoreConfig: ObjectStoreConfig{
+					ObjectStoreS3Config: ObjectStoreS3Config{
+						Endpoint: "s3.amazonaws.com",
+						Bucket:   "my-iam-bucket",
+						Region:   "us-west-2",
+						// AccessKey and SecretKey should be zero values (empty)
+						AccessKey: ValueSource{},
+						SecretKey: ValueSource{},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name:     "disabled objectstore",
 			filename: "testdata/objectstore_disabled.yaml",
 			want: ServiceObjectStore{

--- a/pkg/config/testdata/objectstore_s3_iam.yaml
+++ b/pkg/config/testdata/objectstore_s3_iam.yaml
@@ -1,0 +1,6 @@
+type: s3
+id: s3-iam-store
+endpoint: s3.amazonaws.com
+bucket: my-iam-bucket
+region: us-west-2
+# access_key and secret_key intentionally omitted for IAM auth

--- a/pkg/services/objectstore/s3/factory.go
+++ b/pkg/services/objectstore/s3/factory.go
@@ -60,17 +60,42 @@ func (f *Factory) Init(ctx context.Context, cfg any) error {
 	if c.ObjectStoreS3Config.AccessURL != "" {
 		f.accessURL = c.ObjectStoreS3Config.AccessURL
 	}
-	if c.ObjectStoreS3Config.AccessKey.String() == "" {
-		if c.ObjectStoreS3Config.AccessKey.Type == config.ValueSourceType_ENV {
-			return fmt.Errorf("s3 access key env var (%s) is empty or not set", c.ObjectStoreS3Config.AccessKey.Value)
+
+	// Check if credentials are provided
+	accessKey := c.ObjectStoreS3Config.AccessKey.String()
+	secretKey := c.ObjectStoreS3Config.SecretKey.String()
+
+	// Both credentials must be provided together, or both omitted
+	hasAccessKey := accessKey != ""
+	hasSecretKey := secretKey != ""
+
+	if hasAccessKey != hasSecretKey {
+		// One is provided but not the other - this is an error
+		if hasAccessKey {
+			return errors.New("secret_key is required when access_key is provided")
 		}
-		return errors.New("access_key is required")
+		return errors.New("access_key is required when secret_key is provided")
 	}
-	if c.ObjectStoreS3Config.SecretKey.String() == "" {
-		if c.ObjectStoreS3Config.SecretKey.Type == config.ValueSourceType_ENV {
-			return fmt.Errorf("s3 secret key env var (%s) is empty or not set", c.ObjectStoreS3Config.SecretKey.Value)
-		}
-		return errors.New("secret_key is required")
+
+	// If AccessKey has type ENV but the env var is empty, that's a config error
+	if c.ObjectStoreS3Config.AccessKey.Type == config.ValueSourceType_ENV &&
+		c.ObjectStoreS3Config.AccessKey.Value != "" &&
+		accessKey == "" {
+		return fmt.Errorf("s3 access key env var (%s) is empty or not set", c.ObjectStoreS3Config.AccessKey.Value)
+	}
+
+	// If SecretKey has type ENV but the env var is empty, that's a config error
+	if c.ObjectStoreS3Config.SecretKey.Type == config.ValueSourceType_ENV &&
+		c.ObjectStoreS3Config.SecretKey.Value != "" &&
+		secretKey == "" {
+		return fmt.Errorf("s3 secret key env var (%s) is empty or not set", c.ObjectStoreS3Config.SecretKey.Value)
+	}
+
+	// Log the credential mode being used
+	if hasAccessKey && hasSecretKey {
+		f.logger.Debug("using explicit S3 credentials from config")
+	} else {
+		f.logger.Debug("no explicit S3 credentials configured, will use IAM credential chain")
 	}
 
 	s, err := minio.NewS3ObjectStore(
@@ -78,8 +103,8 @@ func (f *Factory) Init(ctx context.Context, cfg any) error {
 		c.ObjectStoreS3Config.Endpoint,
 		c.ObjectStoreS3Config.Bucket,
 		c.ObjectStoreS3Config.Region,
-		c.ObjectStoreS3Config.AccessKey.String(),
-		c.ObjectStoreS3Config.SecretKey.String(),
+		accessKey,
+		secretKey,
 		c.ObjectStoreS3Config.Insecure)
 	if err != nil {
 		return fmt.Errorf("failed to create s3 object store: %w", err)

--- a/pkg/services/objectstore/s3/factory_test.go
+++ b/pkg/services/objectstore/s3/factory_test.go
@@ -1,0 +1,253 @@
+package s3
+
+import (
+	"testing"
+
+	"github.com/qpoint-io/qtap/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestFactory_Init_WithStaticCredentials(t *testing.T) {
+	// Set up logger for factory
+	logger := zaptest.NewLogger(t)
+	oldLogger := zap.L()
+	defer zap.ReplaceGlobals(oldLogger)
+	zap.ReplaceGlobals(logger)
+
+	f := &Factory{}
+	cfg := config.ServiceObjectStore{
+		Type: config.ObjectStoreType_S3,
+		ObjectStoreConfig: config.ObjectStoreConfig{
+			ObjectStoreS3Config: config.ObjectStoreS3Config{
+				Bucket: "test-bucket",
+				Region: "us-east-1",
+				AccessKey: config.ValueSource{
+					Type:  config.ValueSourceType_TEXT,
+					Value: "test-access-key",
+				},
+				SecretKey: config.ValueSource{
+					Type:  config.ValueSourceType_TEXT,
+					Value: "test-secret-key",
+				},
+			},
+		},
+	}
+
+	err := f.Init(t.Context(), cfg)
+	require.NoError(t, err)
+	assert.NotNil(t, f.objectstore)
+}
+
+func TestFactory_Init_WithIAMCredentials(t *testing.T) {
+	// Set up logger for factory
+	logger := zaptest.NewLogger(t)
+	oldLogger := zap.L()
+	defer zap.ReplaceGlobals(oldLogger)
+	zap.ReplaceGlobals(logger)
+
+	// Set up environment variables to simulate IAM credentials available
+	t.Setenv("AWS_ACCESS_KEY_ID", "test-aws-key")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "test-aws-secret")
+
+	f := &Factory{}
+	cfg := config.ServiceObjectStore{
+		Type: config.ObjectStoreType_S3,
+		ObjectStoreConfig: config.ObjectStoreConfig{
+			ObjectStoreS3Config: config.ObjectStoreS3Config{
+				Bucket: "test-bucket",
+				Region: "us-east-1",
+				// AccessKey and SecretKey omitted - should use IAM credential chain
+			},
+		},
+	}
+
+	err := f.Init(t.Context(), cfg)
+	require.NoError(t, err)
+	assert.NotNil(t, f.objectstore)
+}
+
+func TestFactory_Init_PartialCredentials_OnlyAccessKey(t *testing.T) {
+	// Set up logger for factory
+	logger := zaptest.NewLogger(t)
+	oldLogger := zap.L()
+	defer zap.ReplaceGlobals(oldLogger)
+	zap.ReplaceGlobals(logger)
+
+	f := &Factory{}
+	cfg := config.ServiceObjectStore{
+		Type: config.ObjectStoreType_S3,
+		ObjectStoreConfig: config.ObjectStoreConfig{
+			ObjectStoreS3Config: config.ObjectStoreS3Config{
+				Bucket: "test-bucket",
+				Region: "us-east-1",
+				AccessKey: config.ValueSource{
+					Type:  config.ValueSourceType_TEXT,
+					Value: "test-access-key",
+				},
+				// SecretKey omitted
+			},
+		},
+	}
+
+	err := f.Init(t.Context(), cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "secret_key is required when access_key is provided")
+}
+
+func TestFactory_Init_PartialCredentials_OnlySecretKey(t *testing.T) {
+	// Set up logger for factory
+	logger := zaptest.NewLogger(t)
+	oldLogger := zap.L()
+	defer zap.ReplaceGlobals(oldLogger)
+	zap.ReplaceGlobals(logger)
+
+	f := &Factory{}
+	cfg := config.ServiceObjectStore{
+		Type: config.ObjectStoreType_S3,
+		ObjectStoreConfig: config.ObjectStoreConfig{
+			ObjectStoreS3Config: config.ObjectStoreS3Config{
+				Bucket: "test-bucket",
+				Region: "us-east-1",
+				SecretKey: config.ValueSource{
+					Type:  config.ValueSourceType_TEXT,
+					Value: "test-secret-key",
+				},
+				// AccessKey omitted
+			},
+		},
+	}
+
+	err := f.Init(t.Context(), cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "access_key is required when secret_key is provided")
+}
+
+func TestFactory_Init_EmptyEnvVar(t *testing.T) {
+	// Set up logger for factory
+	logger := zaptest.NewLogger(t)
+	oldLogger := zap.L()
+	defer zap.ReplaceGlobals(oldLogger)
+	zap.ReplaceGlobals(logger)
+
+	// Ensure the env vars don't exist
+	t.Setenv("NONEXISTENT_VAR", "")
+	t.Setenv("ANOTHER_NONEXISTENT_VAR", "")
+
+	f := &Factory{}
+	cfg := config.ServiceObjectStore{
+		Type: config.ObjectStoreType_S3,
+		ObjectStoreConfig: config.ObjectStoreConfig{
+			ObjectStoreS3Config: config.ObjectStoreS3Config{
+				Bucket: "test-bucket",
+				Region: "us-east-1",
+				AccessKey: config.ValueSource{
+					Type:  config.ValueSourceType_ENV,
+					Value: "NONEXISTENT_VAR",
+				},
+				SecretKey: config.ValueSource{
+					Type:  config.ValueSourceType_ENV,
+					Value: "ANOTHER_NONEXISTENT_VAR",
+				},
+			},
+		},
+	}
+
+	err := f.Init(t.Context(), cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "env var")
+}
+
+func TestFactory_Init_DefaultEndpoint(t *testing.T) {
+	// Set up logger for factory
+	logger := zaptest.NewLogger(t)
+	oldLogger := zap.L()
+	defer zap.ReplaceGlobals(oldLogger)
+	zap.ReplaceGlobals(logger)
+
+	f := &Factory{}
+	cfg := config.ServiceObjectStore{
+		Type: config.ObjectStoreType_S3,
+		ObjectStoreConfig: config.ObjectStoreConfig{
+			ObjectStoreS3Config: config.ObjectStoreS3Config{
+				Bucket: "test-bucket",
+				AccessKey: config.ValueSource{
+					Type:  config.ValueSourceType_TEXT,
+					Value: "test-access-key",
+				},
+				SecretKey: config.ValueSource{
+					Type:  config.ValueSourceType_TEXT,
+					Value: "test-secret-key",
+				},
+				// Endpoint omitted - should default to s3.amazonaws.com
+			},
+		},
+	}
+
+	err := f.Init(t.Context(), cfg)
+	require.NoError(t, err)
+	assert.NotNil(t, f.objectstore)
+}
+
+func TestFactory_Init_DefaultRegion(t *testing.T) {
+	// Set up logger for factory
+	logger := zaptest.NewLogger(t)
+	oldLogger := zap.L()
+	defer zap.ReplaceGlobals(oldLogger)
+	zap.ReplaceGlobals(logger)
+
+	f := &Factory{}
+	cfg := config.ServiceObjectStore{
+		Type: config.ObjectStoreType_S3,
+		ObjectStoreConfig: config.ObjectStoreConfig{
+			ObjectStoreS3Config: config.ObjectStoreS3Config{
+				Bucket: "test-bucket",
+				AccessKey: config.ValueSource{
+					Type:  config.ValueSourceType_TEXT,
+					Value: "test-access-key",
+				},
+				SecretKey: config.ValueSource{
+					Type:  config.ValueSourceType_TEXT,
+					Value: "test-secret-key",
+				},
+				// Region omitted - should default to us-east-1
+			},
+		},
+	}
+
+	err := f.Init(t.Context(), cfg)
+	require.NoError(t, err)
+	assert.NotNil(t, f.objectstore)
+}
+
+func TestFactory_Init_MissingBucket(t *testing.T) {
+	// Set up logger for factory
+	logger := zaptest.NewLogger(t)
+	oldLogger := zap.L()
+	defer zap.ReplaceGlobals(oldLogger)
+	zap.ReplaceGlobals(logger)
+
+	f := &Factory{}
+	cfg := config.ServiceObjectStore{
+		Type: config.ObjectStoreType_S3,
+		ObjectStoreConfig: config.ObjectStoreConfig{
+			ObjectStoreS3Config: config.ObjectStoreS3Config{
+				// Bucket omitted - should error
+				AccessKey: config.ValueSource{
+					Type:  config.ValueSourceType_TEXT,
+					Value: "test-access-key",
+				},
+				SecretKey: config.ValueSource{
+					Type:  config.ValueSourceType_TEXT,
+					Value: "test-secret-key",
+				},
+			},
+		},
+	}
+
+	err := f.Init(t.Context(), cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bucket is required")
+}

--- a/pkg/services/objectstore/s3/integration_test.go
+++ b/pkg/services/objectstore/s3/integration_test.go
@@ -1,0 +1,197 @@
+//go:build integration
+
+package s3
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/qpoint-io/qtap/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+)
+
+// TestS3Integration_WithEnvCredentials tests S3 with AWS environment credentials
+// This test requires:
+// - AWS_ACCESS_KEY_ID environment variable
+// - AWS_SECRET_ACCESS_KEY environment variable
+// - S3_TEST_BUCKET environment variable
+// Run with: go test -tags=integration ./pkg/services/objectstore/s3/...
+func TestS3Integration_WithEnvCredentials(t *testing.T) {
+	bucket := os.Getenv("S3_TEST_BUCKET")
+	if bucket == "" {
+		t.Skip("S3_TEST_BUCKET environment variable not set, skipping integration test")
+	}
+
+	accessKey := os.Getenv("AWS_ACCESS_KEY_ID")
+	secretKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
+	if accessKey == "" || secretKey == "" {
+		t.Skip("AWS credentials not set, skipping integration test")
+	}
+
+	// Set up logger for factory
+	logger := zaptest.NewLogger(t)
+	oldLogger := zap.L()
+	defer zap.ReplaceGlobals(oldLogger)
+	zap.ReplaceGlobals(logger)
+
+	f := &Factory{}
+	cfg := config.ServiceObjectStore{
+		Type: config.ObjectStoreType_S3,
+		ObjectStoreConfig: config.ObjectStoreConfig{
+			ObjectStoreS3Config: config.ObjectStoreS3Config{
+				Bucket: bucket,
+				Region: "us-east-1",
+				// No explicit credentials - should use env vars via credential chain
+			},
+		},
+	}
+
+	err := f.Init(context.Background(), cfg)
+	require.NoError(t, err)
+	assert.NotNil(t, f.objectstore)
+
+	// Test that we can actually put an object
+	ctx := context.Background()
+	data := []byte("test data for integration test")
+	digest := "test-digest-env-creds"
+	contentType := "text/plain"
+
+	metadata, err := f.objectstore.Put(ctx, digest, contentType, data)
+	require.NoError(t, err)
+	assert.NotNil(t, metadata)
+	assert.Equal(t, bucket, metadata["BUCKET"])
+	assert.Equal(t, digest, metadata["DIGEST"])
+}
+
+// TestS3Integration_WithStaticCredentials tests S3 with explicitly configured credentials
+// This test requires:
+// - S3_TEST_BUCKET environment variable
+// - S3_TEST_ACCESS_KEY environment variable
+// - S3_TEST_SECRET_KEY environment variable
+// Run with: go test -tags=integration ./pkg/services/objectstore/s3/...
+func TestS3Integration_WithStaticCredentials(t *testing.T) {
+	bucket := os.Getenv("S3_TEST_BUCKET")
+	if bucket == "" {
+		t.Skip("S3_TEST_BUCKET environment variable not set, skipping integration test")
+	}
+
+	accessKey := os.Getenv("S3_TEST_ACCESS_KEY")
+	secretKey := os.Getenv("S3_TEST_SECRET_KEY")
+	if accessKey == "" || secretKey == "" {
+		t.Skip("S3 test credentials not set, skipping integration test")
+	}
+
+	// Set up logger for factory
+	logger := zaptest.NewLogger(t)
+	oldLogger := zap.L()
+	defer zap.ReplaceGlobals(oldLogger)
+	zap.ReplaceGlobals(logger)
+
+	f := &Factory{}
+	cfg := config.ServiceObjectStore{
+		Type: config.ObjectStoreType_S3,
+		ObjectStoreConfig: config.ObjectStoreConfig{
+			ObjectStoreS3Config: config.ObjectStoreS3Config{
+				Bucket: bucket,
+				Region: "us-east-1",
+				AccessKey: config.ValueSource{
+					Type:  config.ValueSourceType_TEXT,
+					Value: accessKey,
+				},
+				SecretKey: config.ValueSource{
+					Type:  config.ValueSourceType_TEXT,
+					Value: secretKey,
+				},
+			},
+		},
+	}
+
+	err := f.Init(context.Background(), cfg)
+	require.NoError(t, err)
+	assert.NotNil(t, f.objectstore)
+
+	// Test that we can actually put an object
+	ctx := context.Background()
+	data := []byte("test data for integration test with static creds")
+	digest := "test-digest-static-creds"
+	contentType := "text/plain"
+
+	metadata, err := f.objectstore.Put(ctx, digest, contentType, data)
+	require.NoError(t, err)
+	assert.NotNil(t, metadata)
+	assert.Equal(t, bucket, metadata["BUCKET"])
+	assert.Equal(t, digest, metadata["DIGEST"])
+}
+
+// TestS3Integration_WithIAM tests S3 with IAM credentials (IRSA or IMDS)
+// This test requires running in an environment with IAM credentials available:
+// - EKS cluster with IRSA configured
+// - EC2 instance with instance profile
+// - S3_TEST_BUCKET environment variable
+// Run with: go test -tags=integration ./pkg/services/objectstore/s3/...
+func TestS3Integration_WithIAM(t *testing.T) {
+	bucket := os.Getenv("S3_TEST_BUCKET")
+	if bucket == "" {
+		t.Skip("S3_TEST_BUCKET environment variable not set, skipping integration test")
+	}
+
+	// Clear any existing AWS env credentials to force IAM
+	origAccessKey := os.Getenv("AWS_ACCESS_KEY_ID")
+	origSecretKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
+	os.Unsetenv("AWS_ACCESS_KEY_ID")
+	os.Unsetenv("AWS_SECRET_ACCESS_KEY")
+	defer func() {
+		if origAccessKey != "" {
+			os.Setenv("AWS_ACCESS_KEY_ID", origAccessKey)
+		}
+		if origSecretKey != "" {
+			os.Setenv("AWS_SECRET_ACCESS_KEY", origSecretKey)
+		}
+	}()
+
+	// Set up logger for factory
+	logger := zaptest.NewLogger(t)
+	oldLogger := zap.L()
+	defer zap.ReplaceGlobals(oldLogger)
+	zap.ReplaceGlobals(logger)
+
+	f := &Factory{}
+	cfg := config.ServiceObjectStore{
+		Type: config.ObjectStoreType_S3,
+		ObjectStoreConfig: config.ObjectStoreConfig{
+			ObjectStoreS3Config: config.ObjectStoreS3Config{
+				Bucket: bucket,
+				Region: "us-east-1",
+				// No credentials - should use IAM
+			},
+		},
+	}
+
+	err := f.Init(context.Background(), cfg)
+
+	// This will only succeed if running in an IAM-enabled environment
+	if err != nil {
+		t.Logf("IAM credentials not available (expected in non-IAM environments): %v", err)
+		t.Skip("Skipping IAM test - not running in IAM environment")
+		return
+	}
+
+	require.NoError(t, err)
+	assert.NotNil(t, f.objectstore)
+
+	// Test that we can actually put an object
+	ctx := context.Background()
+	data := []byte("test data for integration test with IAM")
+	digest := "test-digest-iam"
+	contentType := "text/plain"
+
+	metadata, err := f.objectstore.Put(ctx, digest, contentType, data)
+	require.NoError(t, err)
+	assert.NotNil(t, metadata)
+	assert.Equal(t, bucket, metadata["BUCKET"])
+	assert.Equal(t, digest, metadata["DIGEST"])
+}

--- a/pkg/services/objectstore/s3/minio/minio.go
+++ b/pkg/services/objectstore/s3/minio/minio.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
@@ -22,22 +24,115 @@ type S3ObjectStore struct {
 }
 
 func NewS3ObjectStore(logger *zap.Logger, endpoint, bucket, region, accessKey, secretKey string, insecure bool) (*S3ObjectStore, error) {
-	client, err := minio.New(endpoint, &minio.Options{
-		Creds:     credentials.NewStaticV4(accessKey, secretKey, ""),
+	httpClient := client.NewHttpClient()
+	var creds *credentials.Credentials
+
+	if accessKey != "" && secretKey != "" {
+		// Explicit credentials provided - use them directly
+		logger.Debug("using static S3 credentials")
+		creds = credentials.NewStaticV4(accessKey, secretKey, "")
+	} else {
+		// No explicit credentials - try IAM/IRSA, then env vars
+		logger.Debug("using S3 credential chain (WebIdentity -> IAM -> EnvAWS -> EnvMinio)")
+
+		// Web identity (IRSA) provider sits ahead of IAM to avoid IMDS calls when tokens are present.
+		providers := []credentials.Provider{}
+		if tokenFile := os.Getenv("AWS_WEB_IDENTITY_TOKEN_FILE"); tokenFile != "" && os.Getenv("AWS_ROLE_ARN") != "" {
+			stsEndpoint := stsEndpointForRegion(os.Getenv("AWS_REGION"))
+			if envEndpoint := os.Getenv("AWS_STS_ENDPOINT"); envEndpoint != "" {
+				stsEndpoint = envEndpoint
+			}
+
+			providers = append(providers, &credentials.STSWebIdentity{
+				Client:      httpClient,
+				STSEndpoint: stsEndpoint,
+				GetWebIDTokenExpiry: func() (*credentials.WebIdentityToken, error) {
+					token, err := os.ReadFile(tokenFile)
+					if err != nil {
+						return nil, err
+					}
+					return &credentials.WebIdentityToken{Token: string(token)}, nil
+				},
+				RoleARN: os.Getenv("AWS_ROLE_ARN"),
+			})
+		}
+
+		providers = append(providers,
+			&credentials.IAM{
+				Client: httpClient,
+			},
+			&credentials.EnvAWS{},
+			&credentials.EnvMinio{},
+		)
+
+		creds = credentials.NewChainCredentials(providers)
+	}
+
+	s3Client, err := minio.New(endpoint, &minio.Options{
+		Creds:     creds,
 		Secure:    !insecure,
 		Region:    region,
-		Transport: client.NewHttpClient().Transport,
+		Transport: httpClient.Transport,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create S3 client: %w", err)
 	}
 
+	// Log which credential provider succeeded (IAM mode only)
+	if accessKey == "" && secretKey == "" {
+		credValue, err := creds.Get() //nolint:staticcheck // Get() is used for validation
+		if err != nil {
+			return nil, fmt.Errorf("failed to retrieve credentials from chain: %w", err)
+		}
+		providerName := determineCredentialProvider(credValue)
+		logger.Info("successfully authenticated to S3",
+			zap.String("provider", providerName),
+			zap.String("endpoint", endpoint))
+	}
+
 	return &S3ObjectStore{
 		logger:   logger,
 		insecure: insecure,
-		client:   client,
+		client:   s3Client,
 		bucket:   bucket,
 	}, nil
+}
+
+func stsEndpointForRegion(region string) string {
+	if region == "" {
+		return credentials.DefaultSTSRoleEndpoint
+	}
+
+	if strings.HasPrefix(region, "cn-") {
+		return "https://sts." + region + ".amazonaws.com.cn"
+	}
+
+	return "https://sts." + region + ".amazonaws.com"
+}
+
+// determineCredentialProvider attempts to identify which provider succeeded
+// based on the credential value characteristics
+func determineCredentialProvider(credValue credentials.Value) string {
+	if credValue.SessionToken != "" && os.Getenv("AWS_WEB_IDENTITY_TOKEN_FILE") != "" {
+		return "WebIdentity (IRSA)"
+	}
+
+	// IAM credentials have a SessionToken
+	if credValue.SessionToken != "" {
+		return "IAM (IRSA/IMDS)"
+	}
+
+	// Check for AWS env var provider (AWS_ACCESS_KEY_ID)
+	if os.Getenv("AWS_ACCESS_KEY_ID") != "" {
+		return "EnvAWS"
+	}
+
+	// Check for Minio env var provider (MINIO_ACCESS_KEY)
+	if os.Getenv("MINIO_ACCESS_KEY") != "" {
+		return "EnvMinio"
+	}
+
+	return "unknown"
 }
 
 func (s *S3ObjectStore) Put(ctx context.Context, digest string, contentType string, data []byte) (map[string]string, error) {

--- a/pkg/services/objectstore/s3/minio/minio_test.go
+++ b/pkg/services/objectstore/s3/minio/minio_test.go
@@ -1,0 +1,229 @@
+package minio
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/minio/minio-go/v7/pkg/credentials"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+)
+
+const credsRespStsImpl = `<AssumeRoleWithWebIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+<AssumeRoleWithWebIdentityResult>
+  <SubjectFromWebIdentityToken>amzn1.account.AF6RHO7KZU5XRVQJGXK6HB56KR2A</SubjectFromWebIdentityToken>
+  <Audience>client.5498841531868486423.1548@apps.example.com</Audience>
+  <AssumedRoleUser>
+	<Arn>arn:aws:sts::123456789012:assumed-role/FederatedWebIdentityRole/app1</Arn>
+	<AssumedRoleId>AROACLKWSDQRAOEXAMPLE:app1</AssumedRoleId>
+  </AssumedRoleUser>
+  <Credentials>
+	<SessionToken>token</SessionToken>
+	<SecretAccessKey>secret</SecretAccessKey>
+	<Expiration>%s</Expiration>
+	<AccessKeyId>accessKey</AccessKeyId>
+  </Credentials>
+  <Provider>www.amazon.com</Provider>
+</AssumeRoleWithWebIdentityResult>
+<ResponseMetadata>
+  <RequestId>ad4156e9-bce1-11e2-82e6-6b6efEXAMPLE</RequestId>
+</ResponseMetadata>
+</AssumeRoleWithWebIdentityResponse>`
+
+func TestNewS3ObjectStore_WithStaticCredentials(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	store, err := NewS3ObjectStore(
+		logger,
+		"s3.amazonaws.com",
+		"test-bucket",
+		"us-east-1",
+		"test-access-key",
+		"test-secret-key",
+		false,
+	)
+
+	// We expect this to succeed in creating the client
+	// (it won't connect, but the client should be constructed)
+	require.NoError(t, err)
+	assert.NotNil(t, store)
+	assert.NotNil(t, store.client)
+	assert.Equal(t, "test-bucket", store.bucket)
+}
+
+func TestNewS3ObjectStore_WithCredentialChain(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	// Set up environment variables for the credential chain
+	t.Setenv("AWS_ACCESS_KEY_ID", "test-aws-key")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "test-aws-secret")
+
+	store, err := NewS3ObjectStore(
+		logger,
+		"s3.amazonaws.com",
+		"test-bucket",
+		"us-east-1",
+		"", // Empty access key
+		"", // Empty secret key
+		false,
+	)
+
+	// Should succeed because AWS env vars are set
+	require.NoError(t, err)
+	assert.NotNil(t, store)
+	assert.NotNil(t, store.client)
+}
+
+func TestNewS3ObjectStore_WithWebIdentity(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	expire := time.Now().UTC().Add(1 * time.Hour).Format(time.RFC3339)
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Skipf("cannot listen for local STS test server: %v", err)
+	}
+
+	sts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		fmt.Fprintf(w, credsRespStsImpl, expire)
+	}))
+	sts.Listener = listener
+	sts.Start()
+	defer sts.Close()
+
+	tokenFile := filepath.Join(t.TempDir(), "token")
+	require.NoError(t, os.WriteFile(tokenFile, []byte("test-token"), 0o600))
+
+	t.Setenv("AWS_WEB_IDENTITY_TOKEN_FILE", tokenFile)
+	t.Setenv("AWS_ROLE_ARN", "arn:aws:sts::123456789012:assumed-role/FederatedWebIdentityRole/app1")
+	t.Setenv("AWS_STS_ENDPOINT", sts.URL)
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+
+	store, err := NewS3ObjectStore(
+		logger,
+		"s3.amazonaws.com",
+		"test-bucket",
+		"us-east-1",
+		"", // Empty access key
+		"", // Empty secret key
+		false,
+	)
+
+	require.NoError(t, err)
+	assert.NotNil(t, store)
+	assert.NotNil(t, store.client)
+}
+
+func TestNewS3ObjectStore_WithCredentialChain_NoCredentials(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	// Ensure no environment credentials are available
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+	t.Setenv("MINIO_ACCESS_KEY", "")
+	t.Setenv("MINIO_SECRET_KEY", "")
+
+	store, err := NewS3ObjectStore(
+		logger,
+		"s3.amazonaws.com",
+		"test-bucket",
+		"us-east-1",
+		"", // Empty access key
+		"", // Empty secret key
+		false,
+	)
+
+	// This test might succeed or fail depending on the environment:
+	// - In CI/local dev: Should fail because no credentials are available
+	// - In EC2/EKS: Might succeed because IAM credentials (IMDS/IRSA) are available
+	// We accept both outcomes as valid
+	if err != nil {
+		// Expected in environments without IAM
+		assert.Contains(t, err.Error(), "failed to retrieve credentials from chain")
+		assert.Nil(t, store)
+	} else {
+		// IAM credentials were found (IMDS/IRSA available)
+		assert.NotNil(t, store)
+		t.Log("IAM credentials were available in this environment")
+	}
+}
+
+func TestDetermineCredentialProvider_IAM(t *testing.T) {
+	credValue := credentials.Value{
+		AccessKeyID:     "ASIATESTACCESSKEY",
+		SecretAccessKey: "test-secret",
+		SessionToken:    "test-session-token",
+		SignerType:      credentials.SignatureV4,
+	}
+
+	provider := determineCredentialProvider(credValue)
+	assert.Equal(t, "IAM (IRSA/IMDS)", provider)
+}
+
+func TestDetermineCredentialProvider_WebIdentity(t *testing.T) {
+	t.Setenv("AWS_WEB_IDENTITY_TOKEN_FILE", "/tmp/token")
+
+	credValue := credentials.Value{
+		AccessKeyID:     "ASIATESTACCESSKEY",
+		SecretAccessKey: "test-secret",
+		SessionToken:    "test-session-token",
+		SignerType:      credentials.SignatureV4,
+	}
+
+	provider := determineCredentialProvider(credValue)
+	assert.Equal(t, "WebIdentity (IRSA)", provider)
+}
+
+func TestDetermineCredentialProvider_EnvAWS(t *testing.T) {
+	t.Setenv("AWS_ACCESS_KEY_ID", "test-key")
+
+	credValue := credentials.Value{
+		AccessKeyID:     "test-key",
+		SecretAccessKey: "test-secret",
+		SessionToken:    "", // No session token
+		SignerType:      credentials.SignatureV4,
+	}
+
+	provider := determineCredentialProvider(credValue)
+	assert.Equal(t, "EnvAWS", provider)
+}
+
+func TestDetermineCredentialProvider_EnvMinio(t *testing.T) {
+	// Clear AWS env vars to ensure we detect Minio
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	t.Setenv("MINIO_ACCESS_KEY", "test-key")
+
+	credValue := credentials.Value{
+		AccessKeyID:     "test-key",
+		SecretAccessKey: "test-secret",
+		SessionToken:    "", // No session token
+		SignerType:      credentials.SignatureV4,
+	}
+
+	provider := determineCredentialProvider(credValue)
+	assert.Equal(t, "EnvMinio", provider)
+}
+
+func TestDetermineCredentialProvider_Unknown(t *testing.T) {
+	// Clear all env vars
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	t.Setenv("MINIO_ACCESS_KEY", "")
+
+	credValue := credentials.Value{
+		AccessKeyID:     "test-key",
+		SecretAccessKey: "test-secret",
+		SessionToken:    "", // No session token
+		SignerType:      credentials.SignatureV4,
+	}
+
+	provider := determineCredentialProvider(credValue)
+	assert.Equal(t, "unknown", provider)
+}


### PR DESCRIPTION
Improves the flexibility of the S3 object store configuration and ensures proper handling of IAM credentials.

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Contributing Guide: https://github.com/qpoint-io/qtap/docs/CONTRIBUTING.md
     - 📖 Read the Contributor License Agreement (CLA): https://github.com/qpoint-io/qtap/docs/CLA.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Qpoint Team member.
-->
