### PR TITLE
(DO NOT MERGE) Add gRPC capture support to httpcapture plugin

### DIFF
--- a/e2e/grpc_test.go
+++ b/e2e/grpc_test.go
@@ -3,6 +3,7 @@
 package e2e
 
 import (
+	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
@@ -11,6 +12,8 @@ import (
 
 	"github.com/qpoint-io/qtap/pkg/config"
 	e2epkg "github.com/qpoint-io/qtap/pkg/e2e"
+	"github.com/qpoint-io/qtap/pkg/plugins/httpcapture"
+	"github.com/qpoint-io/qtap/pkg/plugins/report"
 	"github.com/qpoint-io/qtap/pkg/services/eventstore"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -20,6 +23,8 @@ import (
 	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/reflection"
+	"google.golang.org/protobuf/proto"
+	"gopkg.in/yaml.v3"
 )
 
 func TestGRPC(t *testing.T) {
@@ -94,5 +99,113 @@ func TestGRPC(t *testing.T) {
 		assert.Equal(t, "Check", grpcReq.GrpcMethod)
 		assert.Equal(t, "0", grpcReq.GrpcStatus)
 		assert.Equal(t, "OK", grpcReq.GrpcStatusName)
+	})
+}
+
+func TestGRPC_Capture(t *testing.T) {
+	ctx := e2ectx.TestCtx(t)
+
+	// Start in-process gRPC server with the standard health check service
+	lis, err := net.Listen("tcp", "0.0.0.0:0")
+	require.NoError(t, err)
+	port := lis.Addr().(*net.TCPAddr).Port
+
+	grpcServer := grpc.NewServer()
+	grpc_health_v1.RegisterHealthServer(grpcServer, health.NewServer())
+	reflection.Register(grpcServer)
+	go grpcServer.Serve(lis) //nolint:errcheck
+	defer grpcServer.Stop()
+
+	ctx.WithConfig(t, func(c *config.Config) {
+		c.Tap.IgnoreLoopback = false
+		c.Tap.Direction = config.TrafficDirection_EGRESS
+
+		var pluginConfYaml yaml.Node
+		err := pluginConfYaml.Encode(&httpcapture.HttpCaptureConfig{
+			Level:  httpcapture.CaptureLevelFull,
+			Format: httpcapture.OutputFormatJSON,
+		})
+		require.NoError(t, err)
+
+		c.Stacks[c.Tap.Http.Stack] = config.Stack{
+			Plugins: []config.Plugin{
+				{
+					Type:   string(httpcapture.PluginTypeHttpCapture),
+					Config: pluginConfYaml,
+				},
+				{
+					Type: string(report.PluginTypeReport),
+				},
+			},
+		}
+	}, func(t *testing.T) {
+		target := fmt.Sprintf("%s:%d", ctx.MachineIP().String(), port)
+		ctxID := e2epkg.NewID()
+
+		container, err := testcontainers.Run(
+			ctx,
+			"fullstorydev/grpcurl:latest",
+			testcontainers.WithCmd("-plaintext", target, "grpc.health.v1.Health/Check"),
+			testcontainers.WithEnv(map[string]string{
+				"QPOINT_TAGS": "ctxid:" + ctxID,
+			}),
+			testcontainers.WithWaitStrategy(wait.ForExit().WithExitTimeout(10*time.Second)),
+		)
+		t.Cleanup(func() { testcontainers.TerminateContainer(container) })
+		require.NoError(t, err)
+
+		// Wait for gRPC transaction artifact
+		var artifact *eventstore.Artifact
+		require.Eventually(t, func() bool {
+			for _, a := range e2ectx.EventStore.GetByCtxID(ctxID).Artifacts {
+				if a.Type == eventstore.ArtifactType_GRPCTransaction {
+					artifact = a
+					return true
+				}
+			}
+			return false
+		}, 10*time.Second, 100*time.Millisecond, "no gRPC transaction artifact found")
+
+		assert.Equal(t, eventstore.ArtifactType_GRPCTransaction, artifact.Type)
+
+		var transaction httpcapture.GrpcTransaction
+		err = json.Unmarshal(artifact.Data, &transaction)
+		require.NoError(t, err)
+
+		assert.Equal(t, "grpc.health.v1.Health", transaction.Service)
+		assert.Equal(t, "Check", transaction.Method)
+		assert.Equal(t, "0", transaction.GrpcStatus)
+		assert.Equal(t, "OK", transaction.GrpcStatusName)
+
+		// Validate that the payload was captured (plaintext gRPC should have body data)
+		require.NotEmpty(t, transaction.Request.Body, "request body should be captured for plaintext gRPC at full capture level")
+		require.NotEmpty(t, transaction.Response.Body, "response body should be captured for plaintext gRPC at full capture level")
+
+		// Validate request/response headers were captured
+		assert.NotEmpty(t, transaction.Request.Headers, "request headers should be captured at full capture level")
+		assert.NotEmpty(t, transaction.Response.Headers, "response headers should be captured at full capture level")
+		assert.Equal(t, "application/grpc", transaction.Request.ContentType)
+
+		// Validate request body is a valid gRPC-framed HealthCheckRequest.
+		// gRPC frames: 1 byte compressed flag + 4 bytes message length + protobuf payload.
+		reqBody := transaction.Request.Body
+		require.GreaterOrEqual(t, len(reqBody), 5, "request body too short for gRPC frame header")
+		assert.Equal(t, byte(0), reqBody[0], "request compressed flag should be 0 (uncompressed)")
+		var healthReq grpc_health_v1.HealthCheckRequest
+		reqPayload := reqBody[5:] // skip 5-byte gRPC frame header
+		err = proto.Unmarshal(reqPayload, &healthReq)
+		require.NoError(t, err, "request body should unmarshal as HealthCheckRequest")
+		// HealthCheckRequest with no service field means "overall health"
+		assert.Empty(t, healthReq.Service, "health check request service should be empty (overall health)")
+
+		// Validate response body is a valid gRPC-framed HealthCheckResponse with SERVING status.
+		resBody := transaction.Response.Body
+		require.GreaterOrEqual(t, len(resBody), 5, "response body too short for gRPC frame header")
+		assert.Equal(t, byte(0), resBody[0], "response compressed flag should be 0 (uncompressed)")
+		var healthResp grpc_health_v1.HealthCheckResponse
+		resPayload := resBody[5:] // skip 5-byte gRPC frame header
+		err = proto.Unmarshal(resPayload, &healthResp)
+		require.NoError(t, err, "response body should unmarshal as HealthCheckResponse")
+		assert.Equal(t, grpc_health_v1.HealthCheckResponse_SERVING, healthResp.Status, "health check response should be SERVING")
 	})
 }

--- a/e2e/http_test.go
+++ b/e2e/http_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -58,7 +59,7 @@ func TestHTTP_SSE(t *testing.T) {
 		w.Header().Set("Connection", "keep-alive")
 		w.WriteHeader(http.StatusOK)
 
-		for i := 0; i < 3; i++ {
+		for i := range 3 {
 			fmt.Fprintf(w, "data: %s\n\n", fmt.Sprintf("Event %d", i))
 			time.Sleep(1 * time.Second)
 			w.(http.Flusher).Flush()
@@ -151,7 +152,7 @@ func TestHTTP_Ingress(t *testing.T) {
 		assert.NotZero(t, src.Address.Port)
 
 		assert.Equal(t, serverURL.Hostname(), dst.Address.IP.String())
-		assert.Equal(t, "5678", fmt.Sprint(dst.Address.Port))
+		assert.Equal(t, "5678", strconv.FormatUint(uint64(dst.Address.Port), 10))
 
 		// test request
 		require.Len(t, events.Requests, 1)
@@ -186,7 +187,7 @@ func echoHTTPServer(ctx *e2e.TestContext) *url.URL {
 
 	return &url.URL{
 		Scheme: "http",
-		Host:   fmt.Sprintf("%s:5678", containerIP),
+		Host:   containerIP + ":5678",
 	}
 }
 
@@ -312,7 +313,7 @@ func TestLanguageNonIntrospective(t *testing.T) {
 		WithValidation(func(t *testing.T, ctx e2e.ValidationContext) error {
 			events := ctx.TestContext.Events(1)
 			require.Len(t, events.Connections, 1)
-			require.Len(t, events.Requests, 0)
+			require.Empty(t, events.Requests)
 
 			return nil
 		}).

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -4,6 +4,7 @@ package e2e
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -92,7 +93,7 @@ func mainSetup() error {
 	}
 
 	if syscall.Getuid() != 0 {
-		return fmt.Errorf("please run e2e tests as root to load BPF programs and maps")
+		return errors.New("please run e2e tests as root to load BPF programs and maps")
 	}
 
 	// set up config

--- a/e2e/process_test.go
+++ b/e2e/process_test.go
@@ -55,7 +55,7 @@ func TestProcessFiltering(t *testing.T) {
 
 		// expect to timeout because we should never capture the connection
 		events, err := e2ectx.EventStore.AwaitByCtxID(example.ID, 1, 3*time.Second)
-		require.NotNil(t, err)
+		require.Error(t, err)
 		require.Nil(t, events)
 	})
 }

--- a/pkg/plugins/httpcapture/grpctransaction.go
+++ b/pkg/plugins/httpcapture/grpctransaction.go
@@ -1,0 +1,199 @@
+package httpcapture
+
+import (
+	"encoding/json"
+	"maps"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/qpoint-io/qtap/pkg/plugins"
+	"github.com/qpoint-io/qtap/pkg/plugins/tools"
+)
+
+// GrpcTransaction represents a gRPC request-response transaction
+type GrpcTransaction struct {
+	// Process and connection metadata
+	Metadata Metadata `json:"metadata"`
+
+	// gRPC-specific fields
+	Service        string `json:"service"`
+	Method         string `json:"method"`
+	GrpcStatus     string `json:"grpc_status"`
+	GrpcStatusName string `json:"grpc_status_name"`
+	GrpcMessage    string `json:"grpc_message,omitempty"`
+
+	// Request information
+	Request GrpcMessage `json:"request"`
+
+	// Response information
+	Response GrpcResponse `json:"response"`
+
+	// Transaction metadata
+	TransactionTime time.Time `json:"transaction_time"`
+	DurationMs      int64     `json:"duration_ms,omitempty"`
+	Direction       string    `json:"direction,omitempty"`
+}
+
+// GrpcMessage represents a gRPC request message (metadata + body)
+type GrpcMessage struct {
+	ContentType string            `json:"content_type,omitempty"`
+	Headers     map[string]string `json:"headers,omitempty"`
+	Body        []byte            `json:"body,omitempty"`
+}
+
+// GrpcResponse represents a gRPC response (metadata + body + grpc status fields)
+type GrpcResponse struct {
+	ContentType    string            `json:"content_type,omitempty"`
+	GrpcStatus     string            `json:"grpc_status"`
+	GrpcStatusName string            `json:"grpc_status_name"`
+	GrpcMessage    string            `json:"grpc_message,omitempty"`
+	Headers        map[string]string `json:"headers,omitempty"`
+	Body           []byte            `json:"body,omitempty"`
+}
+
+// NewGrpcTransaction creates a new gRPC transaction with metadata
+func NewGrpcTransaction(ctx plugins.PluginContext, reqHeaders, resHeaders plugins.Headers, startTime, endTime time.Time) *GrpcTransaction {
+	tx := &GrpcTransaction{
+		TransactionTime: time.Now(),
+	}
+
+	// Calculate duration
+	if !startTime.IsZero() && !endTime.IsZero() {
+		tx.DurationMs = endTime.Sub(startTime).Milliseconds()
+		if tx.DurationMs == 0 {
+			tx.DurationMs = 1
+		}
+	}
+
+	meta := ctx.Meta()
+	tx.Direction = meta.Direction()
+	tx.Metadata = getMetadata(meta)
+
+	// Extract gRPC service/method from :path header
+	reqHM := tools.NewHeaderMap(reqHeaders)
+	tx.Service, tx.Method = reqHM.GRPCServiceMethod()
+
+	// Extract gRPC status fields from response headers
+	resHM := tools.NewHeaderMap(resHeaders)
+	tx.GrpcStatus, _ = resHM.Get("Grpc-Status")
+	tx.GrpcStatusName, _ = resHM.Get("Grpc-Status-Name")
+	tx.GrpcMessage, _ = resHM.Get("Grpc-Message")
+
+	// Request
+	reqCT, _ := reqHM.ContentType()
+	tx.Request = GrpcMessage{
+		ContentType: reqCT,
+	}
+	if reqHeaders != nil {
+		tx.Request.Headers = reqHeaders.All()
+	}
+
+	// Response
+	resCT, _ := resHM.ContentType()
+	tx.Response = GrpcResponse{
+		ContentType:    resCT,
+		GrpcStatus:     tx.GrpcStatus,
+		GrpcStatusName: tx.GrpcStatusName,
+		GrpcMessage:    tx.GrpcMessage,
+	}
+	if resHeaders != nil {
+		tx.Response.Headers = resHeaders.All()
+	}
+
+	return tx
+}
+
+// Summary returns a map of key transaction fields for artifact metadata
+func (t *GrpcTransaction) Summary() map[string]any {
+	summary := map[string]any{}
+	if t.Service != "" {
+		summary["grpc_service"] = t.Service
+	}
+	if t.Method != "" {
+		summary["grpc_method"] = t.Method
+	}
+	if t.GrpcStatus != "" {
+		summary["grpc_status"] = t.GrpcStatus
+	}
+	if t.GrpcStatusName != "" {
+		summary["grpc_status_name"] = t.GrpcStatusName
+	}
+	if t.DurationMs > 0 {
+		summary["duration_ms"] = t.DurationMs
+	}
+	if t.Direction != "" {
+		summary["direction"] = t.Direction
+	}
+	maps.Copy(summary, t.Metadata.Summary())
+	return summary
+}
+
+// ToJSON converts the GrpcTransaction to JSON
+func (t *GrpcTransaction) ToJSON() ([]byte, error) {
+	return json.Marshal(t)
+}
+
+// ToString converts the GrpcTransaction to a formatted text string
+func (t *GrpcTransaction) ToString() string {
+	var text strings.Builder
+	text.WriteString("gRPC Transaction\n")
+	text.WriteString("================\n\n")
+
+	// Metadata
+	text.WriteString("Metadata:\n")
+	text.WriteString("  Transaction Time: " + t.TransactionTime.Format(time.RFC3339) + "\n")
+	if t.DurationMs > 0 {
+		text.WriteString("  Duration: " + strconv.FormatInt(t.DurationMs, 10) + "ms\n")
+	}
+	text.WriteString("  Direction: " + t.Direction + "\n")
+	if t.Metadata.RequestID != "" {
+		text.WriteString("  Request ID: " + t.Metadata.RequestID + "\n")
+	}
+	if t.Metadata.ProcessExe != "" {
+		text.WriteString("  Process: " + t.Metadata.ProcessExe + "\n")
+	}
+
+	// RPC
+	text.WriteString("\nRPC:\n")
+	text.WriteString("  Service: " + t.Service + "\n")
+	text.WriteString("  Method: " + t.Method + "\n")
+	text.WriteString("  Status: " + t.GrpcStatusName + " (" + t.GrpcStatus + ")\n")
+	if t.GrpcMessage != "" {
+		text.WriteString("  Message: " + t.GrpcMessage + "\n")
+	}
+
+	// Request
+	text.WriteString("\nRequest:\n")
+	if t.Request.ContentType != "" {
+		text.WriteString("  Content-Type: " + t.Request.ContentType + "\n")
+	}
+	if len(t.Request.Headers) > 0 {
+		text.WriteString("  Headers:\n")
+		for k, v := range t.Request.Headers {
+			text.WriteString("    " + k + ": " + v + "\n")
+		}
+	}
+	if len(t.Request.Body) > 0 {
+		text.WriteString("  Body:\n")
+		text.WriteString(string(t.Request.Body) + "\n")
+	}
+
+	// Response
+	text.WriteString("\nResponse:\n")
+	if t.Response.ContentType != "" {
+		text.WriteString("  Content-Type: " + t.Response.ContentType + "\n")
+	}
+	if len(t.Response.Headers) > 0 {
+		text.WriteString("  Headers:\n")
+		for k, v := range t.Response.Headers {
+			text.WriteString("    " + k + ": " + v + "\n")
+		}
+	}
+	if len(t.Response.Body) > 0 {
+		text.WriteString("  Body:\n")
+		text.WriteString(string(t.Response.Body) + "\n")
+	}
+
+	return text.String()
+}

--- a/pkg/plugins/httpcapture/grpctransaction_test.go
+++ b/pkg/plugins/httpcapture/grpctransaction_test.go
@@ -1,0 +1,155 @@
+package httpcapture
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGrpcTransaction_ToJSON(t *testing.T) {
+	tx := &GrpcTransaction{
+		Service:         "grpc.health.v1.Health",
+		Method:          "Check",
+		GrpcStatus:      "0",
+		GrpcStatusName:  "OK",
+		TransactionTime: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		DurationMs:      42,
+		Direction:       "egress",
+		Request: GrpcMessage{
+			ContentType: "application/grpc",
+			Headers:     map[string]string{":path": "/grpc.health.v1.Health/Check"},
+		},
+		Response: GrpcResponse{
+			ContentType:    "application/grpc",
+			GrpcStatus:     "0",
+			GrpcStatusName: "OK",
+			Headers:        map[string]string{"grpc-status": "0"},
+		},
+	}
+
+	data, err := tx.ToJSON()
+	require.NoError(t, err)
+
+	var decoded GrpcTransaction
+	err = json.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, "grpc.health.v1.Health", decoded.Service)
+	assert.Equal(t, "Check", decoded.Method)
+	assert.Equal(t, "0", decoded.GrpcStatus)
+	assert.Equal(t, "OK", decoded.GrpcStatusName)
+	assert.Equal(t, int64(42), decoded.DurationMs)
+	assert.Equal(t, "egress", decoded.Direction)
+	assert.Equal(t, "application/grpc", decoded.Request.ContentType)
+	assert.Equal(t, "application/grpc", decoded.Response.ContentType)
+}
+
+func TestGrpcTransaction_ToJSON_WithBody(t *testing.T) {
+	tx := &GrpcTransaction{
+		Service:         "myservice.v1.MyService",
+		Method:          "DoStuff",
+		GrpcStatus:      "2",
+		GrpcStatusName:  "UNKNOWN",
+		GrpcMessage:     "something went wrong",
+		TransactionTime: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		DurationMs:      100,
+		Request: GrpcMessage{
+			ContentType: "application/grpc",
+			Headers:     map[string]string{":path": "/myservice.v1.MyService/DoStuff"},
+			Body:        []byte("request-body"),
+		},
+		Response: GrpcResponse{
+			ContentType:    "application/grpc",
+			GrpcStatus:     "2",
+			GrpcStatusName: "UNKNOWN",
+			GrpcMessage:    "something went wrong",
+			Headers:        map[string]string{"grpc-status": "2"},
+			Body:           []byte("response-body"),
+		},
+	}
+
+	data, err := tx.ToJSON()
+	require.NoError(t, err)
+
+	var decoded GrpcTransaction
+	err = json.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, "something went wrong", decoded.GrpcMessage)
+	assert.Equal(t, []byte("request-body"), decoded.Request.Body)
+	assert.Equal(t, []byte("response-body"), decoded.Response.Body)
+}
+
+func TestGrpcTransaction_ToString(t *testing.T) {
+	tx := &GrpcTransaction{
+		Service:         "grpc.health.v1.Health",
+		Method:          "Check",
+		GrpcStatus:      "0",
+		GrpcStatusName:  "OK",
+		TransactionTime: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		DurationMs:      5,
+		Direction:       "egress",
+	}
+
+	text := tx.ToString()
+	assert.Contains(t, text, "gRPC Transaction")
+	assert.Contains(t, text, "grpc.health.v1.Health")
+	assert.Contains(t, text, "Check")
+	assert.Contains(t, text, "OK (0)")
+	assert.Contains(t, text, "5ms")
+}
+
+func TestGrpcTransaction_Summary(t *testing.T) {
+	tx := &GrpcTransaction{
+		Service:        "grpc.health.v1.Health",
+		Method:         "Check",
+		GrpcStatus:     "0",
+		GrpcStatusName: "OK",
+		DurationMs:     10,
+		Direction:      "egress",
+	}
+
+	summary := tx.Summary()
+	assert.Equal(t, "grpc.health.v1.Health", summary["grpc_service"])
+	assert.Equal(t, "Check", summary["grpc_method"])
+	assert.Equal(t, "0", summary["grpc_status"])
+	assert.Equal(t, "OK", summary["grpc_status_name"])
+	assert.Equal(t, int64(10), summary["duration_ms"])
+	assert.Equal(t, "egress", summary["direction"])
+}
+
+func TestGrpcTransaction_SummaryLevel(t *testing.T) {
+	// Verify summary level clears headers and body
+	tx := &GrpcTransaction{
+		Service:    "svc",
+		Method:     "m",
+		GrpcStatus: "0",
+		Request: GrpcMessage{
+			Headers: map[string]string{"k": "v"},
+			Body:    []byte("body"),
+		},
+		Response: GrpcResponse{
+			Headers: map[string]string{"k": "v"},
+			Body:    []byte("body"),
+		},
+	}
+
+	// Simulate summary level stripping
+	tx.Request.Headers = nil
+	tx.Response.Headers = nil
+	tx.Request.Body = nil
+	tx.Response.Body = nil
+
+	data, err := tx.ToJSON()
+	require.NoError(t, err)
+
+	var decoded GrpcTransaction
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assert.Nil(t, decoded.Request.Headers)
+	assert.Nil(t, decoded.Response.Headers)
+	assert.Nil(t, decoded.Request.Body)
+	assert.Nil(t, decoded.Response.Body)
+}

--- a/pkg/plugins/httpcapture/httpcapture_grpc.go
+++ b/pkg/plugins/httpcapture/httpcapture_grpc.go
@@ -1,0 +1,97 @@
+package httpcapture
+
+import (
+	"github.com/qpoint-io/qtap/pkg/services/eventstore"
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
+)
+
+// grpcInstance embeds instance to reuse all HTTP plugin hook methods.
+// Only Destroy() is overridden to build a GrpcTransaction instead of HttpTransaction.
+type grpcInstance struct {
+	instance
+}
+
+func (g *grpcInstance) Destroy() {
+	ctx, span := tracer.Start(g.ctx, "Destroy")
+	defer func() {
+		span.End()
+		// end parent instance span
+		defer trace.SpanFromContext(g.ctx).End()
+	}()
+
+	if g.objectstore == nil {
+		g.logger.Error("objectstore is nil, cannot save gRPC transaction")
+		return
+	}
+
+	// Determine the capture level based on rules
+	captureLevel, outputFormat := g.evaluateRules()
+
+	if captureLevel == CaptureLevelNone {
+		g.logger.Debug("gRPC transaction capture skipped due to 'none' capture level")
+		return
+	}
+
+	// Create gRPC transaction object
+	transaction := NewGrpcTransaction(g.conn, g.reqheaders, g.resheaders, g.startTime, g.endTime)
+
+	// Set content based on capture level
+	switch captureLevel {
+	case CaptureLevelSummary:
+		transaction.Request.Headers = nil
+		transaction.Response.Headers = nil
+		transaction.Request.Body = nil
+		transaction.Response.Body = nil
+
+	case CaptureLevelHeaders:
+		transaction.Request.Body = nil
+		transaction.Response.Body = nil
+
+	case CaptureLevelFull:
+		transaction.Request.Body = g.conn.GetRequestBodyBuffer().Copy()
+		transaction.Response.Body = g.conn.GetResponseBodyBuffer().Copy()
+	}
+
+	// Generate the appropriate format
+	var data []byte
+	var contentType string
+
+	switch outputFormat {
+	case OutputFormatJSON:
+		var err error
+		data, err = transaction.ToJSON()
+		if err != nil {
+			g.logger.Error("failed to marshal gRPC transaction to JSON", zap.Error(err))
+			return
+		}
+		contentType = "application/json"
+
+	case OutputFormatText:
+		data = []byte(transaction.ToString())
+		contentType = "text/plain"
+
+	default:
+		g.logger.Error("unknown output format", zap.String("format", string(outputFormat)))
+		return
+	}
+
+	meta := g.conn.Meta()
+	artifact := &eventstore.Artifact{
+		Type:        eventstore.ArtifactType_GRPCTransaction,
+		Data:        data,
+		ContentType: contentType,
+	}
+	artifact.SetRequestID(meta.RequestID())
+
+	if summary := transaction.Summary(); len(summary) > 0 {
+		artifact.Summary = summary
+	}
+
+	g.logger.Debug("saving gRPC transaction to object store",
+		zap.String("level", string(captureLevel)),
+		zap.String("format", string(outputFormat)),
+		zap.Int("bytes", len(data)))
+
+	g.objectstore.Put(ctx, artifact)
+}

--- a/pkg/plugins/httpcapture/httpcapture_plugin.go
+++ b/pkg/plugins/httpcapture/httpcapture_plugin.go
@@ -139,6 +139,14 @@ func (f *Factory) NewHttpInstance(conn plugins.PluginContext, svcs *services.Ser
 	return fi
 }
 
+func (f *Factory) NewGrpcInstance(conn plugins.PluginContext, svcs *services.ServiceRegistry) plugins.GrpcPluginInstance {
+	httpInstance := f.NewHttpInstance(conn, svcs)
+	if httpInstance == nil {
+		return nil
+	}
+	return &grpcInstance{instance: *httpInstance.(*instance)}
+}
+
 func (f *Factory) Destroy() {
 	f.logger.Debug("http_capture plugin destroyed")
 }

--- a/pkg/services/eventstore/eventstore.go
+++ b/pkg/services/eventstore/eventstore.go
@@ -222,6 +222,7 @@ var (
 	ArtifactType_QscanRequest    ArtifactType = "qscan_request"
 	ArtifactType_HTTPTransaction ArtifactType = "http_transaction"
 	ArtifactType_LLMConversation ArtifactType = "llm_conversation"
+	ArtifactType_GRPCTransaction ArtifactType = "grpc_transaction"
 )
 
 func (a ArtifactType) String() string {


### PR DESCRIPTION
Adds gRPC capture support to the existing `httpcapture` plugin following the same pattern used in `accesslogs`.

**Changes:**
- `grpcInstance` embeds `instance`, overrides only `Destroy()` for gRPC-specific field extraction
- New `GrpcTransaction` types with JSON/text serialization
- `Factory` implements `GrpcPlugin` interface via `NewGrpcInstance()`
- New `ArtifactType_GRPCTransaction` in eventstore
- E2E test added to `e2e/grpc_test.go`
- Unit tests for transaction serialization

No rename, no registry changes — just extending the existing plugin.

> Note: This is a PoC decoding grpc on the fly when the protobuf structure is known. 