### PR TITLE
fix: handle HTTP/2 CONTINUATION frames for non-Go gRPC clients

### DIFF
--- a/e2e/grpc_test.go
+++ b/e2e/grpc_test.go
@@ -33,7 +33,7 @@ func TestGRPCLanguages(t *testing.T) {
 		WithOS("alpine").
 		WithLanguage(e2epkg.Go, "1.25.1").
 		// WithLanguage(e2epkg.Java, "21").
-		// WithLanguage(e2epkg.Python, "3.12.0").
+		WithLanguage(e2epkg.Python, "3.12.0").
 		// WithLanguage(e2epkg.NodeJS, "22.16.0").
 		// WithLanguage(e2epkg.Ruby, "3.4.5").
 		// WithLanguage(e2epkg.PHP, "8.3").

--- a/pkg/stream/protocols/http2/stream.go
+++ b/pkg/stream/protocols/http2/stream.go
@@ -160,8 +160,49 @@ func (s *HTTPStream) Process(event *connection.DataEvent) error {
 			return nil
 		}
 
-		// Now we can safely process the complete frame
-		framer := http2.NewFramer(nil, bytes.NewReader((*buf)[:totalFrameSize]))
+		// If this is a HEADERS or PUSH_PROMISE frame without END_HEADERS,
+		// we need to include all subsequent CONTINUATION frames so the
+		// framer can read them in readMetaFrame. Different gRPC/HTTP2
+		// implementations (e.g. Python grpc C-core) may split header
+		// blocks across HEADERS + CONTINUATION frames.
+		frameType := (*buf)[3] // frame type byte
+		frameFlags := (*buf)[4]
+		const (
+			frameTypeHeaders      = 0x1
+			frameTypeContinuation = 0x9
+			flagEndHeaders        = 0x4
+		)
+		endOfFrames := totalFrameSize
+		if (frameType == frameTypeHeaders) && (frameFlags&flagEndHeaders == 0) {
+			// Scan forward to collect all CONTINUATION frames
+			offset := totalFrameSize
+			for {
+				if len(*buf) < offset+frameHeaderLen {
+					// Need more data; wait for next event
+					return nil
+				}
+				contLength := int((*buf)[offset])<<16 | int((*buf)[offset+1])<<8 | int((*buf)[offset+2])
+				contType := (*buf)[offset+3]
+				contFlags := (*buf)[offset+4]
+				contSize := contLength + frameHeaderLen
+				if len(*buf) < offset+contSize {
+					return nil
+				}
+				if contType != frameTypeContinuation {
+					// Protocol violation: expected CONTINUATION, got something else.
+					// Let the framer handle the error.
+					break
+				}
+				offset += contSize
+				if contFlags&flagEndHeaders != 0 {
+					break
+				}
+			}
+			endOfFrames = offset
+		}
+
+		// Now we can safely process the complete frame (+ any CONTINUATIONs)
+		framer := http2.NewFramer(nil, bytes.NewReader((*buf)[:endOfFrames]))
 		frame, err := framer.ReadFrame()
 		if err != nil {
 			span.AddEvent("http2.frame[error]", trace.WithAttributes(
@@ -176,7 +217,7 @@ func (s *HTTPStream) Process(event *connection.DataEvent) error {
 				// the stream continue so the plugin chain can still extract
 				// method paths, grpc-status trailers, and per-RPC latency.
 				if s.conn.Protocol == connection.Protocol_GRPC {
-					*buf = (*buf)[totalFrameSize:]
+					*buf = (*buf)[endOfFrames:]
 					continue
 				}
 
@@ -186,11 +227,11 @@ func (s *HTTPStream) Process(event *connection.DataEvent) error {
 
 			return connection.ErrStreamUnrecoverable(fmt.Errorf("error reading http2 frame: %w", err))
 		}
-		// Remove the processed frame from buffer
-		*buf = (*buf)[totalFrameSize:]
+		// Remove the processed frame(s) from buffer
+		*buf = (*buf)[endOfFrames:]
 
-		frameType := strings.TrimPrefix(reflect.TypeOf(frame).String(), "*http2.")
-		span.AddEvent(fmt.Sprintf("http2.frame[%s]", frameType), trace.WithAttributes(
+		frameTypeName := strings.TrimPrefix(reflect.TypeOf(frame).String(), "*http2.")
+		span.AddEvent(fmt.Sprintf("http2.frame[%s]", frameTypeName), trace.WithAttributes(
 			attribute.Int64("stream_id", int64(frame.Header().StreamID)),
 			attribute.Int("length", frameLength),
 			attribute.String("direction", string(event.Direction)),
@@ -207,11 +248,11 @@ func (s *HTTPStream) Process(event *connection.DataEvent) error {
 		// session
 		session := s.initSession(frame.Header().StreamID)
 
-		// update the bytes
+		// update the bytes (endOfFrames includes any CONTINUATION frames)
 		if event.Direction == connection.Ingress {
-			session.rdBytes += int64(totalFrameSize)
+			session.rdBytes += int64(endOfFrames)
 		} else {
-			session.wrBytes += int64(totalFrameSize)
+			session.wrBytes += int64(endOfFrames)
 		}
 
 		err = s.handleFrame(session, frame, framer, decoder)

--- a/pkg/stream/protocols/http2/stream_test.go
+++ b/pkg/stream/protocols/http2/stream_test.go
@@ -16,9 +16,7 @@ import (
 // newTestStream creates an HTTPStream with minimal dependencies suitable for unit tests.
 func newTestStream(t *testing.T) *HTTPStream {
 	t.Helper()
-	conn := &connection.Connection{
-		OpenEvent: &connection.OpenEvent{Source: connection.Client},
-	}
+	conn := connection.NewConnection(t.Context(), zap.NewNop(), &connection.OpenEvent{Source: connection.Client})
 	return NewHTTPStream(t.Context(), "example.com", zap.NewNop(), conn)
 }
 
@@ -755,4 +753,69 @@ func buildRawHeadersFrame(streamID uint32, endStream, endHeaders bool, payload [
 	// Payload
 	copy(frame[9:], payload)
 	return frame
+}
+
+// buildRawContinuationFrame constructs a raw HTTP/2 CONTINUATION frame.
+func buildRawContinuationFrame(streamID uint32, endHeaders bool, payload []byte) []byte {
+	length := len(payload)
+	frame := make([]byte, 9+length)
+	frame[0] = byte(length >> 16)
+	frame[1] = byte(length >> 8)
+	frame[2] = byte(length)
+	frame[3] = 0x9 // CONTINUATION
+	if endHeaders {
+		frame[4] = 0x4 // END_HEADERS
+	}
+	frame[5] = byte(streamID >> 24)
+	frame[6] = byte(streamID >> 16)
+	frame[7] = byte(streamID >> 8)
+	frame[8] = byte(streamID)
+	copy(frame[9:], payload)
+	return frame
+}
+
+// TestContinuationFrames verifies that HEADERS frames split across
+// HEADERS + CONTINUATION frames are correctly reassembled. This is
+// critical for gRPC clients like Python's grpc C-core which may split
+// header blocks across multiple frames.
+func TestContinuationFrames(t *testing.T) {
+	stream := newTestStream(t)
+
+	// Encode headers using HPACK
+	var hdrBuf bytes.Buffer
+	enc := hpack.NewEncoder(&hdrBuf)
+	fields := []hpack.HeaderField{
+		{Name: ":method", Value: "POST"},
+		{Name: ":path", Value: "/babel.v1.EchoService/UnaryEcho"},
+		{Name: ":scheme", Value: "http"},
+		{Name: ":authority", Value: "localhost:50051"},
+		{Name: "content-type", Value: "application/grpc"},
+		{Name: "te", Value: "trailers"},
+		{Name: "user-agent", Value: "grpc-python/1.60.0 grpc-c/38.0.0"},
+	}
+	for _, f := range fields {
+		require.NoError(t, enc.WriteField(f))
+	}
+	encoded := hdrBuf.Bytes()
+
+	// Split the HPACK block into two parts: HEADERS (no END_HEADERS) + CONTINUATION (with END_HEADERS)
+	splitPoint := len(encoded) / 2
+	headersFrame := buildRawHeadersFrame(1, false, false, encoded[:splitPoint])
+	contFrame := buildRawContinuationFrame(1, true, encoded[splitPoint:])
+
+	// Process: preface + SETTINGS + HEADERS + CONTINUATION
+	var settingsBuf bytes.Buffer
+	settingsFramer := http2.NewFramer(&settingsBuf, nil)
+	require.NoError(t, settingsFramer.WriteSettings())
+	settings := settingsBuf.Bytes()
+
+	processEgress(t, stream, []byte(http2.ClientPreface), settings, headersFrame, contFrame)
+
+	// Verify the session was created with correct headers
+	session, exists := stream.sessions[1]
+	require.True(t, exists, "session for stream 1 should exist")
+	assert.Equal(t, "/babel.v1.EchoService/UnaryEcho", session.req.URL.Path)
+	assert.Equal(t, "POST", session.req.Method)
+	assert.True(t, session.isGRPC, "should be detected as gRPC")
+	assert.Equal(t, connection.Protocol_GRPC, stream.conn.Protocol, "connection should be marked as gRPC")
 }


### PR DESCRIPTION
## Problem

qtap captures gRPC metadata correctly for Go clients but fails for Python (and potentially other non-Go languages like Java, Ruby, Node.js, PHP).

## Root Cause

The HTTP/2 stream processor created a new `http2.Framer` for each frame independently. When a HEADERS frame didn't have the `END_HEADERS` flag set (meaning the header block continues in CONTINUATION frames), the framer only contained the HEADERS frame data. The `readMetaFrame` method tried to read CONTINUATION frames from the same framer but couldn't find them — they were still in the buffer waiting to be processed as separate frames.

When those CONTINUATION frames were eventually processed by the outer loop with a fresh framer, the framer's `checkFrameOrder` rejected them as "unexpected CONTINUATION" and returned `ConnectionError(ErrCodeProtocol)`. Since gRPC hadn't been detected yet (the `content-type: application/grpc` header was in the incomplete HEADERS block), the connection was marked as `Protocol_UNKNOWN` and killed.

**Go's gRPC** implementation typically fits all headers in a single HEADERS frame (with END_HEADERS set), so it never hit this code path. **Python's gRPC C-core** (and potentially other implementations) may split header blocks across HEADERS + CONTINUATION frames.

## Fix

When processing a HEADERS frame without END_HEADERS, scan ahead in the buffer to collect all subsequent CONTINUATION frames, then feed them to the framer together. This allows `readMetaFrame` to properly reassemble the complete header block.

## Testing

- Added `TestContinuationFrames` unit test that splits HPACK-encoded gRPC headers across HEADERS + CONTINUATION frames
- All 9 existing HTTP/2 unit tests continue to pass
- Enabled Python 3.12.0 in the E2E `TestGRPCLanguages` test (was commented out because it failed)