### PR TITLE
Add direction attribute to HTTP data events and Connection trace

### DIFF
--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -367,6 +367,7 @@ func (c *Connection) Close() {
 	connBytesRecvTotal.WithLabelValues(qnet.IPString(c.OpenEvent.Remote.IP), strconv.Itoa(int(c.OpenEvent.Remote.Port)), c.Direction()).Add(float64(c.CloseEvent.RdBytes))
 
 	span := trace.SpanFromContext(c.ctx)
+	span.SetAttributes(attribute.String("direction", c.Direction()))
 	defer span.End()
 
 	c.logger.Debug("closing connection")

--- a/pkg/stream/protocols/http1/stream.go
+++ b/pkg/stream/protocols/http1/stream.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/qpoint-io/qtap/pkg/connection"
 	"github.com/qpoint-io/qtap/pkg/plugins"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 )
 
@@ -46,6 +48,9 @@ func SetPluginManager(manager *plugins.Manager) HTTPStreamOpt {
 }
 
 func NewHTTPStream(ctx context.Context, domain string, logger *zap.Logger, conn *connection.Connection, opts ...HTTPStreamOpt) *HTTPStream {
+	ctx, span := tracer.Start(ctx, "http1.Stream")
+	span.SetAttributes(attribute.String("stream.type", "http1"))
+
 	// init a stream
 	s := &HTTPStream{
 		ctx:    ctx,
@@ -82,6 +87,12 @@ func (t *HTTPStream) Process(event *connection.DataEvent) error {
 		phase = PhaseResponse
 	}
 
+	span := trace.SpanFromContext(t.ctx)
+	span.AddEvent("http1.data", trace.WithAttributes(
+		attribute.String("direction", string(event.Direction)),
+		attribute.Int("size", len(event.Data)),
+	))
+
 	if t.session == nil || t.session.Closed() {
 		t.session = NewSession(t.ctx, t.logger, t.domain, t.conn, t.pluginManager)
 	}
@@ -96,6 +107,9 @@ func (t *HTTPStream) Process(event *connection.DataEvent) error {
 
 func (t *HTTPStream) Close() {
 	t.logger.Debug("closing http/1 stream")
+	span := trace.SpanFromContext(t.ctx)
+	defer span.End()
+
 	if err := t.session.Close(); err != nil {
 		t.logger.Error("closing session", zap.Error(err))
 	}

--- a/pkg/stream/protocols/http2/stream.go
+++ b/pkg/stream/protocols/http2/stream.go
@@ -152,6 +152,7 @@ func (s *HTTPStream) Process(event *connection.DataEvent) error {
 			span.AddEvent("http2.frame[error]", trace.WithAttributes(
 				attribute.String("error", err.Error()),
 				attribute.Int("length", frameLength),
+				attribute.String("direction", string(event.Direction)),
 			))
 			// stop if the protocol is unrecognized
 			if errors.Is(err, http2.ConnectionError(http2.ErrCodeProtocol)) {
@@ -171,6 +172,7 @@ func (s *HTTPStream) Process(event *connection.DataEvent) error {
 		span.AddEvent(fmt.Sprintf("http2.frame[%s]", frameType), trace.WithAttributes(
 			attribute.Int64("stream_id", int64(frame.Header().StreamID)),
 			attribute.Int("length", frameLength),
+			attribute.String("direction", string(event.Direction)),
 		))
 
 		// session


### PR DESCRIPTION
Adds direction attribute (ingress/egress) to HTTP1 and HTTP2 trace events and the root Connection span, for troubleshooting directionality in event traces.