### PR TITLE
fix: handle HTTP/1.0 close-delimited response bodies

### DIFF
--- a/pkg/stream/protocols/http1/body.go
+++ b/pkg/stream/protocols/http1/body.go
@@ -43,10 +43,16 @@ func expectsResponseBody(reqMethod string, resp *Response) bool {
 		return true
 	}
 
-	// Servers are allowed to withhold content-length or transfer-encoding
-	// and just keep sending data until the connection is closed.
-	// RFC 9112 Section 6.3
-	return strings.EqualFold(resp.Headers.Get("Connection"), "close")
+	// RFC 9112 Section 6.3: When no Content-Length or Transfer-Encoding is present,
+	// the response body is terminated by the server closing the connection.
+	//
+	// For HTTP/1.1, the server MUST send Connection: close to signal this.
+	// For HTTP/1.0, close-delimited is the default (no keep-alive means close).
+	connClose := strings.EqualFold(resp.Headers.Get("Connection"), "close")
+	connKeepAlive := strings.EqualFold(resp.Headers.Get("Connection"), "keep-alive")
+	isHTTP10 := strings.HasPrefix(resp.Proto, "HTTP/1.0")
+
+	return connClose || (isHTTP10 && !connKeepAlive)
 }
 
 // expectsBody determines if a request or response should have a body

--- a/pkg/stream/protocols/http1/body_test.go
+++ b/pkg/stream/protocols/http1/body_test.go
@@ -138,9 +138,10 @@ func TestExpectsResponseBody(t *testing.T) {
 			expected: true,
 		},
 		{
-			name:      "GET with 200 and no body headers",
+			name:      "HTTP/1.1 with 200 and no body headers",
 			reqMethod: "GET",
 			response: &Response{
+				Proto:      "HTTP/1.1",
 				StatusCode: 200,
 				Headers:    http.Header{},
 			},
@@ -158,15 +159,92 @@ func TestExpectsResponseBody(t *testing.T) {
 			expected: true,
 		},
 		{
-			name:      "with Connection close and no Content-Length or Transfer-Encoding",
+			name:      "HTTP/1.1 with Connection close and no Content-Length or Transfer-Encoding",
 			reqMethod: "GET",
 			response: &Response{
+				Proto:      "HTTP/1.1",
 				StatusCode: 200,
 				Headers: http.Header{
 					"Connection": []string{"close"},
 				},
 			},
 			expected: true,
+		},
+		{
+			name:      "HTTP/1.0 with no body headers - close-delimited by default",
+			reqMethod: "GET",
+			response: &Response{
+				Proto:      "HTTP/1.0",
+				StatusCode: 200,
+				Headers:    http.Header{},
+			},
+			expected: true,
+		},
+		{
+			name:      "HTTP/1.0 with Connection keep-alive but no CL/TE",
+			reqMethod: "GET",
+			response: &Response{
+				Proto:      "HTTP/1.0",
+				StatusCode: 200,
+				Headers: http.Header{
+					"Connection": []string{"keep-alive"},
+				},
+			},
+			expected: false,
+		},
+		{
+			name:      "HTTP/1.0 with Connection close",
+			reqMethod: "GET",
+			response: &Response{
+				Proto:      "HTTP/1.0",
+				StatusCode: 200,
+				Headers: http.Header{
+					"Connection": []string{"close"},
+				},
+			},
+			expected: true,
+		},
+		{
+			name:      "HTTP/1.0 with Content-Length",
+			reqMethod: "GET",
+			response: &Response{
+				Proto:      "HTTP/1.0",
+				StatusCode: 200,
+				Headers: http.Header{
+					"Content-Length": []string{"100"},
+				},
+			},
+			expected: true,
+		},
+		{
+			name:      "HEAD request with HTTP/1.0 - never has body",
+			reqMethod: "HEAD",
+			response: &Response{
+				Proto:      "HTTP/1.0",
+				StatusCode: 200,
+				Headers:    http.Header{},
+			},
+			expected: false,
+		},
+		{
+			name:      "HTTP/1.0 204 No Content - never has body",
+			reqMethod: "GET",
+			response: &Response{
+				Proto:      "HTTP/1.0",
+				StatusCode: 204,
+				Headers:    http.Header{},
+			},
+			expected: false,
+		},
+		{
+			name:      "HTTP/1.0 304 Not Modified - never has body",
+			reqMethod: "GET",
+			response: &Response{
+				Proto:      "HTTP/1.0",
+				StatusCode: 304,
+				Headers:    http.Header{},
+			},
+			expected: false,
 		},
 	}
 


### PR DESCRIPTION
**What:** HTTP/1.0 servers without Content-Length had response bodies silently dropped.

**Why:** `expectsResponseBody` only checked for explicit `Connection: close`, missing HTTP/1.0's default close-delimited behavior.

**Fix:** Fall back to read-until-close for HTTP/1.0 responses (unless keep-alive is negotiated).

**Testing:** Unit tests covering all edge cases (HTTP/1.0 default, keep-alive, Connection: close, HEAD, 204/304).