### PR TITLE
fixes security findings for unimported packages

### DIFF
--- a/.govulncheck-allow
+++ b/.govulncheck-allow
@@ -5,9 +5,5 @@
 #
 # Lines starting with `#` are comments. Use them to document *why* each entry
 # is allowlisted so a reviewer can re-evaluate later.
-
-# golang.org/x/crypto/openpgp is deprecated as a package, but qtap does not
-# import it. govulncheck reports this as a module-only finding because qtap
-# uses other x/crypto packages through validator. There is no fixed x/crypto
-# version; revisit if openpgp ever appears in `go list -deps -test ./...`.
-GO-2026-5932
+#
+# Findings for packages that are not imported do not need an exception.

--- a/scripts/security.sh
+++ b/scripts/security.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 # Runs govulncheck and filters findings against .govulncheck-allow.
 #
+# Only findings in imported packages are actionable. Module-only findings
+# refer to vulnerable packages that are not imported by the scanned code.
 # A finding is suppressed if its OSV id or any alias (GHSA-*, CVE-*) is listed
 # in the allowlist. Suppressed findings are still printed, but do not affect
-# the exit code. Any non-allowlisted finding causes a non-zero exit.
+# the exit code. Any non-allowlisted imported-package finding causes a
+# non-zero exit, even if no vulnerable symbol is reachable.
 
 set -euo pipefail
 
@@ -18,21 +21,21 @@ fi
 
 allow_json='[]'
 if [[ -f "$ALLOWLIST" ]]; then
-  allow_json="$(sed 's/#.*$//' "$ALLOWLIST" | tr -d '[:blank:]' | grep -v '^$' | jq -R . | jq -sc .)"
+  allow_json="$(jq -Rsc 'split("\n") | map(sub("#.*$"; "") | gsub("\\s"; "") | select(length > 0))' "$ALLOWLIST")"
 fi
 
 raw="$(mktemp)"
-trap 'rm -f "$raw"' EXIT
+trap 'rm -f "$raw" "$raw.parsed"' EXIT
 
-# govulncheck exits non-zero on findings; capture and re-evaluate ourselves.
-set +e
+# JSON mode exits zero even on findings. A non-zero exit means the scan
+# failed, so let set -e stop the check rather than report incomplete results.
 go tool govulncheck -format=json "$PKGS" >"$raw"
-set -e
 
 jq -s --argjson allow "$allow_json" '
   # Index OSV records by id
   (map(select(.osv)) | map({key: .osv.id, value: .osv}) | from_entries) as $osvs
-  | (map(select(.finding)) | map(.finding)) as $findings
+  # Module-only traces have no package; retain package and symbol findings.
+  | (map(select(.finding)) | map(.finding | select((.trace[0].package // "") != ""))) as $findings
   | ($allow | map(ascii_upcase) | unique) as $allow
   | ([$findings[].osv] | unique) as $ids
   | {

--- a/scripts/security_test.go
+++ b/scripts/security_test.go
@@ -1,0 +1,171 @@
+package scripts_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSecurity(t *testing.T) {
+	for _, tool := range []string{"bash", "jq"} {
+		if _, err := exec.LookPath(tool); err != nil {
+			t.Skipf("%s is required for security script tests", tool)
+		}
+	}
+
+	const osv = `{"osv":{"id":"GO-2026-5932","aliases":["GHSA-test","CVE-2026-1234"],"summary":"OpenPGP is unmaintained"}}` + "\n"
+	const moduleFinding = `{"finding":{"osv":"GO-2026-5932","trace":[{"module":"golang.org/x/crypto","version":"v0.56.0"}]}}` + "\n"
+	const packageFinding = `{"finding":{"osv":"GO-2026-5932","trace":[{"module":"golang.org/x/crypto","package":"golang.org/x/crypto/openpgp"}]}}` + "\n"
+	const symbolFinding = `{"finding":{"osv":"GO-2026-5932","fixed_version":"v0.57.0","trace":[{"module":"golang.org/x/crypto","package":"golang.org/x/crypto/openpgp","function":"ReadMessage"}]}}` + "\n"
+	const otherFinding = `{"finding":{"osv":"GO-2026-9999","trace":[{"module":"example.com/vulnerable","package":"example.com/vulnerable"}]}}` + "\n"
+
+	tests := []struct {
+		name         string
+		output       string
+		allowlist    string
+		missingAllow bool
+		scannerExit  int
+		wantExit     int
+		want         []string
+		unwanted     []string
+	}{
+		{
+			name:     "clean scan with empty allowlist",
+			output:   `{"config":{"scan_level":"symbol"}}`,
+			want:     []string{"No active vulnerabilities."},
+			unwanted: []string{"Suppressed vulnerabilities"},
+		},
+		{
+			name:      "module-only finding needs no exception",
+			output:    osv + moduleFinding,
+			allowlist: "# No exceptions\n \t\n",
+			want:      []string{"No active vulnerabilities."},
+			unwanted:  []string{"GO-2026-5932", "Suppressed vulnerabilities"},
+		},
+		{
+			name:      "module-only finding is not reported as suppressed",
+			output:    osv + moduleFinding,
+			allowlist: "GO-2026-5932\n",
+			want:      []string{"No active vulnerabilities."},
+			unwanted:  []string{"GO-2026-5932", "Suppressed vulnerabilities"},
+		},
+		{
+			name:         "importing OpenPGP fails without an allowlist",
+			output:       osv + moduleFinding + packageFinding,
+			missingAllow: true,
+			wantExit:     1,
+			want:         []string{"Active vulnerabilities (1):", "GO-2026-5932"},
+			unwanted:     []string{"No active vulnerabilities.", "Suppressed vulnerabilities"},
+		},
+		{
+			name:     "reachable finding includes details without counting duplicates",
+			output:   osv + moduleFinding + packageFinding + symbolFinding + symbolFinding,
+			wantExit: 1,
+			want:     []string{"Active vulnerabilities (1):", "reachable symbols: golang.org/x/crypto/openpgp.ReadMessage", "fixed in: v0.57.0"},
+		},
+		{
+			name:      "allowlist matches Go ID",
+			output:    osv + moduleFinding + packageFinding,
+			allowlist: "GO-2026-5932\n",
+			want:      []string{"Suppressed vulnerabilities (1)", "GO-2026-5932", "No active vulnerabilities."},
+		},
+		{
+			name:      "allowlist matches GHSA ignoring case and comments",
+			output:    osv + packageFinding,
+			allowlist: "# Accepted risk\n \tghsa-test \t# explanation\r\n",
+			want:      []string{"Suppressed vulnerabilities (1)", "No active vulnerabilities."},
+		},
+		{
+			name:      "allowlist matches CVE",
+			output:    osv + packageFinding,
+			allowlist: "CVE-2026-1234\n",
+			want:      []string{"Suppressed vulnerabilities (1)", "No active vulnerabilities."},
+		},
+		{
+			name:      "allowlisting one finding does not suppress another",
+			output:    osv + packageFinding + otherFinding,
+			allowlist: "GO-2026-5932\n",
+			wantExit:  1,
+			want:      []string{"Suppressed vulnerabilities (1)", "Active vulnerabilities (1):", "GO-2026-9999"},
+			unwanted:  []string{"No active vulnerabilities."},
+		},
+		{
+			name:        "scanner failure cannot report success",
+			allowlist:   "GO-2026-5932\n",
+			scannerExit: 2,
+			wantExit:    2,
+			want:        []string{"simulated scanner failure"},
+			unwanted:    []string{"No active vulnerabilities."},
+		},
+		{
+			name:        "partial scan cannot report success",
+			output:      osv + moduleFinding,
+			allowlist:   "GO-2026-5932\n",
+			scannerExit: 1,
+			wantExit:    1,
+			want:        []string{"simulated scanner failure"},
+			unwanted:    []string{"No active vulnerabilities.", "Suppressed vulnerabilities"},
+		},
+		{
+			name:      "malformed scanner output fails",
+			output:    "invalid json",
+			allowlist: "GO-2026-5932\n",
+			wantExit:  -1,
+			unwanted:  []string{"No active vulnerabilities."},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			allowlist := filepath.Join(tmp, "allowlist")
+			if !tt.missingAllow {
+				require.NoError(t, os.WriteFile(allowlist, []byte(tt.allowlist), 0o600))
+			}
+			fixture := filepath.Join(tmp, "scanner.json")
+			require.NoError(t, os.WriteFile(fixture, []byte(tt.output), 0o600))
+			require.NoError(t, os.WriteFile(filepath.Join(tmp, "go"), []byte(`#!/usr/bin/env bash
+set -euo pipefail
+[[ "$*" == "tool govulncheck -format=json ./..." ]]
+cat "$SECURITY_TEST_FIXTURE"
+if [[ "$SECURITY_TEST_EXIT" != 0 ]]; then
+  echo "simulated scanner failure" >&2
+fi
+exit "$SECURITY_TEST_EXIT"
+`), 0o700))
+			scratch := filepath.Join(tmp, "scratch")
+			require.NoError(t, os.Mkdir(scratch, 0o700))
+			t.Setenv("PATH", tmp+string(os.PathListSeparator)+os.Getenv("PATH"))
+			t.Setenv("ALLOWLIST", allowlist)
+			t.Setenv("TMPDIR", scratch)
+			t.Setenv("SECURITY_TEST_FIXTURE", fixture)
+			t.Setenv("SECURITY_TEST_EXIT", strconv.Itoa(tt.scannerExit))
+
+			cmd := exec.CommandContext(t.Context(), "bash", "security.sh")
+			output, err := cmd.CombinedOutput()
+			if tt.wantExit == 0 {
+				require.NoError(t, err, "%s", output)
+			} else {
+				var exitErr *exec.ExitError
+				require.ErrorAs(t, err, &exitErr, "%s", output)
+				if tt.wantExit > 0 {
+					assert.Equal(t, tt.wantExit, exitErr.ExitCode(), "%s", output)
+				}
+			}
+			for _, want := range tt.want {
+				assert.Contains(t, string(output), want)
+			}
+			for _, unwanted := range tt.unwanted {
+				assert.NotContains(t, string(output), unwanted)
+			}
+			files, err := os.ReadDir(scratch)
+			require.NoError(t, err)
+			assert.Empty(t, files, "security script must clean up temporary files")
+		})
+	}
+}


### PR DESCRIPTION
`make security` printed a suppressed OpenPGP advisory even though Qtap does not import any affected package. The wrapper now excludes module-only findings and removes the blanket OpenPGP exception. Findings for imported vulnerable packages still fail the check even when no vulnerable function is reachable, so importing OpenPGP in the future will be detected.

Scanner errors now fail the check instead of producing a false clean result. The wrapper also handles an empty or comments-only allowlist and cleans up both temporary output files.

Validation:

- `make security` passes against the live vulnerability database without the suppressed note.
- `go test ./scripts` passes all 12 regression cases, covering finding levels, allowlist matching, scanner failures, malformed output, and cleanup.
- `go tool golangci-lint run ./scripts` reports no issues.
- `bash -n scripts/security.sh` and `git diff --check` pass.
