### PR TITLE
feat: add config command with default and dump subcommands

### DIFF
--- a/pkg/cmd/validate.go
+++ b/pkg/cmd/validate.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/qpoint-io/qtap/pkg/config"
+	"github.com/spf13/cobra"
+)
+
+var validateCmd = &cobra.Command{
+	Use:   "validate [config-file]",
+	Short: "Validate a qtap config file",
+	Long: `Validate a qtap configuration file without starting the agent.
+Pass '-' to read from stdin.
+
+Example usage:
+  qtap validate /etc/qtap/config.yaml
+  cat config.yaml | qtap validate -`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		var data []byte
+		var err error
+
+		if args[0] == "-" {
+			data, err = io.ReadAll(os.Stdin)
+			if err != nil {
+				return fmt.Errorf("reading stdin: %w", err)
+			}
+		} else {
+			data, err = os.ReadFile(args[0])
+			if err != nil {
+				return fmt.Errorf("reading config file: %w", err)
+			}
+		}
+
+		cfg, err := config.UnmarshalConfig(data)
+		if err != nil {
+			return fmt.Errorf("parsing config: %w", err)
+		}
+
+		if err := cfg.Validate(); err != nil {
+			return fmt.Errorf("validating config: %w", err)
+		}
+
+		fmt.Fprintln(cmd.OutOrStdout(), "Config is valid.")
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(validateCmd)
+}

--- a/pkg/cmd/validate_test.go
+++ b/pkg/cmd/validate_test.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestValidateCmd_ValidConfig(t *testing.T) {
+	content := []byte(`stacks:
+  default:
+    plugins:
+      - type: example
+`)
+	tmp := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(tmp, content, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"validate", tmp})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("expected valid config, got error: %v", err)
+	}
+
+	if out := buf.String(); out != "Config is valid.\n" {
+		t.Fatalf("unexpected output: %q", out)
+	}
+}
+
+func TestValidateCmd_InvalidYAML(t *testing.T) {
+	content := []byte(`{{{invalid yaml`)
+	tmp := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(tmp, content, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"validate", tmp})
+
+	if err := rootCmd.Execute(); err == nil {
+		t.Fatal("expected error for invalid YAML, got nil")
+	}
+}
+
+func TestValidateCmd_MissingFile(t *testing.T) {
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"validate", "/nonexistent/config.yaml"})
+
+	if err := rootCmd.Execute(); err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+}
+
+func TestValidateCmd_NoArgs(t *testing.T) {
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"validate"})
+
+	if err := rootCmd.Execute(); err == nil {
+		t.Fatal("expected error for missing args, got nil")
+	}
+}


### PR DESCRIPTION
Implements QPT-273: adds a `config` parent command with two subcommands:

- `qtap config default` — prints the embedded default config YAML to stdout (useful for bootstrapping a config file)
- `qtap config dump --config <path>` — reads a config file, unmarshals it, re-marshals to YAML, and prints the resolved/normalized config. Accepts `-` for stdin.

Also exposes `config.DefaultConfigBytes()` as a public accessor for the embedded default config.