### PR TITLE
fix: enable Java gRPC e2e test

### DIFF
--- a/e2e/grpc_test.go
+++ b/e2e/grpc_test.go
@@ -32,7 +32,7 @@ func TestGRPCLanguages(t *testing.T) {
 		WithConfig(configMut).
 		WithOS("alpine").
 		WithLanguage(e2epkg.Go, "1.25.1").
-		// WithLanguage(e2epkg.Java, "21").
+		WithLanguage(e2epkg.Java, "21").
 		WithLanguage(e2epkg.Python, "3.12.0").
 		WithLanguage(e2epkg.NodeJS, "22.16.0").
 		WithLanguage(e2epkg.Ruby, "3.4.5").

--- a/pkg/e2e/grpc_babel.go
+++ b/pkg/e2e/grpc_babel.go
@@ -11,7 +11,7 @@ var (
 	// Go
 	GRPCRequestGo1_25_1_Alpine GRPCRequestImage = "babel-go:1.25.1-grpc-alpine"
 	// Java
-	GRPCRequestJava21_Alpine GRPCRequestImage = "babel-java:21-grpc-alpine"
+	GRPCRequestJava21_Alpine GRPCRequestImage = "babel-java:21-grpc-corretto-alpine"
 	// Python
 	GRPCRequestPython3_12_0_Alpine GRPCRequestImage = "babel-python:3.12.0-grpc-alpine"
 	// NodeJS


### PR DESCRIPTION
Enables the Java gRPC e2e test to verify the recent Python fix works for Java as well.