### PR TITLE
bump go to 1.26.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.0'
+          go-version: '1.26.1'
           cache: true
 
       - name: Run CI

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.0"
+          go-version: "1.26.1"
           cache: true
 
       - name: Run E2E tests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/qpoint-io/qtap
 
-go 1.26.0
+go 1.26.1
 
 require (
 	github.com/advbet/sseclient v0.0.0-20250521071159-d88bf8fc2362


### PR DESCRIPTION
Bumps Go from 1.26.0 to 1.26.1 across go.mod and CI workflows. govulncheck passed.