### PR TITLE
Add PostgreSQL plugin integration and access logs

### DIFF
--- a/pkg/plugins/accesslogs/access_logs_helpers.go
+++ b/pkg/plugins/accesslogs/access_logs_helpers.go
@@ -1,0 +1,41 @@
+package accesslogs
+
+import "strings"
+
+// truncateQuery trims and truncates a query string for display
+func truncateQuery(query string, maxLen int) string {
+	query = strings.TrimSpace(query)
+	query = strings.ReplaceAll(query, "\n", " ")
+	query = strings.ReplaceAll(query, "\t", " ")
+	if maxLen < 3 {
+		maxLen = 3
+	}
+	if len(query) > maxLen {
+		return query[:maxLen-3] + "..."
+	}
+	return query
+}
+
+// padRight pads a string to the given width with spaces
+func padRight(s string, width int) string {
+	if len(s) >= width {
+		return s
+	}
+	return s + strings.Repeat(" ", width-len(s))
+}
+
+// extractQueryType extracts the SQL command type from a query
+func extractQueryType(query string) string {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return "UNKNOWN"
+	}
+
+	// Find first word
+	parts := strings.Fields(query)
+	if len(parts) == 0 {
+		return "UNKNOWN"
+	}
+
+	return strings.ToUpper(parts[0])
+}

--- a/pkg/plugins/accesslogs/access_logs_helpers_test.go
+++ b/pkg/plugins/accesslogs/access_logs_helpers_test.go
@@ -1,0 +1,86 @@
+package accesslogs
+
+import "testing"
+
+func TestTruncateQuery(t *testing.T) {
+	tests := []struct {
+		name   string
+		query  string
+		maxLen int
+		want   string
+	}{
+		{"short query unchanged", "SELECT 1", 50, "SELECT 1"},
+		{"exact length", "SELECT", 6, "SELECT"},
+		{"truncated with ellipsis", "SELECT * FROM users WHERE id = 1", 20, "SELECT * FROM use..."},
+		{"trims whitespace", "  SELECT 1  ", 50, "SELECT 1"},
+		{"replaces newlines", "SELECT\n1\nFROM\nusers", 50, "SELECT 1 FROM users"},
+		{"replaces tabs", "SELECT\t1\tFROM\tusers", 50, "SELECT 1 FROM users"},
+		{"maxLen less than 3 is clamped", "abcdef", 1, "..."},
+		{"maxLen of 0", "abcdef", 0, "..."},
+		{"maxLen negative", "abcdef", -5, "..."},
+		{"maxLen exactly 3", "abcdef", 3, "..."},
+		{"empty query", "", 50, ""},
+		{"maxLen 4 truncates", "abcdef", 4, "a..."},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := truncateQuery(tt.query, tt.maxLen)
+			if got != tt.want {
+				t.Errorf("truncateQuery(%q, %d) = %q, want %q", tt.query, tt.maxLen, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractQueryType(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+		want  string
+	}{
+		{"select", "SELECT * FROM users", "SELECT"},
+		{"insert", "INSERT INTO users VALUES (1)", "INSERT"},
+		{"update", "update users SET name = 'foo'", "UPDATE"},
+		{"delete", "delete from users", "DELETE"},
+		{"create table", "CREATE TABLE foo (id int)", "CREATE"},
+		{"leading whitespace", "  SELECT 1", "SELECT"},
+		{"empty string", "", "UNKNOWN"},
+		{"whitespace only", "   ", "UNKNOWN"},
+		{"lowercase", "select 1", "SELECT"},
+		{"begin", "BEGIN", "BEGIN"},
+		{"commit", "COMMIT", "COMMIT"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractQueryType(tt.query)
+			if got != tt.want {
+				t.Errorf("extractQueryType(%q) = %q, want %q", tt.query, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPadRight(t *testing.T) {
+	tests := []struct {
+		name  string
+		s     string
+		width int
+		want  string
+	}{
+		{"pad short string", "abc", 6, "abc   "},
+		{"exact width", "abc", 3, "abc"},
+		{"longer than width", "abcdef", 3, "abcdef"},
+		{"empty string", "", 4, "    "},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := padRight(tt.s, tt.width)
+			if got != tt.want {
+				t.Errorf("padRight(%q, %d) = %q, want %q", tt.s, tt.width, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/plugins/accesslogs/access_logs_plugin.go
+++ b/pkg/plugins/accesslogs/access_logs_plugin.go
@@ -167,6 +167,28 @@ func (f *factory) NewMySQLInstance(ctx plugins.PluginContext, svcs *services.Ser
 	}
 }
 
+func (f *factory) NewPostgresInstance(ctx plugins.PluginContext, svcs *services.ServiceRegistry) plugins.PostgresPluginInstance {
+	var mode displayMode
+	var format outputFormat
+	if f.config != nil {
+		mode = f.config.Mode
+		format = f.config.Format
+	}
+
+	// fall back to the factory's default format if none was configured
+	if format == "" {
+		format = f.format
+	}
+
+	return &postgresFilterInstance{
+		ctx:    ctx,
+		logger: f.logger,
+		writer: f.writer,
+		mode:   mode,
+		format: format,
+	}
+}
+
 func (f *factory) Destroy() {
 	f.logger.Debug("plugin destroyed")
 }

--- a/pkg/plugins/accesslogs/access_logs_postgres.go
+++ b/pkg/plugins/accesslogs/access_logs_postgres.go
@@ -1,0 +1,458 @@
+package accesslogs
+
+import (
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/fatih/color"
+	"github.com/qpoint-io/qtap/pkg/plugins"
+	"go.uber.org/zap"
+)
+
+// postgresFilterInstance handles PostgreSQL traffic for access logging
+type postgresFilterInstance struct {
+	logger *zap.Logger
+	writer *zap.Logger
+
+	ctx    plugins.PluginContext
+	mode   displayMode
+	format outputFormat
+
+	command *plugins.PostgresCommand
+	result  *plugins.PostgresResult
+}
+
+func (f *postgresFilterInstance) OnPostgresCommand(cmd *plugins.PostgresCommand) plugins.PostgresStatus {
+	f.command = cmd
+	return plugins.PostgresStatusContinue
+}
+
+func (f *postgresFilterInstance) OnPostgresResult(res *plugins.PostgresResult) plugins.PostgresStatus {
+	f.result = res
+	return plugins.PostgresStatusContinue
+}
+
+func (f *postgresFilterInstance) Destroy() {
+	if f.mode == displayModeNone {
+		return
+	}
+
+	if f.command == nil {
+		return
+	}
+
+	printer := NewPostgresPrinter(f.format, f.ctx, f.command, f.result, f.logger, f.writer)
+	switch f.mode {
+	case displayModeSummary:
+		printer.PrintSummary()
+	case displayModeDetails, displayModeFull:
+		printer.PrintDetails()
+	default:
+		printer.PrintSummary()
+	}
+}
+
+// PostgresPrinter defines the interface for PostgreSQL access log formatting
+type PostgresPrinter interface {
+	PrintSummary()
+	PrintDetails()
+}
+
+// NewPostgresPrinter creates a new PostgreSQL printer based on the specified format
+func NewPostgresPrinter(
+	format outputFormat,
+	ctx plugins.PluginContext,
+	cmd *plugins.PostgresCommand,
+	res *plugins.PostgresResult,
+	logger *zap.Logger,
+	writer *zap.Logger,
+) PostgresPrinter {
+	switch format {
+	case outputFormatJSON:
+		return &postgresJSONPrinter{ctx: ctx, cmd: cmd, res: res, logger: logger, writer: writer}
+	case outputFormatConsole:
+		return &postgresConsolePrinter{ctx: ctx, cmd: cmd, res: res, logger: logger, writer: writer}
+	default:
+		return &postgresJSONPrinter{ctx: ctx, cmd: cmd, res: res, logger: logger, writer: writer}
+	}
+}
+
+// postgresJSONPrinter implements PostgresPrinter for JSON format
+type postgresJSONPrinter struct {
+	ctx    plugins.PluginContext
+	cmd    *plugins.PostgresCommand
+	res    *plugins.PostgresResult
+	logger *zap.Logger
+	writer *zap.Logger
+}
+
+func (p *postgresJSONPrinter) PrintSummary() {
+	meta := p.ctx.Meta()
+	requestID := meta.RequestID()
+	direction := meta.Direction()
+
+	var bin string
+	if proc := meta.Process(); proc != nil {
+		bin = proc.Exe
+	}
+
+	fields := []zap.Field{
+		zap.String("bin", bin),
+		zap.String("direction", direction),
+		zap.String("query", truncateQuery(p.cmd.Query, 100)),
+		zap.String("request_id", requestID),
+	}
+
+	if p.res != nil {
+		fields = append(fields,
+			zap.String("result_type", p.res.Type),
+			zap.Bool("is_error", p.res.Type == "Error"),
+		)
+		if p.res.RowCount > 0 {
+			fields = append(fields, zap.Int64("row_count", p.res.RowCount))
+		}
+		if p.res.ErrorCode != "" {
+			fields = append(fields, zap.String("error_code", p.res.ErrorCode))
+		}
+	}
+
+	p.writer.Info("PostgreSQL transaction", fields...)
+}
+
+func (p *postgresJSONPrinter) PrintDetails() {
+	meta := p.ctx.Meta()
+	requestID := meta.RequestID()
+	direction := meta.Direction()
+
+	command := map[string]any{
+		"query":     p.cmd.Query,
+		"timestamp": p.cmd.Timestamp,
+	}
+
+	var result map[string]any
+	if p.res != nil {
+		result = map[string]any{
+			"type":     p.res.Type,
+			"is_error": p.res.Type == "Error",
+		}
+		switch p.res.Type {
+		case "Error":
+			result["error_code"] = p.res.ErrorCode
+			result["error_message"] = p.res.ErrorMessage
+		case "CommandComplete":
+			result["command_tag"] = p.res.CommandTag
+			result["row_count"] = p.res.RowCount
+			if len(p.res.Columns) > 0 {
+				result["columns"] = p.res.Columns
+			}
+			if len(p.res.Rows) > 0 {
+				result["rows"] = p.res.Rows
+			}
+			result["truncated"] = p.res.Truncated
+		}
+	}
+
+	values := map[string]any{
+		"request_id": requestID,
+	}
+
+	if proc := meta.Process(); proc != nil {
+		values["pid"] = proc.Pid
+		values["exe"] = proc.Exe
+
+		if c, _ := proc.Container(); c != nil {
+			values["container_name"] = c.Name
+			values["container_image"] = c.Image
+		}
+
+		if pod, _ := proc.Pod(); pod != nil {
+			values["pod_name"] = pod.Name
+			values["pod_namespace"] = pod.Namespace
+		}
+	}
+
+	fields := []zap.Field{
+		zap.Any("meta", values),
+		zap.String("direction", direction),
+		zap.Any("command", command),
+	}
+	if result != nil {
+		fields = append(fields, zap.Any("result", result))
+	}
+
+	p.writer.Info("PostgreSQL transaction", fields...)
+}
+
+// postgresConsolePrinter implements PostgresPrinter for console format
+type postgresConsolePrinter struct {
+	ctx    plugins.PluginContext
+	cmd    *plugins.PostgresCommand
+	res    *plugins.PostgresResult
+	logger *zap.Logger
+	writer *zap.Logger
+}
+
+func (p *postgresConsolePrinter) PrintSummary() {
+	meta := p.ctx.Meta()
+	direction := meta.Direction()
+
+	var bin string
+	if proc := meta.Process(); proc != nil {
+		bin = proc.Exe
+	}
+
+	summaryLine := " " + buildPostgresSummary(bin, direction, p.cmd, p.res)
+	fmt.Fprintln(accessLogsWriter, summaryLine)
+}
+
+func (p *postgresConsolePrinter) PrintDetails() {
+	meta := p.ctx.Meta()
+	direction := meta.Direction()
+
+	var bin string
+	if proc := meta.Process(); proc != nil {
+		bin = proc.Exe
+	}
+
+	// Build manual border at terminal width
+	termWidth := terminalWidth()
+	borderWidth := termWidth - 2
+	if borderWidth < 0 {
+		borderWidth = 0
+	} else if borderWidth > borderWidthCap {
+		borderWidth = borderWidthCap
+	}
+
+	borderColor := getPostgresStatusColor(p.res)
+	borderStyle := lipgloss.NewStyle().Foreground(borderColor)
+	leftBorder := borderStyle.Render("│")
+	paddedLeftBorder := leftBorder + "  "
+
+	var output strings.Builder
+
+	// Top border
+	output.WriteString(borderStyle.Render("╭"+strings.Repeat("─", borderWidth)+"┄") + "\n")
+
+	// Summary
+	output.WriteString(prefixLines(buildPostgresSummary(bin, direction, p.cmd, p.res), paddedLeftBorder) + "\n")
+
+	// Meta section
+	output.WriteString(buildSectionDivider(borderColor, "", borderWidth) + "\n")
+	output.WriteString(prefixLines(buildMetaContent(meta), paddedLeftBorder) + "\n")
+
+	// Query section
+	output.WriteString(buildSectionDivider(borderColor, "QUERY", borderWidth) + "\n")
+	output.WriteString(prefixLines(buildPostgresQueryContent(p.cmd), paddedLeftBorder) + "\n")
+
+	// Result section
+	if p.res != nil {
+		resultTitle := "RESULT"
+		if p.res.Type == "Error" {
+			resultTitle = "RESULT (ERROR)"
+		}
+		output.WriteString(buildSectionDivider(borderColor, resultTitle, borderWidth) + "\n")
+		output.WriteString(prefixLines(buildPostgresResultContent(p.res), paddedLeftBorder) + "\n")
+	}
+
+	// Bottom border
+	output.WriteString(borderStyle.Render("╰" + strings.Repeat("─", borderWidth) + "┄"))
+
+	fmt.Fprintln(accessLogsWriter, output.String())
+}
+
+// buildPostgresSummary creates the summary line for PostgreSQL commands
+func buildPostgresSummary(exe, direction string, pgCmd *plugins.PostgresCommand, res *plugins.PostgresResult) string {
+	fn := getPostgresColorFn(res)
+	shortCmd := filepath.Base(exe)
+
+	arrow := "→"
+	if !strings.Contains(direction, "egress") {
+		arrow = "←"
+	}
+	arrow = fn(arrow)
+
+	// Extract query type (SELECT, INSERT, etc.)
+	queryType := extractQueryType(pgCmd.Query)
+	queryType = lipgloss.NewStyle().Bold(true).Render(queryType)
+
+	// Truncate query for summary
+	queryPreview := truncateQuery(pgCmd.Query, 50)
+
+	var status string
+	if res != nil {
+		switch res.Type {
+		case "Error":
+			status = fn("ERR")
+		case "CommandComplete":
+			status = fn("OK")
+			if res.RowCount > 0 {
+				status += " " + valueStyle.Render(strconv.FormatInt(res.RowCount, 10)+" rows")
+			}
+		default:
+			status = fn("OK")
+		}
+	}
+
+	summary := fmt.Sprintf("%s %s %s %s %s %s",
+		fn("■"), shortCmd, arrow, queryType, queryPreview, status)
+
+	return summary
+}
+
+func buildPostgresQueryContent(cmd *plugins.PostgresCommand) string {
+	var sb strings.Builder
+	sb.WriteString("\n")
+
+	sb.WriteString(subsectionStyle.Render("Query") + "\n")
+
+	query := cmd.Query
+	if len(query) > 500 {
+		query = query[:497] + "..."
+	}
+	sb.WriteString(labelStyle.Render("  • SQL: ") + valueStyle.Render(query) + "\n")
+	sb.WriteString(labelStyle.Render("  • Time: ") + valueStyle.Render(cmd.Timestamp.Format("15:04:05.000")) + "\n")
+
+	return sb.String()
+}
+
+func buildPostgresResultContent(res *plugins.PostgresResult) string {
+	var sb strings.Builder
+	sb.WriteString("\n")
+
+	sb.WriteString(subsectionStyle.Render("Result") + "\n")
+	sb.WriteString(labelStyle.Render("  • Type: ") + valueStyle.Render(res.Type) + "\n")
+
+	switch res.Type {
+	case "CommandComplete":
+		sb.WriteString(labelStyle.Render("  • Command Tag: ") + valueStyle.Render(res.CommandTag) + "\n")
+		if res.RowCount > 0 {
+			sb.WriteString(labelStyle.Render("  • Row Count: ") + valueStyle.Render(strconv.FormatInt(res.RowCount, 10)) + "\n")
+		}
+		if res.Truncated {
+			sb.WriteString(labelStyle.Render("  • (showing first ") + valueStyle.Render(strconv.Itoa(len(res.Rows))) + labelStyle.Render(" rows)") + "\n")
+		}
+		if len(res.Columns) > 0 && len(res.Rows) > 0 {
+			sb.WriteString("\n")
+			sb.WriteString(formatPostgresResultTable(res.Columns, res.Rows, res.NullFlags))
+		}
+	case "Error":
+		sb.WriteString(labelStyle.Render("  • Error Code: ") + valueStyle.Render(res.ErrorCode) + "\n")
+		sb.WriteString(labelStyle.Render("  • Error: ") + valueStyle.Render(res.ErrorMessage) + "\n")
+	case "EmptyQuery":
+		sb.WriteString(labelStyle.Render("  • (empty query)") + "\n")
+	}
+
+	return sb.String()
+}
+
+// formatPostgresResultTable formats columns and rows as an aligned text table with NULL handling
+func formatPostgresResultTable(columns []string, rows [][]string, nullFlags [][]bool) string {
+	// Calculate column widths
+	widths := make([]int, len(columns))
+	for i, col := range columns {
+		widths[i] = len(col)
+	}
+	for _, row := range rows {
+		for i, val := range row {
+			if i < len(widths) && len(val) > widths[i] {
+				widths[i] = len(val)
+			}
+		}
+	}
+
+	// Check NULLs for width calculation
+	for ri, flags := range nullFlags {
+		if ri >= len(rows) {
+			break
+		}
+		for ci, isNull := range flags {
+			if isNull && ci < len(widths) && 4 > widths[ci] { // "NULL" is 4 chars
+				widths[ci] = 4
+			}
+		}
+	}
+
+	// Cap column widths
+	for i := range widths {
+		if widths[i] > 30 {
+			widths[i] = 30
+		}
+	}
+
+	var sb strings.Builder
+	pad := "  "
+
+	// Header
+	sb.WriteString(pad)
+	for i, col := range columns {
+		if i > 0 {
+			sb.WriteString(labelStyle.Render(" │ "))
+		}
+		sb.WriteString(subsectionStyle.Render(padRight(col, widths[i])))
+	}
+	sb.WriteString("\n")
+
+	// Separator
+	sb.WriteString(pad)
+	for i, w := range widths {
+		if i > 0 {
+			sb.WriteString(labelStyle.Render("─┼─"))
+		}
+		sb.WriteString(labelStyle.Render(strings.Repeat("─", w)))
+	}
+	sb.WriteString("\n")
+
+	// Rows
+	for ri, row := range rows {
+		sb.WriteString(pad)
+		for ci := range columns {
+			if ci > 0 {
+				sb.WriteString(labelStyle.Render(" │ "))
+			}
+			val := ""
+			isNull := false
+			if ri < len(nullFlags) && ci < len(nullFlags[ri]) {
+				isNull = nullFlags[ri][ci]
+			}
+			if isNull {
+				val = "NULL"
+				sb.WriteString(labelStyle.Render(padRight(val, widths[ci])))
+			} else {
+				if ci < len(row) {
+					val = row[ci]
+				}
+				if len(val) > 30 {
+					val = val[:27] + "..."
+				}
+				sb.WriteString(valueStyle.Render(padRight(val, widths[ci])))
+			}
+		}
+		sb.WriteString("\n")
+	}
+
+	return sb.String()
+}
+
+// getPostgresStatusColor returns lipgloss color based on PostgreSQL result
+func getPostgresStatusColor(res *plugins.PostgresResult) lipgloss.Color {
+	if res == nil {
+		return lipgloss.Color("7") // White - no result yet
+	}
+	if res.Type == "Error" {
+		return lipgloss.Color("1") // Red
+	}
+	return lipgloss.Color("2") // Green
+}
+
+func getPostgresColorFn(res *plugins.PostgresResult) func(a ...any) string {
+	if res == nil {
+		return color.New(color.FgWhite).SprintFunc()
+	}
+	if res.Type == "Error" {
+		return color.New(color.FgRed).SprintFunc()
+	}
+	return color.New(color.FgGreen).SprintFunc()
+}

--- a/pkg/plugins/deployment.go
+++ b/pkg/plugins/deployment.go
@@ -91,6 +91,16 @@ func (d *StackDeployment) NewStack(connType ConnectionType, ctx PluginContext, s
 					zap.Stringer("plugin", p.PluginType()),
 					zap.String("connection_type", string(connType)))
 			}
+		case ConnectionType_POSTGRES:
+			if pgP, ok := p.(PostgresPlugin); ok {
+				if i := pgP.NewPostgresInstance(ctx, svcs); i != nil {
+					instances = append(instances, i)
+				}
+			} else {
+				d.logger.Log(log.TraceLevel, "plugin does not support PostgreSQL protocol, skipping",
+					zap.Stringer("plugin", p.PluginType()),
+					zap.String("connection_type", string(connType)))
+			}
 		}
 	}
 	return instances

--- a/pkg/plugins/wrapper/wrapper.go
+++ b/pkg/plugins/wrapper/wrapper.go
@@ -7,9 +7,13 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// Compile-time interface checks
+var _ plugins.MySQLPlugin = (*PanicCatcher)(nil)
+var _ plugins.PostgresPlugin = (*PanicCatcher)(nil)
+
 // PanicCatcher is a wrapper struct that implements Plugin interface
 // and provides panic recovery and logging. It conditionally implements
-// HttpPlugin, RedisPlugin, and MySQLPlugin based on what the wrapped plugin supports.
+// HttpPlugin, RedisPlugin, MySQLPlugin, and PostgresPlugin based on what the wrapped plugin supports.
 type PanicCatcher struct {
 	logger *zap.Logger
 	p      plugins.Plugin
@@ -296,6 +300,84 @@ func (s *SafeMySQLFilterInstance) Destroy() {
 	defer func() {
 		if r := recover(); r != nil {
 			s.logger.Error("Panic in Destroy (MySQLFilterInstance)",
+				zap.Any("panic", r),
+			)
+		}
+	}()
+
+	s.instance.Destroy()
+}
+
+// NewPostgresInstance implements the PostgresPlugin interface
+func (s *PanicCatcher) NewPostgresInstance(ctx plugins.PluginContext, svcs *services.ServiceRegistry) plugins.PostgresPluginInstance {
+	pgP, ok := s.p.(plugins.PostgresPlugin)
+	if !ok {
+		return nil
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			s.logger.Error("Panic in NewPostgresInstance",
+				zap.Any("panic", r),
+			)
+		}
+	}()
+
+	i := pgP.NewPostgresInstance(ctx, svcs)
+	if i == nil {
+		return nil
+	}
+	return NewSafePostgresFilterInstance(s.logger, i)
+}
+
+// SafePostgresFilterInstance is a wrapper struct that implements PostgresPluginInstance interface
+// and provides panic recovery and logging
+type SafePostgresFilterInstance struct {
+	instance plugins.PostgresPluginInstance
+	logger   *zap.Logger
+}
+
+// NewSafePostgresFilterInstance creates a new SafePostgresFilterInstance
+func NewSafePostgresFilterInstance(logger *zap.Logger, instance plugins.PostgresPluginInstance) *SafePostgresFilterInstance {
+	return &SafePostgresFilterInstance{
+		logger:   logger,
+		instance: instance,
+	}
+}
+
+// OnPostgresCommand implements the PostgresPluginInstance interface
+func (s *SafePostgresFilterInstance) OnPostgresCommand(cmd *plugins.PostgresCommand) (status plugins.PostgresStatus) {
+	defer func() {
+		if r := recover(); r != nil {
+			s.logger.Error("Panic in OnPostgresCommand",
+				zap.Any("panic", r),
+			)
+			status = plugins.PostgresStatusStopIteration
+		}
+	}()
+
+	return s.instance.OnPostgresCommand(cmd)
+}
+
+// OnPostgresResult implements the PostgresPluginInstance interface
+func (s *SafePostgresFilterInstance) OnPostgresResult(res *plugins.PostgresResult) (status plugins.PostgresStatus) {
+	defer func() {
+		if r := recover(); r != nil {
+			s.logger.Error("Panic in OnPostgresResult",
+				zap.Any("panic", r),
+			)
+			status = plugins.PostgresStatusStopIteration
+		}
+	}()
+
+	return s.instance.OnPostgresResult(res)
+}
+
+// Destroy implements the PostgresPluginInstance interface
+func (s *SafePostgresFilterInstance) Destroy() {
+	defer func() {
+		if r := recover(); r != nil {
+			s.logger.Error("Panic in Destroy (PostgresFilterInstance)",
 				zap.Any("panic", r),
 			)
 		}

--- a/pkg/services/eventstore/eventstore.go
+++ b/pkg/services/eventstore/eventstore.go
@@ -272,12 +272,15 @@ const (
 type L7Protocol string
 
 const (
-	L7Protocol_HTTP1 L7Protocol = "http1"
-	L7Protocol_HTTP2 L7Protocol = "http2"
-	L7Protocol_DNS   L7Protocol = "dns"
-	L7Protocol_GRPC  L7Protocol = "grpc"
-	L7Protocol_MYSQL L7Protocol = "mysql"
-	L7Protocol_OTHER L7Protocol = "other"
+	L7Protocol_HTTP1    L7Protocol = "http1"
+	L7Protocol_HTTP2    L7Protocol = "http2"
+	L7Protocol_DNS      L7Protocol = "dns"
+	L7Protocol_GRPC     L7Protocol = "grpc"
+	L7Protocol_REDIS    L7Protocol = "redis"
+	L7Protocol_MYSQL    L7Protocol = "mysql"
+	L7Protocol_MONGODB  L7Protocol = "mongodb"
+	L7Protocol_POSTGRES L7Protocol = "postgres"
+	L7Protocol_OTHER    L7Protocol = "other"
 )
 
 type Connection struct {


### PR DESCRIPTION
Wire PostgreSQL into the access_logs plugin system:

- **access_logs**: console + JSON formatters with result table rendering
- **PanicCatcher wrapper**: safe plugin execution for Postgres
- **Factory and deployment wiring**: ConnectionType_POSTGRES case
- **Shared SQL helpers**: `truncateQuery`, `extractQueryType` extracted to helpers file
- **EventStore**: add `Columns`/`Rows`/`Truncated` fields + missing L7Protocol constants

Report plugin integration is in #270.

## Stack
Stacks on #268 (PostgreSQL wire parser) and #267 (PostgreSQL detection).

## Files Added
| File | Purpose |
|------|---------|
| `access_logs_postgres.go` | Console + JSON formatters for PG commands/results |
| `access_logs_helpers.go` | Shared `truncateQuery`/`extractQueryType` helpers |

## Files Modified
| File | Change |
|------|--------|
| `access_logs_plugin.go` | `NewPostgresInstance()` factory method |
| `deployment.go` | `ConnectionType_POSTGRES` case in `NewStack()` |
| `wrapper.go` | Postgres PanicCatcher wrapper |
| `eventstore.go` | `Columns`/`Rows`/`Truncated` fields + L7Protocol constants |

Closes QPT-977