### PR TITLE
Add header promotion to report_usage plugin

### DIFF
--- a/examples/sample-axiom.yaml
+++ b/examples/sample-axiom.yaml
@@ -19,6 +19,9 @@ stacks:
           mode: summary
           format: console
       - type: report_usage
+        # config:
+        #   headers:
+        #     - x-request-id
 tap:
   direction: egress-external
   ignore_loopback: true

--- a/examples/sample-capture-minio.yaml
+++ b/examples/sample-capture-minio.yaml
@@ -54,6 +54,9 @@ stacks:
               level: full
 
       - type: report_usage
+        # config:
+        #   headers:
+        #     - x-request-id
 tap:
   direction: egress # (egress|egress-external|egress-internal)
   ignore_loopback: true

--- a/examples/sample-capture.yaml
+++ b/examples/sample-capture.yaml
@@ -13,6 +13,9 @@ stacks:
     plugins:
       - type: http_metrics
       - type: report_usage
+        # config:
+        #   headers:
+        #     - x-request-id
       - type: http_capture
         config:
           level: summary # (none|summary|headers|full)

--- a/examples/sample-config.yaml
+++ b/examples/sample-config.yaml
@@ -26,6 +26,12 @@ stacks:
               expr: http.res.status >= 400 && http.res.status < 500
               mode: full
       - type: report_usage
+        # config:
+        #   # Promote HTTP headers into custom attributes on reported events.
+        #   # Request headers become "req.<header>", response headers become "res.<header>".
+        #   headers:
+        #     - x-request-id
+        #     - content-type
 tap:
   direction: egress # (all|egress|egress-external|egress-internal|ingress)
   ignore_loopback: true

--- a/examples/sample-otel-grpc-eventstore.yaml
+++ b/examples/sample-otel-grpc-eventstore.yaml
@@ -38,6 +38,12 @@ stacks:
               level: full
 
       - type: report_usage
+        config:
+          # Promote HTTP headers into OTel span attributes.
+          # Request headers become "req.<header>", response headers become "res.<header>".
+          headers:
+            - x-request-id
+            - content-type
 tap:
   direction: egress # (egress|egress-external|egress-internal)
   ignore_loopback: true

--- a/examples/sample-otel-http-eventstore.yaml
+++ b/examples/sample-otel-http-eventstore.yaml
@@ -38,6 +38,12 @@ stacks:
               level: full
 
       - type: report_usage
+        config:
+          # Promote HTTP headers into OTel span attributes.
+          # Request headers become "req.<header>", response headers become "res.<header>".
+          headers:
+            - x-request-id
+            - content-type
 tap:
   direction: egress # (egress|egress-external|egress-internal)
   ignore_loopback: true

--- a/examples/sample-otel-stdout-eventstore.yaml
+++ b/examples/sample-otel-stdout-eventstore.yaml
@@ -30,6 +30,12 @@ stacks:
               level: full
 
       - type: report_usage
+        config:
+          # Promote HTTP headers into OTel span attributes.
+          # Request headers become "req.<header>", response headers become "res.<header>".
+          headers:
+            - x-request-id
+            - content-type
 tap:
   direction: egress # (egress|egress-external|egress-internal)
   ignore_loopback: true

--- a/pkg/plugins/report/report_http.go
+++ b/pkg/plugins/report/report_http.go
@@ -16,8 +16,9 @@ type filterInstance struct {
 
 	eventstore eventstore.EventStore
 
-	reqheaders plugins.Headers
-	resheaders plugins.Headers
+	reqheaders     plugins.Headers
+	resheaders     plugins.Headers
+	promoteHeaders []string
 
 	startTime  time.Time
 	finishTime time.Time
@@ -104,6 +105,28 @@ func (h *filterInstance) buildBaseRequest() eventstore.Request {
 	}
 
 	r.SetRequestID(meta.RequestID())
+
+	// Promote configured headers into CustomHeaders
+	if len(h.promoteHeaders) > 0 {
+		for _, key := range h.promoteHeaders {
+			if h.reqheaders != nil {
+				if val, ok := h.reqheaders.Get(key); ok {
+					if r.CustomHeaders == nil {
+						r.CustomHeaders = make(map[string]string)
+					}
+					r.CustomHeaders["req."+key] = val.String()
+				}
+			}
+			if h.resheaders != nil {
+				if val, ok := h.resheaders.Get(key); ok {
+					if r.CustomHeaders == nil {
+						r.CustomHeaders = make(map[string]string)
+					}
+					r.CustomHeaders["res."+key] = val.String()
+				}
+			}
+		}
+	}
 
 	// Scan for auth tokens
 	authTokenSource, authToken, authTokenFound := h.scanForAuthTokens()

--- a/pkg/plugins/report/report_http.go
+++ b/pkg/plugins/report/report_http.go
@@ -107,26 +107,7 @@ func (h *filterInstance) buildBaseRequest() eventstore.Request {
 	r.SetRequestID(meta.RequestID())
 
 	// Promote configured headers into CustomHeaders
-	if len(h.promoteHeaders) > 0 {
-		for _, key := range h.promoteHeaders {
-			if h.reqheaders != nil {
-				if val, ok := h.reqheaders.Get(key); ok {
-					if r.CustomHeaders == nil {
-						r.CustomHeaders = make(map[string]string)
-					}
-					r.CustomHeaders["req."+key] = val.String()
-				}
-			}
-			if h.resheaders != nil {
-				if val, ok := h.resheaders.Get(key); ok {
-					if r.CustomHeaders == nil {
-						r.CustomHeaders = make(map[string]string)
-					}
-					r.CustomHeaders["res."+key] = val.String()
-				}
-			}
-		}
-	}
+	r.CustomHeaders = promoteHeaders(h.promoteHeaders, h.reqheaders, h.resheaders)
 
 	// Scan for auth tokens
 	authTokenSource, authToken, authTokenFound := h.scanForAuthTokens()
@@ -163,4 +144,34 @@ func (h *filterInstance) scanForAuthTokens() (string, string, bool) {
 	}
 
 	return "", "", false
+}
+
+// promoteHeaders copies the values of the given header keys from the request
+// and/or response into a map keyed by "req.<key>" / "res.<key>". Returns nil
+// when no headers match.
+func promoteHeaders(keys []string, reqheaders, resheaders plugins.Headers) map[string]string {
+	if len(keys) == 0 {
+		return nil
+	}
+
+	var out map[string]string
+	for _, key := range keys {
+		if reqheaders != nil {
+			if val, ok := reqheaders.Get(key); ok {
+				if out == nil {
+					out = make(map[string]string)
+				}
+				out["req."+key] = val.String()
+			}
+		}
+		if resheaders != nil {
+			if val, ok := resheaders.Get(key); ok {
+				if out == nil {
+					out = make(map[string]string)
+				}
+				out["res."+key] = val.String()
+			}
+		}
+	}
+	return out
 }

--- a/pkg/plugins/report/report_http_test.go
+++ b/pkg/plugins/report/report_http_test.go
@@ -1,0 +1,147 @@
+package report
+
+import (
+	"testing"
+
+	"github.com/qpoint-io/qtap/pkg/plugins"
+	"github.com/stretchr/testify/assert"
+)
+
+// --- mock types implementing plugins.Headers and plugins.HeaderValue ---
+
+type mockHeaderValue string
+
+func (v mockHeaderValue) String() string      { return string(v) }
+func (v mockHeaderValue) Bytes() []byte       { return []byte(v) }
+func (v mockHeaderValue) Equal(s string) bool { return string(v) == s }
+
+type mockHeaders struct {
+	data map[string]string
+}
+
+func newMockHeaders(m map[string]string) *mockHeaders {
+	return &mockHeaders{data: m}
+}
+
+func (h *mockHeaders) Get(key string) (plugins.HeaderValue, bool) {
+	v, ok := h.data[key]
+	return mockHeaderValue(v), ok
+}
+
+func (h *mockHeaders) Values(key string, iter func(value plugins.HeaderValue)) {
+	if v, ok := h.data[key]; ok {
+		iter(mockHeaderValue(v))
+	}
+}
+
+func (h *mockHeaders) Set(key, value string)  { h.data[key] = value }
+func (h *mockHeaders) Remove(key string)      { delete(h.data, key) }
+func (h *mockHeaders) All() map[string]string { return h.data }
+
+// --- tests ---
+
+func TestPromoteHeaders(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		keys       []string
+		reqHeaders map[string]string // nil map means nil Headers
+		resHeaders map[string]string
+		expected   map[string]string
+	}{
+		{
+			name:       "no promote headers configured",
+			keys:       nil,
+			reqHeaders: map[string]string{"X-Req": "val"},
+			resHeaders: map[string]string{"X-Res": "val"},
+			expected:   nil,
+		},
+		{
+			name:       "empty promote headers slice",
+			keys:       []string{},
+			reqHeaders: map[string]string{"X-Req": "val"},
+			resHeaders: map[string]string{"X-Res": "val"},
+			expected:   nil,
+		},
+		{
+			name:       "matching request header only",
+			keys:       []string{"X-Trace-Id"},
+			reqHeaders: map[string]string{"X-Trace-Id": "abc123"},
+			resHeaders: map[string]string{},
+			expected:   map[string]string{"req.X-Trace-Id": "abc123"},
+		},
+		{
+			name:       "matching response header only",
+			keys:       []string{"X-Trace-Id"},
+			reqHeaders: map[string]string{},
+			resHeaders: map[string]string{"X-Trace-Id": "res456"},
+			expected:   map[string]string{"res.X-Trace-Id": "res456"},
+		},
+		{
+			name:       "both request and response headers match",
+			keys:       []string{"X-Trace-Id"},
+			reqHeaders: map[string]string{"X-Trace-Id": "req-val"},
+			resHeaders: map[string]string{"X-Trace-Id": "res-val"},
+			expected: map[string]string{
+				"req.X-Trace-Id": "req-val",
+				"res.X-Trace-Id": "res-val",
+			},
+		},
+		{
+			name:       "header key not found in either",
+			keys:       []string{"X-Missing"},
+			reqHeaders: map[string]string{"X-Other": "a"},
+			resHeaders: map[string]string{"X-Other": "b"},
+			expected:   nil,
+		},
+		{
+			name:       "multiple headers some present some missing",
+			keys:       []string{"X-A", "X-B", "X-C"},
+			reqHeaders: map[string]string{"X-A": "a1"},
+			resHeaders: map[string]string{"X-B": "b2"},
+			expected: map[string]string{
+				"req.X-A": "a1",
+				"res.X-B": "b2",
+			},
+		},
+		{
+			name:       "nil reqheaders response only",
+			keys:       []string{"X-Id"},
+			reqHeaders: nil,
+			resHeaders: map[string]string{"X-Id": "resp"},
+			expected:   map[string]string{"res.X-Id": "resp"},
+		},
+		{
+			name:       "nil resheaders request only",
+			keys:       []string{"X-Id"},
+			reqHeaders: map[string]string{"X-Id": "requ"},
+			resHeaders: nil,
+			expected:   map[string]string{"req.X-Id": "requ"},
+		},
+		{
+			name:       "both reqheaders and resheaders nil",
+			keys:       []string{"X-Id"},
+			reqHeaders: nil,
+			resHeaders: nil,
+			expected:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var req, res plugins.Headers
+			if tt.reqHeaders != nil {
+				req = newMockHeaders(tt.reqHeaders)
+			}
+			if tt.resHeaders != nil {
+				res = newMockHeaders(tt.resHeaders)
+			}
+
+			got := promoteHeaders(tt.keys, req, res)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}

--- a/pkg/plugins/report/report_plugin.go
+++ b/pkg/plugins/report/report_plugin.go
@@ -14,22 +14,29 @@ const (
 )
 
 type Config struct {
-	Tags []string `json:"tags"`
+	Tags    []string `yaml:"tags" json:"tags"`
+	Headers []string `yaml:"headers" json:"headers"`
 }
 
 type Factory struct {
 	logger *zap.Logger
+	config Config
 }
 
 func (f *Factory) Init(logger *zap.Logger, config yaml.Node) {
 	f.logger = logger
+
+	if err := config.Decode(&f.config); err != nil {
+		logger.Error("error decoding config", zap.Error(err))
+	}
 }
 
 func (f *Factory) NewHttpInstance(ctx plugins.PluginContext, svcs *services.ServiceRegistry) plugins.HttpPluginInstance {
 	f.logger.Debug("new plugin instance created")
 	fi := &filterInstance{
-		logger: f.logger,
-		ctx:    ctx,
+		logger:         f.logger,
+		ctx:            ctx,
+		promoteHeaders: f.config.Headers,
 	}
 
 	if es, err := services.GetService[eventstore.EventStore](ctx.Context(), svcs, eventstore.TypeEventStore, ""); err != nil {

--- a/pkg/services/eventstore/eventstore.go
+++ b/pkg/services/eventstore/eventstore.go
@@ -79,6 +79,8 @@ type Request struct {
 	WrBytes int64 `json:"bytesSent"`
 	RdBytes int64 `json:"bytesReceived"`
 
+	CustomHeaders map[string]string `json:"customHeaders,omitempty"`
+
 	RequestAuthToken
 }
 


### PR DESCRIPTION
Adds a `headers` config option to `report_usage` that promotes specified HTTP headers into `eventstore.Request.CustomHeaders`. Headers are looked up case-insensitively from both request and response, prefixed with `req.`/`res.`. The OTel store auto-converts these to span attributes via `structToAttributes`.