### PR TITLE
Fixes unbounded eBPF verifier check

### DIFF
--- a/bpf/tap/protocol.bpf.c
+++ b/bpf/tap/protocol.bpf.c
@@ -115,6 +115,8 @@ static bool capture_tls_server_hello(struct socket_tls_server_hello_event *hands
 			return false;
 		}
 
+		total_size &= (MAX_MSG_SIZE - 1);
+
 		// Read the entire handshake into our buffer
 		if (buf_read((char *)handshake->data, total_size, buf_info, 0) == 0) {
 			return false;


### PR DESCRIPTION
Resolves error:
R2 unbounded memory access, use 'var &= const' or 'if (var < const)'

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Contributing Guide: https://github.com/qpoint-io/qtap/docs/CONTRIBUTING.md
     - 📖 Read the Contributor License Agreement (CLA): https://github.com/qpoint-io/qtap/docs/CLA.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Qpoint Team member.
-->
