### PR TITLE
Add L7Protocol mapping for PostgreSQL and Redis

### DIFF
--- a/pkg/plugins/report/report_mysql.go
+++ b/pkg/plugins/report/report_mysql.go
@@ -1,0 +1,79 @@
+package report
+
+import (
+	"context"
+	"time"
+
+	"github.com/qpoint-io/qtap/pkg/plugins"
+	"github.com/qpoint-io/qtap/pkg/services/eventstore"
+	"go.uber.org/zap"
+)
+
+// mysqlFilterInstance handles MySQL traffic for reporting
+type mysqlFilterInstance struct {
+	logger     *zap.Logger
+	ctx        plugins.PluginContext
+	eventstore eventstore.EventStore
+
+	command *plugins.MySQLCommand
+	result  *plugins.MySQLResult
+}
+
+func (m *mysqlFilterInstance) OnMySQLCommand(cmd *plugins.MySQLCommand) plugins.MySQLStatus {
+	m.command = cmd
+	return plugins.MySQLStatusContinue
+}
+
+func (m *mysqlFilterInstance) OnMySQLResult(res *plugins.MySQLResult) plugins.MySQLStatus {
+	m.result = res
+	return plugins.MySQLStatusContinue
+}
+
+func (m *mysqlFilterInstance) Destroy() {
+	if m.command == nil {
+		return
+	}
+
+	ctx := context.TODO()
+	meta := m.ctx.Meta()
+
+	req := m.buildDatabaseRequest(m.command, m.result, meta)
+	m.eventstore.Save(ctx, req)
+
+	m.logger.Debug("mysql plugin instance destroyed")
+}
+
+func (m *mysqlFilterInstance) buildDatabaseRequest(cmd *plugins.MySQLCommand, res *plugins.MySQLResult, meta plugins.Meta) *eventstore.DatabaseRequest {
+	req := &eventstore.DatabaseRequest{
+		Timestamp:    time.Now().UTC(),
+		Direction:    meta.Direction(),
+		DatabaseType: "mysql",
+		Statement:    cmd.Query,
+		WrBytes:      meta.WriteBytes(),
+		RdBytes:      meta.ReadBytes(),
+	}
+
+	// Calculate duration if we have timestamp info
+	if !cmd.Timestamp.IsZero() {
+		duration := time.Since(cmd.Timestamp).Milliseconds()
+		if duration == 0 {
+			duration = 1
+		}
+		req.Duration = duration
+	}
+
+	// Add result details if available
+	if res != nil {
+		req.ResultType = res.Type
+		req.IsError = res.Type == "Error"
+		if req.IsError {
+			req.ErrorMsg = res.ErrorMessage
+		}
+		req.AffectedCount = int64(res.AffectedRows)
+		req.ResultCount = int64(res.RowCount)
+	}
+
+	req.SetRequestID(meta.RequestID())
+
+	return req
+}

--- a/pkg/plugins/report/report_plugin.go
+++ b/pkg/plugins/report/report_plugin.go
@@ -59,6 +59,40 @@ func (f *Factory) NewRedisInstance(ctx plugins.PluginContext, svcs *services.Ser
 	return ri
 }
 
+func (f *Factory) NewMySQLInstance(ctx plugins.PluginContext, svcs *services.ServiceRegistry) plugins.MySQLPluginInstance {
+	f.logger.Debug("new MySQL plugin instance created")
+	mi := &mysqlFilterInstance{
+		logger: f.logger,
+		ctx:    ctx,
+	}
+
+	if es, err := services.GetService[eventstore.EventStore](ctx.Context(), svcs, eventstore.TypeEventStore, ""); err != nil {
+		f.logger.Error("failed to get event store", zap.Error(err))
+		return nil
+	} else {
+		mi.eventstore = es
+	}
+
+	return mi
+}
+
+func (f *Factory) NewPostgresInstance(ctx plugins.PluginContext, svcs *services.ServiceRegistry) plugins.PostgresPluginInstance {
+	f.logger.Debug("new Postgres plugin instance created")
+	pi := &postgresFilterInstance{
+		logger: f.logger,
+		ctx:    ctx,
+	}
+
+	if es, err := services.GetService[eventstore.EventStore](ctx.Context(), svcs, eventstore.TypeEventStore, ""); err != nil {
+		f.logger.Error("failed to get event store", zap.Error(err))
+		return nil
+	} else {
+		pi.eventstore = es
+	}
+
+	return pi
+}
+
 func (f *Factory) Destroy() {
 	f.logger.Debug("plugin destroyed")
 }

--- a/pkg/plugins/report/report_postgres.go
+++ b/pkg/plugins/report/report_postgres.go
@@ -1,0 +1,78 @@
+package report
+
+import (
+	"context"
+	"time"
+
+	"github.com/qpoint-io/qtap/pkg/plugins"
+	"github.com/qpoint-io/qtap/pkg/services/eventstore"
+	"go.uber.org/zap"
+)
+
+// postgresFilterInstance handles PostgreSQL traffic for reporting
+type postgresFilterInstance struct {
+	logger     *zap.Logger
+	ctx        plugins.PluginContext
+	eventstore eventstore.EventStore
+
+	command *plugins.PostgresCommand
+	result  *plugins.PostgresResult
+}
+
+func (p *postgresFilterInstance) OnPostgresCommand(cmd *plugins.PostgresCommand) plugins.PostgresStatus {
+	p.command = cmd
+	return plugins.PostgresStatusContinue
+}
+
+func (p *postgresFilterInstance) OnPostgresResult(res *plugins.PostgresResult) plugins.PostgresStatus {
+	p.result = res
+	return plugins.PostgresStatusContinue
+}
+
+func (p *postgresFilterInstance) Destroy() {
+	if p.command == nil {
+		return
+	}
+
+	ctx := context.TODO()
+	meta := p.ctx.Meta()
+
+	req := p.buildDatabaseRequest(p.command, p.result, meta)
+	p.eventstore.Save(ctx, req)
+
+	p.logger.Debug("postgres plugin instance destroyed")
+}
+
+func (p *postgresFilterInstance) buildDatabaseRequest(cmd *plugins.PostgresCommand, res *plugins.PostgresResult, meta plugins.Meta) *eventstore.DatabaseRequest {
+	req := &eventstore.DatabaseRequest{
+		Timestamp:    time.Now().UTC(),
+		Direction:    meta.Direction(),
+		DatabaseType: "postgresql",
+		Statement:    cmd.Query,
+		WrBytes:      meta.WriteBytes(),
+		RdBytes:      meta.ReadBytes(),
+	}
+
+	// Calculate duration if we have timestamp info
+	if !cmd.Timestamp.IsZero() {
+		duration := time.Since(cmd.Timestamp).Milliseconds()
+		if duration == 0 {
+			duration = 1
+		}
+		req.Duration = duration
+	}
+
+	// Add result details if available
+	if res != nil {
+		req.ResultType = res.Type
+		req.IsError = res.Type == "Error"
+		if req.IsError {
+			req.ErrorMsg = res.ErrorMessage
+		}
+		req.ResultCount = res.RowCount
+	}
+
+	req.SetRequestID(meta.RequestID())
+
+	return req
+}

--- a/pkg/services/reporter/reporter.go
+++ b/pkg/services/reporter/reporter.go
@@ -231,6 +231,10 @@ func toEventStoreL7Protocol(protocol connection.Protocol) eventstore.L7Protocol 
 		return eventstore.L7Protocol_GRPC
 	case connection.Protocol_MYSQL:
 		return eventstore.L7Protocol_MYSQL
+	case connection.Protocol_REDIS:
+		return eventstore.L7Protocol_REDIS
+	case connection.Protocol_POSTGRES:
+		return eventstore.L7Protocol_POSTGRES
 	default:
 		return eventstore.L7Protocol_OTHER
 	}


### PR DESCRIPTION
Map `Protocol_POSTGRES` and `Protocol_REDIS` to their proper `L7Protocol` enum values in the event store reporter. Previously these fell through to `L7Protocol_OTHER`.

Stacked on #251 (postgres-plugins).

Closes QPT-978