### PR TITLE
chore: update Go to 1.25.7

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.5'
+          go-version: '1.25.7'
           cache: true
 
       - name: Run CI

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.25.7"
           cache: true
 
       - name: Run E2E tests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/qpoint-io/qtap
 
-go 1.25.5
+go 1.25.7
 
 require (
 	github.com/advbet/sseclient v0.0.0-20250521071159-d88bf8fc2362


### PR DESCRIPTION
Updates Go version to 1.25.7.

## Changes
- Updated `go.mod` go directive from 1.25.5 → 1.25.7
- Verified: `go build ./...` passes ✅
- Verified: `make ci` passes (1178 tests, lint, security, deps) ✅

## Workflow updates needed
The CI token doesn't have `workflow` scope, so these workflow files need manual update:

**`.github/workflows/ci.yaml`**: Change `go-version: '1.25.5'` → `go-version: '1.25.7'`
**`.github/workflows/test.yaml`**: Change `go-version: "1.25"` → `go-version: "1.25.7"`

@jonfriesen can you push the workflow changes, or grant the token workflow scope?