### PR TITLE
fix(otel): resolve grpc marshal error with binary payloads

### DIFF
--- a/pkg/services/objectstore/otel/factory.go
+++ b/pkg/services/objectstore/otel/factory.go
@@ -22,6 +22,7 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
 	"go.uber.org/zap"
 	"golang.org/x/term"
+	"google.golang.org/grpc"
 )
 
 // ensure we implement the ObjectStore interface
@@ -133,7 +134,7 @@ func (f *Factory) Init(ctx context.Context, cfg any) error {
 		sdklog.WithProcessor(
 			sdklog.NewBatchProcessor(exporter,
 				sdklog.WithExportInterval(time.Second),
-				sdklog.WithExportMaxBatchSize(512),
+				sdklog.WithExportMaxBatchSize(32), // Smaller batches for large payload data
 			),
 		),
 	)
@@ -175,6 +176,8 @@ func (f *Factory) FactoryType() services.ServiceType {
 func (f *Factory) createGRPCExporter(ctx context.Context, endpoint string, c config.ObjectStoreOTelConfig) (sdklog.Exporter, error) {
 	opts := []otlploggrpc.Option{
 		otlploggrpc.WithEndpoint(endpoint),
+		// Object store payloads can be large, increase max message size to 32MB
+		otlploggrpc.WithDialOption(grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(32 * 1024 * 1024))),
 	}
 
 	// Configure TLS

--- a/pkg/services/objectstore/otel/otel.go
+++ b/pkg/services/objectstore/otel/otel.go
@@ -44,7 +44,7 @@ func (s *ObjectStore) Put(ctx context.Context, artifact *eventstore.Artifact) {
 			log.String("artifact.content_type", artifact.ContentType),
 			log.String("artifact.digest", artifact.Digest()),
 			log.Int64("artifact.size_bytes", int64(len(artifact.Data))),
-			log.String("artifact.data", string(artifact.Data)),
+			log.Bytes("artifact.data", artifact.Data),
 		}
 
 		// Add connection metadata if available


### PR DESCRIPTION
This fixes two critical issues with the OTel object store that cause the exporter to silently drop batches:

1. **UTF-8 Marshal Panic:** `artifact.Data` often contains binary data (e.g. gzipped HTTP bodies). Using `log.String(\"artifact.data\", string(artifact.Data))` creates invalid UTF-8 strings which crash the gRPC protobuf marshaler, silently dropping the entire log batch. Changed to `log.Bytes()`.
2. **gRPC 4MB Size Limit:** The OTel BatchProcessor defaults to 512 logs per batch. 512 full HTTP payloads easily exceed the default gRPC `MaxCallSendMsgSize` of 4MB. Increased max message size to 32MB and decreased batch size to 32 to ensure payloads go through smoothly.