### PR TITLE
Implement per-direction HPACK decoders

### DIFF
--- a/pkg/stream/protocols/http2/headers.go
+++ b/pkg/stream/protocols/http2/headers.go
@@ -33,14 +33,14 @@ type headersOrContinuation interface {
 //
 // This is a modified version of the http2 framer's readMetaFrame method
 // which allows for illegal protocol operations.
-func (t *HTTPStream) readMetaFrame(hf *http2.HeadersFrame, framer *http2.Framer) (*http2.MetaHeadersFrame, error) {
+func (t *HTTPStream) readMetaFrame(hf *http2.HeadersFrame, framer *http2.Framer, decoder *hpack.Decoder) (*http2.MetaHeadersFrame, error) {
 	mh := &http2.MetaHeadersFrame{
 		HeadersFrame: hf,
 	}
 	var remainSize uint32 = MaxHeaderListSize
 
 	// var invalid error // pseudo header field errors
-	hdec := t.headerDecoder
+	hdec := decoder
 	hdec.SetEmitEnabled(true)
 	hdec.SetMaxStringLength(MaxStringLength) // no limit
 	hdec.SetEmitFunc(func(hf hpack.HeaderField) {

--- a/pkg/stream/protocols/http2/stream.go
+++ b/pkg/stream/protocols/http2/stream.go
@@ -56,8 +56,10 @@ type HTTPStream struct {
 	// plugin manager
 	pluginManager *plugins.Manager
 
-	// a buffer
-	buffer []byte
+	// HTTP/2 requires independent HPACK dynamic tables for client→server
+	// and server→client header compression.
+	egressBuffer  []byte // client→server frames
+	ingressBuffer []byte // server→client frames
 
 	// socket connection
 	conn *connection.Connection
@@ -65,8 +67,9 @@ type HTTPStream struct {
 	// sessions
 	sessions map[uint32]*Session
 
-	// HTTP/2 read meta headers decoder
-	headerDecoder *hpack.Decoder
+	// per-direction HPACK decoders
+	egressDecoder  *hpack.Decoder // client→server
+	ingressDecoder *hpack.Decoder // server→client
 
 	// closed
 	closed bool
@@ -100,8 +103,9 @@ func NewHTTPStream(ctx context.Context, domain string, logger *zap.Logger, conn 
 		opt(s)
 	}
 
-	// initialize the header decoder
-	s.headerDecoder = hpack.NewDecoder(4096, nil)
+	// initialize per-direction HPACK decoders
+	s.egressDecoder = hpack.NewDecoder(4096, nil)
+	s.ingressDecoder = hpack.NewDecoder(4096, nil)
 
 	// return the stream
 	return s
@@ -117,36 +121,47 @@ func (s *HTTPStream) Process(event *connection.DataEvent) error {
 		return nil
 	}
 
-	s.buffer = append(s.buffer, event.Data...)
+	// select the directional buffer and decoder
+	var buf *[]byte
+	var decoder *hpack.Decoder
+	if event.Direction == connection.Egress {
+		buf = &s.egressBuffer
+		decoder = s.egressDecoder
+	} else {
+		buf = &s.ingressBuffer
+		decoder = s.ingressDecoder
+	}
+
+	*buf = append(*buf, event.Data...)
 
 	// read the preface if we haven't already
 	if !s.prefaceRead && event.Direction == connection.Egress {
-		if err := s.readPreface(); err != nil {
+		if err := s.readPreface(buf); err != nil {
 			return connection.ErrStreamUnrecoverable(err)
 		}
 
 		s.prefaceRead = true
 	}
 
-	for len(s.buffer) > 0 {
+	for len(*buf) > 0 {
 		// Need at least 9 bytes for the frame header
-		if len(s.buffer) < frameHeaderLen {
+		if len(*buf) < frameHeaderLen {
 			return nil
 		}
 
 		// Parse the frame length from the first 3 bytes (big endian)
-		frameLength := int(s.buffer[0])<<16 | int(s.buffer[1])<<8 | int(s.buffer[2])
+		frameLength := int((*buf)[0])<<16 | int((*buf)[1])<<8 | int((*buf)[2])
 
 		// Calculate total frame size (header + payload)
 		totalFrameSize := frameLength + frameHeaderLen
 
 		// Check if we have the complete frame
-		if len(s.buffer) < totalFrameSize {
+		if len(*buf) < totalFrameSize {
 			return nil
 		}
 
 		// Now we can safely process the complete frame
-		framer := http2.NewFramer(nil, bytes.NewReader(s.buffer[:totalFrameSize]))
+		framer := http2.NewFramer(nil, bytes.NewReader((*buf)[:totalFrameSize]))
 		frame, err := framer.ReadFrame()
 		if err != nil {
 			span.AddEvent("http2.frame[error]", trace.WithAttributes(
@@ -166,7 +181,7 @@ func (s *HTTPStream) Process(event *connection.DataEvent) error {
 			return connection.ErrStreamUnrecoverable(fmt.Errorf("error reading http2 frame: %w", err))
 		}
 		// Remove the processed frame from buffer
-		s.buffer = s.buffer[totalFrameSize:]
+		*buf = (*buf)[totalFrameSize:]
 
 		frameType := strings.TrimPrefix(reflect.TypeOf(frame).String(), "*http2.")
 		span.AddEvent(fmt.Sprintf("http2.frame[%s]", frameType), trace.WithAttributes(
@@ -185,13 +200,13 @@ func (s *HTTPStream) Process(event *connection.DataEvent) error {
 			session.wrBytes += int64(totalFrameSize)
 		}
 
-		err = s.handleFrame(session, frame, framer)
+		err = s.handleFrame(session, frame, framer, decoder)
 		if err != nil {
 			return err
 		}
 
 		// If we have consumed all the buffer, exit the loop
-		if len(s.buffer) == 0 {
+		if len(*buf) == 0 {
 			break
 		}
 	}
@@ -199,12 +214,12 @@ func (s *HTTPStream) Process(event *connection.DataEvent) error {
 	return nil
 }
 
-func (s *HTTPStream) readPreface() error {
+func (s *HTTPStream) readPreface(buf *[]byte) error {
 	// first, read the client connection preface
 	clientPreface := []byte(http2.ClientPreface)
 	prefaceBuffer := make([]byte, len(clientPreface))
 
-	_, err := io.ReadFull(bytes.NewReader(s.buffer), prefaceBuffer)
+	_, err := io.ReadFull(bytes.NewReader(*buf), prefaceBuffer)
 	if err != nil {
 		return fmt.Errorf("failed to read http2 client preface: %w", err)
 	}
@@ -214,10 +229,10 @@ func (s *HTTPStream) readPreface() error {
 	}
 
 	// remove the preface from the buffer
-	if len(s.buffer) > len(clientPreface) {
-		s.buffer = s.buffer[len(clientPreface):]
+	if len(*buf) > len(clientPreface) {
+		*buf = (*buf)[len(clientPreface):]
 	} else {
-		s.buffer = nil
+		*buf = nil
 	}
 
 	return nil
@@ -248,11 +263,11 @@ func (t *HTTPStream) cleanupSession(session *Session) {
 	delete(t.sessions, session.ID)
 }
 
-func (t *HTTPStream) handleFrame(session *Session, frame http2.Frame, framer *http2.Framer) error {
+func (t *HTTPStream) handleFrame(session *Session, frame http2.Frame, framer *http2.Framer, decoder *hpack.Decoder) error {
 	// process the frame
 	switch f := frame.(type) {
 	case *http2.HeadersFrame:
-		mh, err := t.readMetaFrame(f, framer)
+		mh, err := t.readMetaFrame(f, framer, decoder)
 		if err != nil {
 			t.logger.Error("Failed to read meta headers frame",
 				zap.Any("mh", mh),
@@ -401,7 +416,8 @@ func (t *HTTPStream) Close() {
 	}
 
 	t.closed = true
-	t.buffer = nil
+	t.egressBuffer = nil
+	t.ingressBuffer = nil
 }
 
 func (t *HTTPStream) Closed() bool {

--- a/pkg/stream/protocols/http2/stream_test.go
+++ b/pkg/stream/protocols/http2/stream_test.go
@@ -1,0 +1,169 @@
+package http2
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/qpoint-io/qtap/pkg/connection"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/hpack"
+)
+
+// newTestStream creates an HTTPStream with minimal dependencies suitable for unit tests.
+func newTestStream(t *testing.T) *HTTPStream {
+	t.Helper()
+	conn := &connection.Connection{
+		OpenEvent: &connection.OpenEvent{Source: connection.Client},
+	}
+	return NewHTTPStream(t.Context(), "example.com", zap.NewNop(), conn)
+}
+
+// encodeHeadersFrame encodes fields using enc into buf and returns a raw HEADERS frame.
+// The same encoder must be reused across calls within a direction to maintain dynamic
+// table state between frames, mirroring what a real HTTP/2 client or server does.
+func encodeHeadersFrame(t *testing.T, enc *hpack.Encoder, buf *bytes.Buffer, streamID uint32, endStream bool, fields []hpack.HeaderField) []byte {
+	t.Helper()
+	buf.Reset()
+	for _, f := range fields {
+		require.NoError(t, enc.WriteField(f))
+	}
+	var out bytes.Buffer
+	fr := http2.NewFramer(&out, nil)
+	require.NoError(t, fr.WriteHeaders(http2.HeadersFrameParam{
+		StreamID:      streamID,
+		BlockFragment: buf.Bytes(),
+		EndStream:     endStream,
+		EndHeaders:    true,
+	}))
+	return out.Bytes()
+}
+
+func processEgress(t *testing.T, stream *HTTPStream, data ...[]byte) {
+	t.Helper()
+	var combined []byte
+	for _, d := range data {
+		combined = append(combined, d...)
+	}
+	require.NoError(t, stream.Process(&connection.DataEvent{
+		Direction: connection.Egress,
+		Data:      combined,
+	}))
+}
+
+func processIngress(t *testing.T, stream *HTTPStream, data ...[]byte) {
+	t.Helper()
+	var combined []byte
+	for _, d := range data {
+		combined = append(combined, d...)
+	}
+	require.NoError(t, stream.Process(&connection.DataEvent{
+		Direction: connection.Ingress,
+		Data:      combined,
+	}))
+}
+
+// TestHPACKEgressDecoderPersistsAcrossStreams verifies that the egress HPACK decoder
+// maintains its dynamic table across multiple request streams on the same connection.
+// HTTP/2 requires one dynamic table per direction, shared across all streams.
+func TestHPACKEgressDecoderPersistsAcrossStreams(t *testing.T) {
+	stream := newTestStream(t)
+
+	var hdrBuf bytes.Buffer
+	enc := hpack.NewEncoder(&hdrBuf)
+
+	// Request 1 on stream 1: adds x-request-id=abc123 to the egress encoder's
+	// dynamic table via literal-with-incremental-indexing.
+	req1 := encodeHeadersFrame(t, enc, &hdrBuf, 1, true, []hpack.HeaderField{
+		{Name: ":method", Value: "GET"},
+		{Name: ":scheme", Value: "https"},
+		{Name: ":path", Value: "/first"},
+		{Name: "x-request-id", Value: "abc123"},
+	})
+	processEgress(t, stream, []byte(http2.ClientPreface), req1)
+
+	// Request 2 on stream 3: the encoder emits x-request-id=abc123 as a back-reference
+	// to the dynamic table entry established in request 1. The egress decoder must
+	// have retained that entry to resolve it correctly.
+	req2 := encodeHeadersFrame(t, enc, &hdrBuf, 3, true, []hpack.HeaderField{
+		{Name: ":method", Value: "GET"},
+		{Name: ":scheme", Value: "https"},
+		{Name: ":path", Value: "/second"},
+		{Name: "x-request-id", Value: "abc123"},
+	})
+	processEgress(t, stream, req2)
+
+	s1, ok := stream.sessions[1]
+	require.True(t, ok, "session for stream 1 should exist")
+	require.Equal(t, "/first", s1.req.URL.Path)
+	require.Equal(t, "abc123", s1.req.Header.Get("X-Request-Id"))
+
+	s3, ok := stream.sessions[3]
+	require.True(t, ok, "session for stream 3 should exist")
+	require.Equal(t, "/second", s3.req.URL.Path)
+	require.Equal(t, "abc123", s3.req.Header.Get("X-Request-Id"),
+		"x-request-id should decode correctly via HPACK back-reference from a prior stream")
+}
+
+// TestHPACKDirectionsUseIndependentDecoders verifies that the egress and ingress HPACK
+// decoders maintain independent dynamic tables, as required by the HTTP/2 spec (RFC 7541).
+//
+// The bug this tests: a single shared headerDecoder was used for both directions.
+// When the server sent a response HEADERS frame, entries were added to the shared
+// decoder's dynamic table, shifting the indices the egress encoder expected. A
+// subsequent egress HEADERS back-reference would then resolve to the wrong header.
+func TestHPACKDirectionsUseIndependentDecoders(t *testing.T) {
+	stream := newTestStream(t)
+
+	var egressHdrBuf, ingressHdrBuf bytes.Buffer
+	egressEnc := hpack.NewEncoder(&egressHdrBuf)
+	ingressEnc := hpack.NewEncoder(&ingressHdrBuf)
+
+	// Step 1: Request 1 (egress, stream 1).
+	// Adds x-request-id=abc123 to the egress encoder's dynamic table at index 62
+	// (after :path=/api/v1 is also indexed, shifting it to 63).
+	req1 := encodeHeadersFrame(t, egressEnc, &egressHdrBuf, 1, true, []hpack.HeaderField{
+		{Name: ":method", Value: "GET"},
+		{Name: ":scheme", Value: "https"},
+		{Name: ":path", Value: "/api/v1"},
+		{Name: "x-request-id", Value: "abc123"},
+	})
+	processEgress(t, stream, []byte(http2.ClientPreface), req1)
+
+	// Step 2: Response 1 (ingress, stream 1).
+	// Adds content-type=text/html to the ingress encoder's dynamic table.
+	// With the old shared decoder, this would also insert content-type=text/html
+	// at index 62 of the shared decoder, pushing x-request-id=abc123 to index 63.
+	// The egress encoder still believes x-request-id=abc123 is at index 62.
+	resp1 := encodeHeadersFrame(t, ingressEnc, &ingressHdrBuf, 1, true, []hpack.HeaderField{
+		{Name: ":status", Value: "200"},
+		{Name: "content-type", Value: "text/html"},
+	})
+	processIngress(t, stream, resp1)
+	// Stream 1's session is now completed and removed from the map.
+	_, exists := stream.sessions[1]
+	require.False(t, exists, "stream 1 session should have been cleaned up after response")
+
+	// Step 3: Request 2 (egress, stream 3).
+	// The egress encoder emits x-request-id=abc123 as an indexed back-reference.
+	// With the old shared decoder, the index it resolves to points at content-type=text/html
+	// (inserted by the ingress response), producing the wrong header.
+	// With the fix (per-direction decoders), the egress decoder's table is untouched
+	// by ingress frames and resolves the index to x-request-id=abc123 correctly.
+	req2 := encodeHeadersFrame(t, egressEnc, &egressHdrBuf, 3, true, []hpack.HeaderField{
+		{Name: ":method", Value: "GET"},
+		{Name: ":scheme", Value: "https"},
+		{Name: ":path", Value: "/api/v2"},
+		{Name: "x-request-id", Value: "abc123"},
+	})
+	processEgress(t, stream, req2)
+
+	s3, ok := stream.sessions[3]
+	require.True(t, ok, "session for stream 3 should exist")
+	require.Equal(t, "/api/v2", s3.req.URL.Path)
+	require.Equal(t, "abc123", s3.req.Header.Get("X-Request-Id"),
+		"x-request-id header was corrupted: egress decoder was polluted by ingress frames (shared decoder bug)")
+	require.Empty(t, s3.req.Header.Get("Content-Type"),
+		"content-type from the ingress response must not appear in the egress request headers")
+}


### PR DESCRIPTION
This change addresses issues with shared header decoders that could lead to incorrect header resolution in HTTP/2 communication.

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Contributing Guide: https://github.com/qpoint-io/qtap/docs/CONTRIBUTING.md
     - 📖 Read the Contributor License Agreement (CLA): https://github.com/qpoint-io/qtap/docs/CLA.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Qpoint Team member.
-->
