### PR TITLE
Split HPACK decoder per direction

### DIFF
--- a/pkg/stream/protocols/http2/headers.go
+++ b/pkg/stream/protocols/http2/headers.go
@@ -33,14 +33,14 @@ type headersOrContinuation interface {
 //
 // This is a modified version of the http2 framer's readMetaFrame method
 // which allows for illegal protocol operations.
-func (t *HTTPStream) readMetaFrame(hf *http2.HeadersFrame, framer *http2.Framer) (*http2.MetaHeadersFrame, error) {
+func (t *HTTPStream) readMetaFrame(hf *http2.HeadersFrame, framer *http2.Framer, decoder *hpack.Decoder) (*http2.MetaHeadersFrame, error) {
 	mh := &http2.MetaHeadersFrame{
 		HeadersFrame: hf,
 	}
 	var remainSize uint32 = MaxHeaderListSize
 
 	// var invalid error // pseudo header field errors
-	hdec := t.headerDecoder
+	hdec := decoder
 	hdec.SetEmitEnabled(true)
 	hdec.SetMaxStringLength(MaxStringLength) // no limit
 	hdec.SetEmitFunc(func(hf hpack.HeaderField) {

--- a/pkg/stream/protocols/http2/hpack_test.go
+++ b/pkg/stream/protocols/http2/hpack_test.go
@@ -1,0 +1,199 @@
+package http2
+
+import (
+	"bytes"
+	"testing"
+
+	"golang.org/x/net/http2/hpack"
+)
+
+// encodeHeaders encodes header fields using the given encoder, returning the
+// encoded bytes. The encoder maintains dynamic table state across calls.
+func encodeHeaders(enc *hpack.Encoder, buf *bytes.Buffer, fields ...hpack.HeaderField) []byte {
+	buf.Reset()
+	for _, f := range fields {
+		_ = enc.WriteField(f)
+	}
+	out := make([]byte, buf.Len())
+	copy(out, buf.Bytes())
+	return out
+}
+
+func hf(name, value string) hpack.HeaderField {
+	return hpack.HeaderField{Name: name, Value: value}
+}
+
+func assertHeader(t *testing.T, fields []hpack.HeaderField, name, want string) {
+	t.Helper()
+	for _, f := range fields {
+		if f.Name == name {
+			if f.Value != want {
+				t.Errorf("header %q = %q, want %q", name, f.Value, want)
+			}
+			return
+		}
+	}
+	t.Errorf("header %q not found in %v", name, fields)
+}
+
+// TestPerDirectionDecodersIndependentDynamicTables verifies that separate
+// HPACK decoders maintain independent dynamic tables, which is required
+// by HTTP/2 (RFC 7540 §4.3, RFC 7541 §4).
+func TestPerDirectionDecodersIndependentDynamicTables(t *testing.T) {
+	egressDecoder := hpack.NewDecoder(4096, nil)
+	ingressDecoder := hpack.NewDecoder(4096, nil)
+
+	var eBuf, iBuf bytes.Buffer
+	egressEncoder := hpack.NewEncoder(&eBuf)
+	ingressEncoder := hpack.NewEncoder(&iBuf)
+
+	// Encode request headers (egress direction)
+	egressData := encodeHeaders(egressEncoder, &eBuf,
+		hf(":method", "POST"),
+		hf(":path", "/api/v1/users"),
+		hf("x-request-id", "req-123"),
+	)
+
+	// Encode response headers (ingress direction)
+	ingressData := encodeHeaders(ingressEncoder, &iBuf,
+		hf(":status", "200"),
+		hf("content-type", "application/json"),
+		hf("x-trace-id", "trace-456"),
+	)
+
+	// Decode with separate decoders
+	egressFields, err := egressDecoder.DecodeFull(egressData)
+	if err != nil {
+		t.Fatalf("egress decode failed: %v", err)
+	}
+	assertHeader(t, egressFields, ":method", "POST")
+	assertHeader(t, egressFields, ":path", "/api/v1/users")
+	assertHeader(t, egressFields, "x-request-id", "req-123")
+
+	ingressFields, err := ingressDecoder.DecodeFull(ingressData)
+	if err != nil {
+		t.Fatalf("ingress decode failed: %v", err)
+	}
+	assertHeader(t, ingressFields, ":status", "200")
+	assertHeader(t, ingressFields, "content-type", "application/json")
+	assertHeader(t, ingressFields, "x-trace-id", "trace-456")
+}
+
+// TestSharedDecoderCorruptsDynamicTable demonstrates the bug that occurs
+// when a single HPACK decoder is shared between both directions.
+func TestSharedDecoderCorruptsDynamicTable(t *testing.T) {
+	sharedDecoder := hpack.NewDecoder(4096, nil)
+
+	var eBuf, iBuf bytes.Buffer
+	egressEncoder := hpack.NewEncoder(&eBuf)
+	ingressEncoder := hpack.NewEncoder(&iBuf)
+
+	// Round 1: both directions encode a custom header
+	egressData1 := encodeHeaders(egressEncoder, &eBuf, hf("x-custom", "egress-value-1"))
+	ingressData1 := encodeHeaders(ingressEncoder, &iBuf, hf("x-custom", "ingress-value-1"))
+
+	// Decode egress with shared decoder — adds "x-custom: egress-value-1" to dynamic table
+	_, err := sharedDecoder.DecodeFull(egressData1)
+	if err != nil {
+		t.Fatalf("shared decode egress round 1: %v", err)
+	}
+
+	// Decode ingress with same decoder — should work for literal headers
+	_, err = sharedDecoder.DecodeFull(ingressData1)
+	if err != nil {
+		t.Logf("shared decoder failed on cross-direction decode (round 1): %v", err)
+		return
+	}
+
+	// Round 2: encoders will now use indexed references to their own dynamic tables
+	egressData2 := encodeHeaders(egressEncoder, &eBuf, hf("x-custom", "egress-value-2"))
+	ingressData2 := encodeHeaders(ingressEncoder, &iBuf, hf("x-custom", "ingress-value-2"))
+
+	// Decode egress round 2
+	_, err = sharedDecoder.DecodeFull(egressData2)
+	if err != nil {
+		t.Logf("shared decoder failed on egress round 2: %v", err)
+		return
+	}
+
+	// This ingress decode is where corruption is most likely
+	fields, err := sharedDecoder.DecodeFull(ingressData2)
+	if err != nil {
+		t.Logf("shared decoder correctly failed on ingress round 2: %v", err)
+		return
+	}
+
+	// Even if no error, the dynamic table state is polluted
+	for _, f := range fields {
+		t.Logf("shared decoder got: %s=%s", f.Name, f.Value)
+	}
+
+	// Demonstrate that separate decoders don't have this problem
+	egressDec := hpack.NewDecoder(4096, nil)
+	ingressDec := hpack.NewDecoder(4096, nil)
+
+	eBuf.Reset()
+	iBuf.Reset()
+	egressEncoder2 := hpack.NewEncoder(&eBuf)
+	ingressEncoder2 := hpack.NewEncoder(&iBuf)
+
+	for i := range 3 {
+		ed := encodeHeaders(egressEncoder2, &eBuf, hf("x-round", "egress"))
+		id := encodeHeaders(ingressEncoder2, &iBuf, hf("x-round", "ingress"))
+
+		ef, err := egressDec.DecodeFull(ed)
+		if err != nil {
+			t.Fatalf("separate egress decode round %d: %v", i, err)
+		}
+		assertHeader(t, ef, "x-round", "egress")
+
+		inf, err := ingressDec.DecodeFull(id)
+		if err != nil {
+			t.Fatalf("separate ingress decode round %d: %v", i, err)
+		}
+		assertHeader(t, inf, "x-round", "ingress")
+	}
+}
+
+// TestInterleavedEgressIngressDecoding verifies that interleaved egress and
+// ingress frames decode correctly with separate per-direction decoders.
+func TestInterleavedEgressIngressDecoding(t *testing.T) {
+	egressDecoder := hpack.NewDecoder(4096, nil)
+	ingressDecoder := hpack.NewDecoder(4096, nil)
+
+	var eBuf, iBuf bytes.Buffer
+	egressEncoder := hpack.NewEncoder(&eBuf)
+	ingressEncoder := hpack.NewEncoder(&iBuf)
+
+	// Interleaved: egress1, egress3, ingress1, ingress3
+	egress1 := encodeHeaders(egressEncoder, &eBuf, hf(":method", "GET"), hf(":path", "/stream1"))
+	egress3 := encodeHeaders(egressEncoder, &eBuf, hf(":method", "POST"), hf(":path", "/stream3"))
+	ingress1 := encodeHeaders(ingressEncoder, &iBuf, hf(":status", "200"), hf("x-stream", "1"))
+	ingress3 := encodeHeaders(ingressEncoder, &iBuf, hf(":status", "404"), hf("x-stream", "3"))
+
+	f, err := egressDecoder.DecodeFull(egress1)
+	if err != nil {
+		t.Fatalf("egress1: %v", err)
+	}
+	assertHeader(t, f, ":path", "/stream1")
+
+	f, err = egressDecoder.DecodeFull(egress3)
+	if err != nil {
+		t.Fatalf("egress3: %v", err)
+	}
+	assertHeader(t, f, ":path", "/stream3")
+
+	f, err = ingressDecoder.DecodeFull(ingress1)
+	if err != nil {
+		t.Fatalf("ingress1: %v", err)
+	}
+	assertHeader(t, f, ":status", "200")
+	assertHeader(t, f, "x-stream", "1")
+
+	f, err = ingressDecoder.DecodeFull(ingress3)
+	if err != nil {
+		t.Fatalf("ingress3: %v", err)
+	}
+	assertHeader(t, f, ":status", "404")
+	assertHeader(t, f, "x-stream", "3")
+}

--- a/pkg/stream/protocols/http2/stream.go
+++ b/pkg/stream/protocols/http2/stream.go
@@ -56,8 +56,10 @@ type HTTPStream struct {
 	// plugin manager
 	pluginManager *plugins.Manager
 
-	// a buffer
-	buffer []byte
+	// separate buffers for each direction to avoid mixing frames
+	// from client→server and server→client
+	egressBuffer  []byte // client → server (requests)
+	ingressBuffer []byte // server → client (responses)
 
 	// socket connection
 	conn *connection.Connection
@@ -65,8 +67,11 @@ type HTTPStream struct {
 	// sessions
 	sessions map[uint32]*Session
 
-	// HTTP/2 read meta headers decoder
-	headerDecoder *hpack.Decoder
+	// Separate HPACK decoders for each direction.
+	// HTTP/2 requires independent HPACK dynamic tables for
+	// client→server and server→client header compression.
+	egressDecoder  *hpack.Decoder // decodes client→server HEADERS (requests)
+	ingressDecoder *hpack.Decoder // decodes server→client HEADERS (responses)
 
 	// closed
 	closed bool
@@ -100,8 +105,10 @@ func NewHTTPStream(ctx context.Context, domain string, logger *zap.Logger, conn 
 		opt(s)
 	}
 
-	// initialize the header decoder
-	s.headerDecoder = hpack.NewDecoder(4096, nil)
+	// initialize separate HPACK decoders for each direction
+	// HTTP/2 spec requires independent dynamic tables per direction
+	s.egressDecoder = hpack.NewDecoder(4096, nil)
+	s.ingressDecoder = hpack.NewDecoder(4096, nil)
 
 	// return the stream
 	return s
@@ -117,36 +124,49 @@ func (s *HTTPStream) Process(event *connection.DataEvent) error {
 		return nil
 	}
 
-	s.buffer = append(s.buffer, event.Data...)
+	// Select the correct buffer and HPACK decoder based on direction.
+	// HTTP/2 requires separate frame streams and HPACK dynamic tables
+	// for each direction (client→server vs server→client).
+	var buffer *[]byte
+	var decoder *hpack.Decoder
+	if event.Direction == connection.Egress {
+		buffer = &s.egressBuffer
+		decoder = s.egressDecoder
+	} else {
+		buffer = &s.ingressBuffer
+		decoder = s.ingressDecoder
+	}
+
+	*buffer = append(*buffer, event.Data...)
 
 	// read the preface if we haven't already
 	if !s.prefaceRead && event.Direction == connection.Egress {
-		if err := s.readPreface(); err != nil {
+		if err := s.readPreface(buffer); err != nil {
 			return connection.ErrStreamUnrecoverable(err)
 		}
 
 		s.prefaceRead = true
 	}
 
-	for len(s.buffer) > 0 {
+	for len(*buffer) > 0 {
 		// Need at least 9 bytes for the frame header
-		if len(s.buffer) < frameHeaderLen {
+		if len(*buffer) < frameHeaderLen {
 			return nil
 		}
 
 		// Parse the frame length from the first 3 bytes (big endian)
-		frameLength := int(s.buffer[0])<<16 | int(s.buffer[1])<<8 | int(s.buffer[2])
+		frameLength := int((*buffer)[0])<<16 | int((*buffer)[1])<<8 | int((*buffer)[2])
 
 		// Calculate total frame size (header + payload)
 		totalFrameSize := frameLength + frameHeaderLen
 
 		// Check if we have the complete frame
-		if len(s.buffer) < totalFrameSize {
+		if len(*buffer) < totalFrameSize {
 			return nil
 		}
 
 		// Now we can safely process the complete frame
-		framer := http2.NewFramer(nil, bytes.NewReader(s.buffer[:totalFrameSize]))
+		framer := http2.NewFramer(nil, bytes.NewReader((*buffer)[:totalFrameSize]))
 		frame, err := framer.ReadFrame()
 		if err != nil {
 			span.AddEvent("http2.frame[error]", trace.WithAttributes(
@@ -166,7 +186,7 @@ func (s *HTTPStream) Process(event *connection.DataEvent) error {
 			return connection.ErrStreamUnrecoverable(fmt.Errorf("error reading http2 frame: %w", err))
 		}
 		// Remove the processed frame from buffer
-		s.buffer = s.buffer[totalFrameSize:]
+		*buffer = (*buffer)[totalFrameSize:]
 
 		frameType := strings.TrimPrefix(reflect.TypeOf(frame).String(), "*http2.")
 		span.AddEvent(fmt.Sprintf("http2.frame[%s]", frameType), trace.WithAttributes(
@@ -185,13 +205,13 @@ func (s *HTTPStream) Process(event *connection.DataEvent) error {
 			session.wrBytes += int64(totalFrameSize)
 		}
 
-		err = s.handleFrame(session, frame, framer)
+		err = s.handleFrame(session, frame, framer, decoder)
 		if err != nil {
 			return err
 		}
 
 		// If we have consumed all the buffer, exit the loop
-		if len(s.buffer) == 0 {
+		if len(*buffer) == 0 {
 			break
 		}
 	}
@@ -199,12 +219,12 @@ func (s *HTTPStream) Process(event *connection.DataEvent) error {
 	return nil
 }
 
-func (s *HTTPStream) readPreface() error {
+func (s *HTTPStream) readPreface(buffer *[]byte) error {
 	// first, read the client connection preface
 	clientPreface := []byte(http2.ClientPreface)
 	prefaceBuffer := make([]byte, len(clientPreface))
 
-	_, err := io.ReadFull(bytes.NewReader(s.buffer), prefaceBuffer)
+	_, err := io.ReadFull(bytes.NewReader(*buffer), prefaceBuffer)
 	if err != nil {
 		return fmt.Errorf("failed to read http2 client preface: %w", err)
 	}
@@ -214,10 +234,10 @@ func (s *HTTPStream) readPreface() error {
 	}
 
 	// remove the preface from the buffer
-	if len(s.buffer) > len(clientPreface) {
-		s.buffer = s.buffer[len(clientPreface):]
+	if len(*buffer) > len(clientPreface) {
+		*buffer = (*buffer)[len(clientPreface):]
 	} else {
-		s.buffer = nil
+		*buffer = nil
 	}
 
 	return nil
@@ -248,11 +268,11 @@ func (t *HTTPStream) cleanupSession(session *Session) {
 	delete(t.sessions, session.ID)
 }
 
-func (t *HTTPStream) handleFrame(session *Session, frame http2.Frame, framer *http2.Framer) error {
+func (t *HTTPStream) handleFrame(session *Session, frame http2.Frame, framer *http2.Framer, decoder *hpack.Decoder) error {
 	// process the frame
 	switch f := frame.(type) {
 	case *http2.HeadersFrame:
-		mh, err := t.readMetaFrame(f, framer)
+		mh, err := t.readMetaFrame(f, framer, decoder)
 		if err != nil {
 			t.logger.Error("Failed to read meta headers frame",
 				zap.Any("mh", mh),
@@ -401,7 +421,8 @@ func (t *HTTPStream) Close() {
 	}
 
 	t.closed = true
-	t.buffer = nil
+	t.egressBuffer = nil
+	t.ingressBuffer = nil
 }
 
 func (t *HTTPStream) Closed() bool {


### PR DESCRIPTION
Splits the shared HPACK decoder and buffer into per-direction pairs (egress/ingress). HTTP/2 requires independent dynamic tables for each direction; sharing one decoder corrupts header decoding on multiplexed connections.

Extracted from #253 per review feedback.

Includes tests verifying independent dynamic table state.