### PR TITLE
Add L7Protocol mapping for PostgreSQL and Redis

### DIFF
--- a/pkg/services/reporter/reporter.go
+++ b/pkg/services/reporter/reporter.go
@@ -231,6 +231,10 @@ func toEventStoreL7Protocol(protocol connection.Protocol) eventstore.L7Protocol 
 		return eventstore.L7Protocol_GRPC
 	case connection.Protocol_MYSQL:
 		return eventstore.L7Protocol_MYSQL
+	case connection.Protocol_REDIS:
+		return eventstore.L7Protocol_REDIS
+	case connection.Protocol_POSTGRES:
+		return eventstore.L7Protocol_POSTGRES
 	default:
 		return eventstore.L7Protocol_OTHER
 	}


### PR DESCRIPTION
Maps PostgreSQL and Redis protocol constants to L7Protocol enum values in the reporter, enabling protocol-level metrics.

4 lines changed in `reporter.go` — adds switch cases for the new protocol types.