### PR TITLE
Fix HTTP/1 keep-alive

### DIFF
--- a/pkg/stream/protocols/http1/parser.go
+++ b/pkg/stream/protocols/http1/parser.go
@@ -22,6 +22,7 @@ type Callbacks interface {
 	OnResponse(*Response, bool)  // response, noBody
 	OnResponseBody([]byte, bool) // chunk data, isComplete
 	OnError(error)
+	OnTransactionEnd() // called when transaction is logically complete, before OnDone
 	OnDone() // called when transaction is complete
 }
 
@@ -186,13 +187,14 @@ func (p *Parser) processRequestStream() {
 		streamBody(bodyReader, p.callbacks.OnRequestBody, p.callbacks.OnError)
 	}
 
-	// Flush any extra data that may have been written to the request writer
-	// This could be something like a body was longer then the Content-Length header.
-	// TODO(Jon): We may want to note this in our callback for user investgiation.
-	_, _ = io.Copy(io.Discard, p.requestReader)
-
 	// Signal that request is complete
 	close(p.state.requestComplete)
+
+	// Flush any extra data that may have been written to the request writer
+	// (e.g. a body that exceeded Content-Length). This will unblock when the
+	// outer consumer closes the pipe via parser.Close (triggered by OnDone).
+	// TODO(Jon): We may want to note this in our callback for user investgiation.
+	_, _ = io.Copy(io.Discard, p.requestReader)
 }
 
 // processResponseStream runs in its own goroutine, reading from the response pipe
@@ -229,6 +231,7 @@ func (p *Parser) processResponseStream() {
 			// Special case: 101 Switching Protocols ends the HTTP transaction
 			if response.StatusCode == http.StatusSwitchingProtocols {
 				p.callbacks.OnResponse(response, true) // 101 responses have no body
+				p.callbacks.OnTransactionEnd()
 				p.callbacks.OnDone()
 				close(p.state.transactionDone)
 				return
@@ -258,15 +261,33 @@ func (p *Parser) processResponseStream() {
 			streamBody(bodyReader, p.callbacks.OnResponseBody, p.callbacks.OnError)
 		}
 
-		// Flush any extra data that may have been written to the response writer
-		// This could be something like a body was longer then the Content-Length header.
-		// TODO(Jon): We may want to note this in our callback for user investgiation.
-		_, _ = io.Copy(io.Discard, p.responseReader)
+		// Mark the transaction as logically complete *before* releasing
+		// control back to the HTTPStream. On a persistent (keep-alive)
+		// HTTP/1.1 connection the next request's bytes can arrive any
+		// moment, and the HTTPStream decides whether to reuse this session
+		// or build a new one based on Session.Closed(). OnTransactionEnd
+		// flips that flag synchronously so the next request is routed to
+		// a fresh session with a fresh plugin connection.
+		p.callbacks.OnTransactionEnd()
 
 		// TOOD(Jon): Not a fan of this, but it's common for consumers to try and
 		// clean up the parser on OnDone, but if they call Close(), it will end
 		// in a deadlock.
+		//
+		// IMPORTANT: fire OnDone *before* the trailing io.Copy below.
+		// In production, OnDone runs Session.Close → parser.Close, which
+		// closes the response writer and lets the io.Copy below return.
+		// If we fired OnDone after the io.Copy, the parser would block
+		// here forever on keep-alive connections (no further response
+		// bytes ever arrive on this session), and the artifact would
+		// never be emitted.
 		go p.callbacks.OnDone()
+
+		// Flush any extra data that may have been written to the response writer
+		// (e.g. a body longer than the Content-Length header). Unblocks when
+		// the OnDone path above closes the response pipe.
+		// TODO(Jon): We may want to note this in our callback for user investgiation.
+		_, _ = io.Copy(io.Discard, p.responseReader)
 
 		// Transaction complete
 		close(p.state.transactionDone)

--- a/pkg/stream/protocols/http1/parser_test.go
+++ b/pkg/stream/protocols/http1/parser_test.go
@@ -178,6 +178,31 @@ func TestChunkedDataProcessing(t *testing.T) {
 	require.Equal(t, 200, state.Response.StatusCode)
 }
 
+func TestKeepAliveResponseEmitsDoneWithoutExplicitClose(t *testing.T) {
+	requestData := loadTestData(t, "requests/get_simple.txt")
+	responseData := loadTestData(t, "responses/get_200_with_body.txt")
+
+	recorder := NewTestCallbackRecorder(WithTimeout(200 * time.Millisecond))
+	parser := NewParser(t.Context(), recorder)
+	t.Cleanup(func() {
+		_ = parser.Close()
+	})
+
+	require.NoError(t, parser.ProcessEvent(PhaseRequest, requestData))
+
+	reqEvent, err := recorder.WaitForEvent(EventRequest)
+	require.NoError(t, err)
+	require.Equal(t, "GET", reqEvent.Request.Method)
+
+	require.NoError(t, parser.ProcessEvent(PhaseResponse, responseData))
+
+	respEvent, err := recorder.WaitForEvent(EventResponse)
+	require.NoError(t, err)
+	require.Equal(t, 200, respEvent.Response.StatusCode)
+
+	require.NoError(t, recorder.WaitForCompletion(), "keep-alive transaction should complete without waiting for parser.Close")
+}
+
 // Example using the advanced test helpers
 func TestAdvancedChunkedTransmission(t *testing.T) {
 	requestData := loadTestData(t, "requests/get_simple.txt")

--- a/pkg/stream/protocols/http1/parser_test_helpers.go
+++ b/pkg/stream/protocols/http1/parser_test_helpers.go
@@ -202,6 +202,11 @@ func (r *TestCallbackRecorder) OnError(err error) {
 	}
 }
 
+// OnTransactionEnd implements Callbacks. It's a synchronous hook with
+// no observable side effects from a test recorder's perspective — the
+// async OnDone event is what consumers wait on.
+func (r *TestCallbackRecorder) OnTransactionEnd() {}
+
 // OnDone implements Callbacks
 func (r *TestCallbackRecorder) OnDone() {
 	r.mu.Lock()

--- a/pkg/stream/protocols/http1/session.go
+++ b/pkg/stream/protocols/http1/session.go
@@ -44,7 +44,11 @@ type Session struct {
 	reqBytes atomic.Int64
 	resBytes atomic.Int64
 
-	// total bytes written
+	// transactionEnded tells HTTPStream to rotate to a fresh Session on the
+	// next byte event for keep-alive connections.
+	transactionEnded atomic.Bool
+
+	// closed guards one-time teardown of parser/plugin resources.
 	closed atomic.Bool
 }
 
@@ -227,6 +231,17 @@ func (s *Session) OnResponseBody(chunk []byte, isComplete bool) {
 	}
 }
 
+// OnTransactionEnd is called synchronously by the parser as soon as a
+// single HTTP/1.1 transaction is complete. We flip the transaction-ended
+// flag here so that HTTPStream.Process (running on the next byte event)
+// observes the closure and starts a fresh session for the next
+// request on the same TCP/TLS connection. The heavy cleanup
+// (artifact emission, parser shutdown) still happens asynchronously
+// via OnDone.
+func (s *Session) OnTransactionEnd() {
+	s.transactionEnded.Store(true)
+}
+
 // OnError handles HTTP parsing error callbacks
 func (s *Session) OnError(err error) {
 	span := trace.SpanFromContext(s.ctx)
@@ -254,6 +269,8 @@ func (s *Session) OnDone() {
 }
 
 func (s *Session) Close() error {
+	s.transactionEnded.Store(true)
+
 	if !s.closed.CompareAndSwap(false, true) {
 		return nil
 	}
@@ -284,5 +301,5 @@ func (s *Session) Close() error {
 }
 
 func (s *Session) Closed() bool {
-	return s.closed.Load()
+	return s.transactionEnded.Load()
 }

--- a/pkg/stream/protocols/http1/session_test.go
+++ b/pkg/stream/protocols/http1/session_test.go
@@ -1,0 +1,28 @@
+package http1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSessionTransactionEndDoesNotSkipClose(t *testing.T) {
+	s := NewSession(t.Context(), nil, "example.com", nil, nil)
+	t.Cleanup(func() {
+		_ = s.Close()
+	})
+
+	require.False(t, s.Closed())
+	require.False(t, s.closed.Load())
+	require.False(t, s.parser.state.closed.Load())
+
+	s.OnTransactionEnd()
+
+	require.True(t, s.Closed())
+	require.False(t, s.closed.Load(), "transaction end should not mark teardown complete")
+	require.False(t, s.parser.state.closed.Load(), "parser should remain open until Close runs")
+
+	require.NoError(t, s.Close())
+	require.True(t, s.closed.Load())
+	require.True(t, s.parser.state.closed.Load())
+}

--- a/pkg/stream/protocols/http2/session.go
+++ b/pkg/stream/protocols/http2/session.go
@@ -363,6 +363,14 @@ func (s *Session) WriteResponseBody(data []byte, endStream bool) error {
 	// however, some servers provide it anyway.
 	if ce := s.res.Header.Get("Content-Encoding"); ce != "" && !strings.EqualFold(ce, "identity") {
 		s.logger.Debug("response body is encoded, skipping plugins", zap.String("domain", s.domain), zap.String("encoding", ce))
+		// Still tear the session down on end-of-stream — otherwise plugin
+		// instances are never destroyed, no artifact is emitted, and on a
+		// reused connection (HTTP/2 multiplexing, keep-alive) every
+		// subsequent stream that creates a new pluginConn but shares the
+		// same outer Connection leaves a leaked session behind.
+		if endStream {
+			s.Close()
+		}
 		return ErrEncodedBody
 	}
 


### PR DESCRIPTION
This change fixes session lifecycle handling for streamed HTTP traffic.

For HTTP/1, transaction completion is now signaled synchronously before async teardown. That lets `HTTPStream` rotate to a new session as soon as a keep-alive transaction is complete, while still allowing the old session to finish parser/plugin cleanup safely.

For HTTP/2, encoded response bodies now still trigger session cleanup on end-of-stream, preventing leaked plugin sessions and missing artifacts.

## What changed

- add `OnTransactionEnd()` to the HTTP/1 parser callback interface
- mark HTTP/1 sessions as closed-for-rotation when a transaction completes
- keep full teardown in `OnDone()` / `Close()`
- fire `OnDone()` before draining the trailing response pipe to avoid blocking cleanup
- close HTTP/2 sessions on encoded response bodies when `endStream` is reached

## Why

Previously:
- HTTP/1 keep-alive traffic could be routed into the previous session because the session was not marked closed until full teardown
- the HTTP/1 parser could block in the final response drain before cleanup happened
- HTTP/2 encoded responses could skip plugin processing and never tear the session down