### PR TITLE
fix: handle closed events channel in routeAPIEvents

### DIFF
--- a/pkg/devtools/manager.go
+++ b/pkg/devtools/manager.go
@@ -172,7 +172,11 @@ func (m *Manager) routeAPIEvents(w http.ResponseWriter, r *http.Request) {
 				)
 			}
 			return
-		case e := <-events:
+		case e, ok := <-events:
+			if !ok {
+				// events channel closed (unsubscribed); stop streaming
+				return
+			}
 			writeEvent(ll, w, e)
 		}
 	}


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Contributing Guide: https://github.com/qpoint-io/qtap/docs/CONTRIBUTING.md
     - 📖 Read the Contributor License Agreement (CLA): https://github.com/qpoint-io/qtap/docs/CLA.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Qpoint Team member.
-->

Fixes closed channel NPE:

```
2026-02-13 12:57:41.000	ERROR	panic in handler	{"method": "GET", "path": "/devtools/api/events", "remote_addr": "[::1]:35250", "panic": "runtime error: invalid memory address or nil pointer dereference"}
github.com/qpoint-io/qtap/pkg/status.(*BaseStatusServer).Start.safeHandler.func3.1
	/go/pkg/mod/github.com/qpoint-io/qtap@v0.0.0-20260211233329-703aaa0a831a/pkg/status/server.go:120
runtime.gopanic
	/usr/local/go/src/runtime/panic.go:783
runtime.panicmem
	/usr/local/go/src/runtime/panic.go:262
runtime.sigpanic
	/usr/local/go/src/runtime/signal_unix.go:925
github.com/qpoint-io/qtap/pkg/devtools.writeEvent
	/go/pkg/mod/github.com/qpoint-io/qtap@v0.0.0-20260211233329-703aaa0a831a/pkg/devtools/manager.go:225
github.com/qpoint-io/qtap/pkg/devtools.(*Manager).routeAPIEvents
	/go/pkg/mod/github.com/qpoint-io/qtap@v0.0.0-20260211233329-703aaa0a831a/pkg/devtools/manager.go:176
net/http.HandlerFunc.ServeHTTP
	/usr/local/go/src/net/http/server.go:2322
github.com/qpoint-io/qtap/pkg/devtools.(*Manager).RegisterRoutes.(*Manager).RegisterRoutes.func1.StripPrefix.func3
	/usr/local/go/src/net/http/server.go:2384
net/http.HandlerFunc.ServeHTTP
	/usr/local/go/src/net/http/server.go:2322
net/http.(*ServeMux).ServeHTTP
	/usr/local/go/src/net/http/server.go:2861
github.com/qpoint-io/qtap/pkg/status.(*BaseStatusServer).Start.safeHandler.func3
	/go/pkg/mod/github.com/qpoint-io/qtap@v0.0.0-20260211233329-703aaa0a831a/pkg/status/server.go:128
net/http.HandlerFunc.ServeHTTP
	/usr/local/go/src/net/http/server.go:2322
net/http.serverHandler.ServeHTTP
	/usr/local/go/src/net/http/server.go:3340
net/http.(*conn).serve
	/usr/local/go/src/net/http/server.go:2109
```
