### PR TITLE
fix the Docker README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,10 @@ Converse with Qpoint devs and the contributors in [Github Discussions](https://g
       --pid=host \
       --network=host \
       -v /sys:/sys \
+      -v /var/run/docker.sock:/var/run/docker.sock \
+      -e TINI_SUBREAPER=1 \
       --ulimit=memlock=-1 \
-      us-docker.pkg.dev/qpoint-edge/public/qpoint:v0 \
-      tap \
+      us-docker.pkg.dev/qpoint-edge/public/qtap:v0 \
       --log-level=info
   ```
 


### PR DESCRIPTION
The Docker example was still pointing at the old image and passing the removed `tap` subcommand.

This switches it to `qtap:v0` and includes the Docker socket and tini subreaper setup from the current docs.

fixes #343