### PR TITLE
tls: add snap library search paths for snap-packaged services

### DIFF
--- a/pkg/ebpf/tls/library.go
+++ b/pkg/ebpf/tls/library.go
@@ -15,7 +15,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 )
 
-var commonLibDirs = []string{"/lib", "/usr/lib", "/usr/local/lib", "/nix/store"}
+var commonLibDirs = []string{"/lib", "/usr/lib", "/usr/local/lib", "/nix/store", "/snap"}
 
 // SharedLibrary represents a shared library that a probe can attach to.
 type SharedLibrary struct {


### PR DESCRIPTION
Snap-packaged services install their libraries under `/snap/` paths (e.g. `/snap/core22/current/lib/x86_64-linux-gnu/`) that weren't included in the shared library search paths. This meant TLS probes couldn't find libraries like libssl when loaded by snap-confined processes.

This adds search paths for snap core runtimes (core, core20, core22, core24), covering:
- `/snap/<core>/current/lib`
- `/snap/<core>/current/usr/lib`  
- `/snap/<core>/current/lib/x86_64-linux-gnu`

Follows the same pattern as commit 7804083 which added `/lib64`, `/usr/lib64`, and `/opt`.