### PR TITLE
fix: use protocol-specific default stacks

### DIFF
--- a/pkg/plugins/manager.go
+++ b/pkg/plugins/manager.go
@@ -47,8 +47,10 @@ type Manager struct {
 	// domain -> stack mapping
 	domainStacks *synq.Map[stackKey, config.TapProtocolConfig]
 
-	// default stack
-	defaultStackConfig config.TapProtocolConfig
+	// default stack configs per protocol
+	defaultStackConfig      config.TapProtocolConfig
+	defaultRedisStackConfig config.TapProtocolConfig
+	defaultMySQLStackConfig config.TapProtocolConfig
 
 	// plugin registry
 	pluginRegistry *PluginRegistry
@@ -136,9 +138,11 @@ func (m *Manager) SetConfig(conf *config.Config) {
 		)
 	}
 
-	// set the default stack
+	// set the default stacks per protocol
 	m.mu.Lock()
 	m.defaultStackConfig = conf.Tap.Http
+	m.defaultRedisStackConfig = conf.Tap.Redis
+	m.defaultMySQLStackConfig = conf.Tap.MySQL
 	m.mu.Unlock()
 
 	// generate a snapshot of the incoming config
@@ -173,7 +177,14 @@ func (m *Manager) registerDomainToStack(domain, protocol string) (*StackDeployme
 	// fetch the endpointConfig
 	endpointConfig, exists := m.domainStacks.Load(key)
 	if !exists {
-		endpointConfig = m.defaultStackConfig
+		switch protocol {
+		case "redis":
+			endpointConfig = m.defaultRedisStackConfig
+		case "mysql":
+			endpointConfig = m.defaultMySQLStackConfig
+		default:
+			endpointConfig = m.defaultStackConfig
+		}
 	}
 
 	// unlock the manager
@@ -204,8 +215,15 @@ func (m *Manager) GetDomainStack(domain, protocol string) (string, bool) {
 		return stackID.Stack, stackID.HasStack()
 	}
 
-	// return the default stack
-	return m.defaultStackConfig.Stack, m.defaultStackConfig.HasStack()
+	// return the protocol-specific default stack
+	switch protocol {
+	case "redis":
+		return m.defaultRedisStackConfig.Stack, m.defaultRedisStackConfig.HasStack()
+	case "mysql":
+		return m.defaultMySQLStackConfig.Stack, m.defaultMySQLStackConfig.HasStack()
+	default:
+		return m.defaultStackConfig.Stack, m.defaultStackConfig.HasStack()
+	}
 }
 
 func (m *Manager) Stop() {


### PR DESCRIPTION
GetDomainStack and registerDomainToStack always fell back to the HTTP default stack config when no domain-specific entry was found. This meant top-level tap.mysql.stack and tap.redis.stack configs were used for eBPF protocol detection but never for stream processor creation, so MySQL and Redis connections silently got nil stream processors and their traffic was not parsed.

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Contributing Guide: https://github.com/qpoint-io/qtap/docs/CONTRIBUTING.md
     - 📖 Read the Contributor License Agreement (CLA): https://github.com/qpoint-io/qtap/docs/CLA.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Qpoint Team member.
-->
