### PR TITLE
bump go to 1.26.2

### DIFF
--- a/apps/kafka/go/Dockerfile
+++ b/apps/kafka/go/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine AS builder
+FROM golang:1.26.2-alpine AS builder
 
 WORKDIR /app
 

--- a/apps/mysql/go/Dockerfile
+++ b/apps/mysql/go/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.0-alpine AS builder
+FROM golang:1.26.2-alpine AS builder
 
 WORKDIR /app
 COPY go.mod go.sum* ./

--- a/apps/redis/go/Dockerfile
+++ b/apps/redis/go/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.0-alpine AS builder
+FROM golang:1.26.2-alpine AS builder
 
 WORKDIR /app
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/qpoint-io/qtap
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/advbet/sseclient v0.0.0-20250521071159-d88bf8fc2362

--- a/pkg/plugins/httpcapture/httptransaction.go
+++ b/pkg/plugins/httpcapture/httptransaction.go
@@ -3,6 +3,7 @@ package httpcapture
 import (
 	"encoding/json"
 	"maps"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -30,18 +31,18 @@ type HttpTransaction struct {
 
 // Metadata contains process and connection information
 type Metadata struct {
-	ProcessID      string   `json:"process_id,omitempty"`
-	ProcessExe     string   `json:"process_exe,omitempty"`
-	ContainerName  string   `json:"container_name,omitempty"`
-	ContainerImage string   `json:"container_image,omitempty"`
-	PodName        string   `json:"pod_name,omitempty"`
-	PodNamespace   string   `json:"pod_namespace,omitempty"`
-	BytesSent      int64    `json:"bytes_sent,omitempty"`
-	BytesReceived  int64    `json:"bytes_received,omitempty"`
-	RequestID      string   `json:"request_id,omitempty"`
-	ConnectionID   string   `json:"connection_id,omitempty"`
-	EndpointID     string   `json:"endpoint_id,omitempty"`
-	Tags           []string `json:"tags,omitempty"`
+	ProcessID      string              `json:"process_id,omitempty"`
+	ProcessExe     string              `json:"process_exe,omitempty"`
+	ContainerName  string              `json:"container_name,omitempty"`
+	ContainerImage string              `json:"container_image,omitempty"`
+	PodName        string              `json:"pod_name,omitempty"`
+	PodNamespace   string              `json:"pod_namespace,omitempty"`
+	BytesSent      int64               `json:"bytes_sent,omitempty"`
+	BytesReceived  int64               `json:"bytes_received,omitempty"`
+	RequestID      string              `json:"request_id,omitempty"`
+	ConnectionID   string              `json:"connection_id,omitempty"`
+	EndpointID     string              `json:"endpoint_id,omitempty"`
+	Tags           map[string][]string `json:"tags,omitempty"`
 }
 
 // Request contains HTTP request information
@@ -122,7 +123,7 @@ func getMetadata(meta plugins.Meta) Metadata {
 	}
 
 	if t := meta.Tags(); t != nil {
-		m.Tags = t.List()
+		m.Tags = t.Map()
 	}
 
 	return m
@@ -277,7 +278,10 @@ func (t *HttpTransaction) ToString() string {
 	text.WriteString("  Bytes Sent: " + strconv.FormatInt(t.Metadata.BytesSent, 10) + "\n")
 	text.WriteString("  Bytes Received: " + strconv.FormatInt(t.Metadata.BytesReceived, 10) + "\n")
 	if tags := t.Metadata.Tags; len(tags) > 0 {
-		text.WriteString("  Tags: " + strings.Join(tags, ", ") + "\n")
+		text.WriteString("  Tags:\n")
+		for _, k := range slices.Sorted(maps.Keys(tags)) {
+			text.WriteString("    " + k + ": " + strings.Join(tags[k], ", ") + "\n")
+		}
 	}
 	text.WriteString("\n")
 

--- a/pkg/plugins/httpcapture/httptransaction_test.go
+++ b/pkg/plugins/httpcapture/httptransaction_test.go
@@ -136,7 +136,10 @@ func TestHttpTransactionToJSONFormat(t *testing.T) {
 			transaction: HttpTransaction{
 				TransactionTime: time.Date(2025, 5, 20, 10, 0, 0, 0, time.UTC),
 				Metadata: Metadata{
-					Tags: []string{"env:production", "team:backend"},
+					Tags: map[string][]string{
+						"env":  {"production"},
+						"team": {"backend"},
+					},
 				},
 				Request: Request{
 					Method: "GET",
@@ -149,7 +152,10 @@ func TestHttpTransactionToJSONFormat(t *testing.T) {
 			expectedJSON: map[string]any{
 				"transaction_time": "2025-05-20T10:00:00Z",
 				"metadata": map[string]any{
-					"tags": []any{"env:production", "team:backend"},
+					"tags": map[string]any{
+						"env":  []any{"production"},
+						"team": []any{"backend"},
+					},
 				},
 				"request": map[string]any{
 					"method": "GET",
@@ -197,7 +203,7 @@ func TestHttpTransactionToJSONFormat(t *testing.T) {
 			transaction: HttpTransaction{
 				TransactionTime: time.Date(2025, 5, 20, 10, 0, 0, 0, time.UTC),
 				Metadata: Metadata{
-					Tags: []string{},
+					Tags: map[string][]string{},
 				},
 				Request: Request{
 					Method: "GET",
@@ -332,6 +338,30 @@ func TestHttpTransactionToText(t *testing.T) {
 				"Method: GET",
 				"URL: https://example.com",
 				"Status: 200",
+			},
+		},
+		{
+			name: "Transaction with tags in text",
+			transaction: HttpTransaction{
+				TransactionTime: time.Date(2025, 5, 20, 10, 0, 0, 0, time.UTC),
+				Metadata: Metadata{
+					Tags: map[string][]string{
+						"env":  {"production"},
+						"team": {"backend", "infra"},
+					},
+				},
+				Request: Request{
+					Method: "GET",
+					URL:    "https://example.com",
+				},
+				Response: Response{
+					Status: 200,
+				},
+			},
+			expectedSubstrings: []string{
+				"Tags:",
+				"env: production",
+				"team: backend, infra",
 			},
 		},
 	}


### PR DESCRIPTION
Updates this repo to Go 1.26.2.\n\n- bumps the go directive where applicable\n- updates Go Docker base image/version references used by this repo