### PR TITLE
fix: enable PHP gRPC e2e test

### DIFF
--- a/e2e/grpc_test.go
+++ b/e2e/grpc_test.go
@@ -36,7 +36,7 @@ func TestGRPCLanguages(t *testing.T) {
 		WithLanguage(e2epkg.Python, "3.12.0").
 		WithLanguage(e2epkg.NodeJS, "22.16.0").
 		WithLanguage(e2epkg.Ruby, "3.4.5").
-		// WithLanguage(e2epkg.PHP, "8.3").
+		WithLanguage(e2epkg.PHP, "8.3").
 		WithMessage(`{"message":"hello"}`).
 		WithPlaintextOnly().
 		WithValidation(func(t *testing.T, ctx e2epkg.ValidationContext) error {


### PR DESCRIPTION
Enables the PHP gRPC e2e test to verify the recent Python fix works for PHP as well.